### PR TITLE
Refactored backend functions for getting stops and wait times

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3011,7 +3011,8 @@
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -3029,11 +3030,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3046,15 +3049,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3157,7 +3163,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3167,6 +3174,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3179,17 +3187,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3206,6 +3217,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3278,7 +3290,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3288,6 +3301,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3363,7 +3377,8 @@
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -3393,6 +3408,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -3410,6 +3426,7 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -3448,11 +3465,13 @@
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             }
           }
         },
@@ -6298,11 +6317,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6319,7 +6340,8 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",

--- a/models/get_stops.py
+++ b/models/get_stops.py
@@ -5,12 +5,12 @@ from datetime import datetime, timedelta, timezone, time, date
 import pandas as pd
 import numpy as np
 
-from eclipses import query_graphql, produce_buses, produce_stops, find_eclipses, find_nadirs
+from .eclipses import query_graphql, produce_buses, produce_stops, find_eclipses, find_nadirs
 
 
 def get_stops(data = None, **kwargs):
     """Returns a DataFrame containing every instance of a bus arriving at a stop.
-    
+
     Can be passed existing geolocation data, or specify a query with named parameters:
 
         dates: an array of dates, formatted as strings in the form YYYY-MM-DD
@@ -35,31 +35,31 @@ def get_stops(data = None, **kwargs):
             # error handling here?
             if param not in kwargs.keys():
                 return f"Error: {param} is a required parameter!"
-        
+
         return get_queried_stops(**kwargs)
-     
+
 
 # get all stops from raw json data from graphql
 # getting all stops at once from the entire set of location data might take prohibitively long (~3-4 hours)
 def get_stops_from_data(data):
     bus_stops = pd.DataFrame(columns = ["VID", "TIME", "SID", "DID", "ROUTE"])
-    
+
     for route in {ele['rid'] for ele in data}:
         #print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: Starting with {route}.")
         try:
             stop_ids = [stop['id']
                 for stop
                 in requests.get(f"http://restbus.info/api/agencies/sf-muni/routes/{route}").json()['stops']]
-                 
+
             route_data = [ele for ele in data if ele['rid'] == route]
 
             for stop_id in stop_ids:
                 bus_stops = bus_stops.append(get_arrivals(route, route_data, stop_id), sort = True)
-                     
+
         except KeyError as err:
             print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: KeyError at {route}: {err}")
             continue
-  
+
     return bus_stops
 
 
@@ -96,10 +96,10 @@ def get_queried_stops(dates, routes, directions=[], stops=[], timespan=("00:00",
             # check if stops to filter were provided, or if the stop_id is in the list of filtered stops
             if (stop_id in stops) ^ (len(stops) == 0):
                 for date in dates:
-                    # parse date/time to pass to query                   
+                    # parse date/time to pass to query
                     start_time = int(datetime.strptime(f"{date} {timespan[0]} -0800", "%Y-%m-%d %H:%M %z").timestamp())*1000
                     end_time   = int(datetime.strptime(f"{date} {timespan[1]} -0800", "%Y-%m-%d %H:%M %z").timestamp())*1000
-    
+
                     dt_params = tuple(int(x) for x in date.split("-") + timespan[0].split(":") + ["0"])
                     hours = int((end_time - start_time)//36e5)
 
@@ -139,7 +139,7 @@ def get_arrivals(route, route_data, stop_id):
         nadirs["SID"] = stop_id
         nadirs["DID"] = stop["DID"]
         nadirs["ROUTE"] = route
-        
+
         return nadirs
     except ValueError as err: # accounts for stops with no associated direction
         print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: skipping buses for stop {stop_id} and route {route} due to ValueError: {err}")

--- a/models/get_stops.py
+++ b/models/get_stops.py
@@ -1,16 +1,69 @@
 import json
 import requests
-
 from datetime import datetime, timedelta, timezone, time, date
-from itertools import product
-from functools import reduce
-from .eclipses import query_graphql, produce_buses, produce_stops, find_eclipses, find_nadirs
 
 import pandas as pd
 import numpy as np
 
+from eclipses import query_graphql, produce_buses, produce_stops, find_eclipses, find_nadirs
 
-def get_stops(dates, routes, directions=[], new_stops=[], timespan=("00:00", "23:59")):
+
+def get_stops(data = None, **kwargs):
+    """Returns a DataFrame containing every instance of a bus arriving at a stop.
+    
+    Can be passed existing geolocation data, or specify a query with named parameters:
+
+        dates: an array of dates, formatted as strings in the form YYYY-MM-DD
+        routes: an array of routes, each represented as a string
+        directions: an array of strings representing the directions to filter (optional)
+        stops: an array of strings representing the stops to filter (optional)
+        timespan: a tuple with the start and end times (in UTC -8:00) as strings in the form HH:MM (optional)
+    """
+    params = ["dates", "routes", "directions", "stops", "timespan"]
+
+    if data is not None:
+        return get_stops_from_data(data)
+    else:
+        print(kwargs)
+        # first check for invalid params or missing params
+        for key in kwargs.keys():
+            # error handling here?
+            if key not in params:
+                return f"Error: {key} is an invalid parameter!"
+
+        for param in ["dates", "routes"]:
+            # error handling here?
+            if param not in kwargs.keys():
+                return f"Error: {param} is a required parameter!"
+        
+        return get_queried_stops(**kwargs)
+     
+
+# get all stops from raw json data from graphql
+# getting all stops at once from the entire set of location data might take prohibitively long (~3-4 hours)
+def get_stops_from_data(data):
+    bus_stops = pd.DataFrame(columns = ["VID", "TIME", "SID", "DID", "ROUTE"])
+    
+    for route in {ele['rid'] for ele in data}:
+        #print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: Starting with {route}.")
+        try:
+            stop_ids = [stop['id']
+                for stop
+                in requests.get(f"http://restbus.info/api/agencies/sf-muni/routes/{route}").json()['stops']]
+                 
+            route_data = [ele for ele in data if ele['rid'] == route]
+
+            for stop_id in stop_ids:
+                bus_stops = bus_stops.append(get_arrivals(route, route_data, stop_id), sort = True)
+                     
+        except KeyError as err:
+            print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: KeyError at {route}: {err}")
+            continue
+  
+    return bus_stops
+
+
+def get_queried_stops(dates, routes, directions=[], stops=[], timespan=("00:00", "23:59")):
     """
     get_stops
 
@@ -32,7 +85,7 @@ def get_stops(dates, routes, directions=[], new_stops=[], timespan=("00:00", "23
             Stop: the stop at which the stop occurred
             Dir: the direction in which the stop occurred
     """
-    bus_stops = pd.DataFrame(columns = ["VID", "DATE", "TIME", "SID", "DID", "ROUTE"])
+    bus_stops = pd.DataFrame(columns = ["VID", "TIME", "SID", "DID", "ROUTE"])
 
     for route in routes:
         stop_ids = [stop['id']
@@ -41,13 +94,16 @@ def get_stops(dates, routes, directions=[], new_stops=[], timespan=("00:00", "23
 
         for stop_id in stop_ids:
             # check if stops to filter were provided, or if the stop_id is in the list of filtered stops
-            if (stop_id in new_stops) ^ (len(new_stops) == 0):
+            if (stop_id in stops) ^ (len(stops) == 0):
                 for date in dates:
-                    #print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: starting processing on stop {stop_id} on route {route} on {date}.")
+                    # parse date/time to pass to query                   
                     start_time = int(datetime.strptime(f"{date} {timespan[0]} -0800", "%Y-%m-%d %H:%M %z").timestamp())*1000
                     end_time   = int(datetime.strptime(f"{date} {timespan[1]} -0800", "%Y-%m-%d %H:%M %z").timestamp())*1000
+    
+                    dt_params = tuple(int(x) for x in date.split("-") + timespan[0].split(":") + ["0"])
+                    hours = int((end_time - start_time)//36e5)
 
-                    data = query_graphql(start_time, end_time, route)
+                    data = query_graphql([route], dt_params, hours)
                     #print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: performed query.")
 
                     if data is None:  # API might refuse to cooperate
@@ -57,90 +113,37 @@ def get_stops(dates, routes, directions=[], new_stops=[], timespan=("00:00", "23
                         print(f"no data for {date}")
                         continue
                     else:
-                        stops = produce_stops(data, route)
-                        #print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: produced stops.")
-
-                        buses = produce_buses(data)
-                        #print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: produced buses.")
-
-                        stop = stops[stops['SID'] == stop_id].squeeze()
-                        buses = buses[buses['DID'] == stop['DID']]
-
-                        eclipses = find_eclipses(buses, stop)
-                        #print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: found eclipses.")
-
-                        nadirs = find_nadirs(eclipses)
-                        #print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: found nadirs.")
-
-                        nadirs["TIME"] = nadirs["TIME"].apply(lambda x: datetime.fromtimestamp(x//1000, timezone(timedelta(hours = -8))))
-                        nadirs['DATE'] = nadirs['TIME'].apply(lambda x: x.date())
-                        nadirs['TIME'] = nadirs['TIME'].apply(lambda x: x.time())
-                        nadirs["SID"] = stop_id
-                        nadirs["DID"] = stop["DID"]
-                        nadirs["ROUTE"] = route
-                        bus_stops = bus_stops.append(nadirs, sort = True)
-                        #print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: finished processing.")
+                        bus_stops = bus_stops.append(get_arrivals(route, data, stop_id), sort = True)
 
     # filter for directions
     if len(directions) > 0:
         bus_stops = bus_stops.loc[bus_stops['DID'].apply(lambda x: x in directions)]
 
-    # prepare timestamp data
-    bus_stops['timestamp'] = bus_stops[['DATE', 'TIME']].apply(lambda x: datetime.strptime(f"{x['DATE'].isoformat()} {x['TIME'].isoformat()} -0800",
-                                                                                       "%Y-%m-%d %H:%M:%S %z"), axis = 'columns')
-
     return bus_stops
 
 
-# find the smallest nonnegative waiting time
-def absmin(series):
-    return series[series >= 0].min()
+# get the arrivals to a single stop on a single route
+def get_arrivals(route, route_data, stop_id):
+    print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: starting processing for {stop_id} and {route}")
+    try:
+        stops = produce_stops(route_data, route)
+        buses = produce_buses(route_data)
 
+        stop = stops[stops['SID'] == stop_id].drop_duplicates().squeeze()
+        buses = buses[buses['DID'] == stop['DID']]
 
-# # input: df with entries from one day
-# # possible optimzation: sort df by timestamp, then pick first timestamp > minute for each minute (need to time to make sure but should be faster)
-def minimum_waiting_times(df, start_time, end_time, group):
-    minute_range = [start_time + timedelta(minutes=i) for i in range(
-        (end_time - start_time).seconds//60)]
-    wait_times = pd.DataFrame(columns=[])
+        eclipses = find_eclipses(buses, stop)
+        nadirs = find_nadirs(eclipses)
 
-    for minute in minute_range:
-        # TODO (jtanquil): we get this error, see if you can fix it
-        # A value is trying to be set on a copy of a slice from a DataFrame.
-        # Try using .loc[row_indexer,col_indexer] = value instead
-        # See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy
-        #   df['WAIT'] = df['timestamp'].apply(lambda x: (x - minute).total_seconds())
-        df['WAIT'] = df['timestamp'].apply(lambda x: (x - minute).total_seconds())
-        pivot = df[group + ['WAIT']].pivot_table(values = ['WAIT'], index = group, aggfunc = absmin)
-        pivot['TIME'] = minute
-        pivot = pivot.reset_index()
-        wait_times = wait_times.append(pivot, sort = True)
-
-    return wait_times
-
-def all_wait_times(df, timespan, group):
-    dates = df['DATE'].unique()
-    avg_over_pd = pd.DataFrame(columns = group + ['DATE', 'TIME', 'WAIT'])
-
-    for date in dates:
-        #print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: start processing {date}.")
-        start_time = datetime.strptime(f"{date.isoformat()} {timespan[0]} -0800", "%Y-%m-%d %H:%M %z")
-        end_time   = datetime.strptime(f"{date.isoformat()} {timespan[1]} -0800", "%Y-%m-%d %H:%M %z")
-        daily_wait = minimum_waiting_times(df[df['DATE'] == date], start_time, end_time, group)
-        #print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: found waits for {date}.")
-        #daily_wait = daily_wait.pivot_table(values = ['WAIT'], index = group).reset_index()
-        daily_wait['DATE'] = date
-        daily_wait['TIME'] = daily_wait['TIME'].apply(lambda x: x.time())
-        avg_over_pd = avg_over_pd.append(daily_wait, sort = True)
-
-    return avg_over_pd
-
-def quantiles(series):
-    return [np.percentile(series, i) for i in [5, 25, 50, 75, 95]]
-
-def get_summary_statistics(df, group):
-    waits = df.pivot_table(values = ['WAIT'], index = group, aggfunc = {'WAIT': [np.mean, np.std, quantiles]}).reset_index()
-    waits.columns = ['_'.join(col) if col[0] == 'WAIT' else ''.join(col) for col in waits.columns.values]
-    waits[[f"{i}th percentile" for i in [5, 25, 50, 75, 95]]] = waits['WAIT_quantiles'].apply(lambda x: pd.Series(x))
-    waits = waits.drop('WAIT_quantiles', axis = 1)
-    return waits
+        nadirs["TIME"] = nadirs["TIME"].apply(lambda x: datetime.fromtimestamp(x//1000, timezone(timedelta(hours = -8))))
+        nadirs["SID"] = stop_id
+        nadirs["DID"] = stop["DID"]
+        nadirs["ROUTE"] = route
+        
+        return nadirs
+    except ValueError as err: # accounts for stops with no associated direction
+        print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: skipping buses for stop {stop_id} and route {route} due to ValueError: {err}")
+        return pd.DataFrame()
+    except Exception as err:
+        print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: could not produce stops df for {stop_id} on route {route}: {err}")
+        return pd.DataFrame()

--- a/models/metrics.py
+++ b/models/metrics.py
@@ -1,8 +1,7 @@
 import pandas as pd
 
 #from . import get_stops
-import get_stops
-import wait_times
+from . import get_stops, wait_times
 
 def test():
     return "test test test"

--- a/models/metrics.py
+++ b/models/metrics.py
@@ -1,15 +1,16 @@
 import pandas as pd
 
-from . import get_stops
-
+#from . import get_stops
+import get_stops
+import wait_times
 
 def test():
     return "test test test"
 
 
 def get_average_waiting_time(stop_id, route_id, direction,
-                             date_range = [d.date().strftime("%Y-%m-%d") for d in pd.date_range(pd.datetime.today(), periods=30).tolist()],
-                             time_range = ("00:00", "23:59")):
+                             date_range = ["2018-11-11"], #[d.date().strftime("%Y-%m-%d") for d in pd.date_range(pd.datetime.today(), periods=30).tolist()],
+                             time_range = ("08:00", "09:00")): #("00:00", "23:59")):
     """Gets average waiting time for all buses with given parameters.
 
     Uses historical data to compute this. Gets the average waiting time for all
@@ -32,12 +33,11 @@ def get_average_waiting_time(stop_id, route_id, direction,
     Returns:
         double: average waiting time, in minutes
     """
-    stops = get_stops.get_stops(date_range, [route_id], f"{route_id}___{direction}_F00", [stop_id], time_range)
-    waits = get_stops.all_wait_times(stops, time_range, ['SID'])
+    stops = get_stops.get_stops(data = None, dates = date_range, routes = [route_id], directions = f"{route_id}___{direction}_F00", stops = [stop_id], timespan = time_range)
+    waits = wait_times.get_all_wait_times(stops, time_range, ['SID'])
 
     # TODO: later on, add filtering for days of week, dates, and times of year
 
-    # This is a stub function so we return some random number :)
     return waits['WAIT'].mean()/60
 
 """
@@ -59,3 +59,5 @@ josh's comments
 
 
 # """
+# if __name__ == "__main__":
+#     print(get_average_waiting_time('4970', '12', 'O'))

--- a/models/wait_times.py
+++ b/models/wait_times.py
@@ -1,0 +1,70 @@
+import json
+import requests
+from datetime import datetime, timedelta, timezone, time, date
+
+import pandas as pd
+import numpy as np
+
+
+# find the smallest nonnegative waiting time
+def absmin(series):
+    return series[series >= 0].min()
+
+
+# finds the wait times for data from a single day
+def get_daily_wait_times(df, start_time, end_time, group):
+    minute_range = [start_time + timedelta(minutes=i) for i in range(
+        (end_time - start_time).seconds//60)]
+    wait_times = pd.DataFrame(columns=[])
+
+    for minute in minute_range:
+        # TODO (jtanquil): we get this error, see if you can fix it
+        # A value is trying to be set on a copy of a slice from a DataFrame.
+        # Try using .loc[row_indexer,col_indexer] = value instead
+        # See the caveats in the documentation: http://pandas.pydata.org/pandas-docs/stable/indexing.html#indexing-view-versus-copy
+        #   df['WAIT'] = df['timestamp'].apply(lambda x: (x - minute).total_seconds())
+        df['WAIT'] = df['TIME'].apply(lambda x: (x - minute).total_seconds())
+        pivot = df[group + ['WAIT']].pivot_table(values = ['WAIT'], index = group, aggfunc = absmin)
+        pivot['TIME'] = minute
+        pivot = pivot.reset_index()
+        wait_times = wait_times.append(pivot, sort = True)
+
+    return wait_times
+
+
+def get_all_wait_times(df, timespan = ("00:00", "23:59"), group = ['ROUTE']): #probably restrict timespan to when buses are actually running
+    # process arrivals df
+    arrivals = df.copy(deep = True)
+    arrivals['DATE'] = arrivals['TIME'].apply(lambda x: x.date())
+    
+    dates = arrivals['DATE'].unique()
+    avg_over_pd = pd.DataFrame(columns = group + ['DATE', 'TIME', 'WAIT'])
+
+    for date in dates:
+        #print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: start processing {date}.")
+        start_time = datetime.strptime(f"{date.isoformat()} {timespan[0]} -0800", "%Y-%m-%d %H:%M %z")
+        end_time   = datetime.strptime(f"{date.isoformat()} {timespan[1]} -0800", "%Y-%m-%d %H:%M %z")
+        daily_wait = get_daily_wait_times(arrivals[arrivals['DATE'] == date], start_time, end_time, group)
+        #print(f"{datetime.now().strftime('%a %b %d %I:%M:%S %p')}: found waits for {date}.")
+        #daily_wait = daily_wait.pivot_table(values = ['WAIT'], index = group).reset_index()
+        daily_wait['DATE'] = date
+        daily_wait['TIME'] = daily_wait['TIME'].apply(lambda x: x.time())
+        avg_over_pd = avg_over_pd.append(daily_wait, sort = True)
+
+    return avg_over_pd
+
+
+def quantiles(series):
+    return [np.percentile(series, i) for i in [5, 25, 50, 75, 95]]
+
+
+def get_summary_statistics(df, group):
+    waits = df.pivot_table(values = ['WAIT'], index = group, aggfunc = {'WAIT': [np.mean, np.std, quantiles]}).reset_index()
+    waits.columns = ['_'.join(col) if col[0] == 'WAIT' else ''.join(col) for col in waits.columns.values]
+    waits[[f"{i}th percentile" for i in [5, 25, 50, 75, 95]]] = waits['WAIT_quantiles'].apply(lambda x: pd.Series(x))
+    waits = waits.drop('WAIT_quantiles', axis = 1)
+    return waits
+
+
+def get_avg_wait_times(df, timespan = ("05:00", "23:59"), group = ['ROUTE']): # defaulting to muni operating hours
+    return get_summary_statistics(get_all_wait_times(df, timespan, group), group)


### PR DESCRIPTION
`get_stops` can now either query graphql (with the same parameters as before) or can take raw json data from a previous query. Moved functions for computing the wait times to another file.