### PR TITLE
Improve arrival history

### DIFF
--- a/compute_arrivals.py
+++ b/compute_arrivals.py
@@ -1,5 +1,6 @@
-from models import arrival_history, util
+from models import arrival_history, util, trynapi, nextbus
 import json
+import math
 import argparse
 from datetime import datetime, timedelta
 import pytz
@@ -8,7 +9,7 @@ import gzip
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Compute and cache arrival history')
-    parser.add_argument('--route', required=True)
+    parser.add_argument('--route', nargs='*')
     parser.add_argument('--date', help='Date (yyyy-mm-dd)')
     parser.add_argument('--start-date', help='Start date (yyyy-mm-dd)')
     parser.add_argument('--end-date', help='End date (yyyy-mm-dd), inclusive')
@@ -16,8 +17,13 @@ if __name__ == '__main__':
     parser.set_defaults(s3=False)
 
     args = parser.parse_args()
-    route_id = args.route
-    date_str  = args.date
+    route_ids = args.route
+    agency = 'sf-muni'
+
+    if route_ids is None:
+        route_ids = [route.id for route in nextbus.get_route_list(agency)]
+
+    date_str = args.date
 
     if args.date:
         dates = util.get_dates_in_range(args.date, args.date)
@@ -28,7 +34,6 @@ if __name__ == '__main__':
 
     tz = pytz.timezone('America/Los_Angeles')
 
-    agency = 'sf-muni'
 
     incr = timedelta(days=1)
 
@@ -39,27 +44,63 @@ if __name__ == '__main__':
         start_time = int(start_dt.timestamp())
         end_time = int(end_dt.timestamp())
 
-        print(f"route = {route_id}")
-        print(f"time = [{start_dt}, {end_dt})")
+        # Request data from trynapi in smaller chunks to avoid internal server errors.
+        # The more routes we have, the smaller our chunk size needs to be in order to
+        # avoid getting internal server errors from trynapi.
+        chunk_minutes = math.ceil(720 / len(route_ids))
 
-        history = arrival_history.compute_from_state(agency, route_id, start_time, end_time)
+        print(f"route = {route_ids}")
+        print(f"time = [{start_dt}, {end_dt}) (chunk_minutes={chunk_minutes})")
 
-        if history is not None:
-            data_str = json.dumps(history.get_data())
+        route_state_map = {}
+        chunk_start_time = start_time
+        while chunk_start_time < end_time:
 
-            cache_path = arrival_history.get_cache_path(agency, route_id, d)
-            with open(cache_path, "w") as f:
-                f.write(data_str)
+            chunk_end_time = min(chunk_start_time + 60 * chunk_minutes, end_time)
 
-            if args.s3:
-                s3 = boto3.resource('s3')
-                s3_path = arrival_history.get_s3_path(agency, route_id, d)
-                s3_bucket = arrival_history.get_s3_bucket()
-                print(f'saving to s3://{s3_bucket}/{s3_path}')
-                object = s3.Object(s3_bucket, s3_path)
-                object.put(
-                    Body=gzip.compress(bytes(data_str, 'utf-8')),
-                    ContentType='application/json',
-                    ContentEncoding='gzip',
-                    ACL='public-read'
-                )
+            # trynapi returns all route states in the UTC minute containing the end timestamp, *inclusive*.
+            # This would normally cause trynapi to return duplicate route states at the end of one chunk and
+            # the beginning of the next chunk. Since chunk_end_time is always the first second in a UTC minute,
+            # subtracting 1 from the corresponding millisecond will be the last millisecond in the previous minute,
+            # so it should avoid fetching duplicate vehicle states at chunk boundaries
+            chunk_state = trynapi.get_state(agency, chunk_start_time*1000, chunk_end_time*1000 - 1, route_ids)
+
+            if 'message' in chunk_state: # trynapi returns an internal server error if you ask for too much data at once
+                raise Exception(f"trynapi error for time range {chunk_start_time}-{chunk_end_time}: {chunk_state['message']}")
+
+            if not ('data' in chunk_state):
+                print(chunk_state)
+                raise Exception(f'trynapi returned no data')
+
+            for chunk_route_state in chunk_state['data']['trynState']['routes']:
+                route_id = chunk_route_state['rid']
+                if route_id not in route_state_map:
+                    route_state_map[route_id] = chunk_route_state
+                else:
+                    route_state_map[route_id]['routeStates'].extend(chunk_route_state['routeStates'])
+
+            chunk_start_time = chunk_end_time
+
+        for route_id, route_state in route_state_map.items():
+
+            history = arrival_history.compute_from_state(agency, route_id, start_time, end_time, route_state)
+
+            if history is not None:
+                data_str = json.dumps(history.get_data())
+
+                cache_path = arrival_history.get_cache_path(agency, route_id, d)
+                with open(cache_path, "w") as f:
+                    f.write(data_str)
+
+                if args.s3:
+                    s3 = boto3.resource('s3')
+                    s3_path = arrival_history.get_s3_path(agency, route_id, d)
+                    s3_bucket = arrival_history.get_s3_bucket()
+                    print(f'saving to s3://{s3_bucket}/{s3_path}')
+                    object = s3.Object(s3_bucket, s3_path)
+                    object.put(
+                        Body=gzip.compress(bytes(data_str, 'utf-8')),
+                        ContentType='application/json',
+                        ContentEncoding='gzip',
+                        ACL='public-read'
+                    )

--- a/get_state.py
+++ b/get_state.py
@@ -8,13 +8,13 @@ from datetime import datetime
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Download raw state data from tryn-api')
-    parser.add_argument('--route', required=True)
+    parser.add_argument('--route', nargs='+', required=True)
     parser.add_argument('--start', required=True, help='unix timestamp (seconds)')
     parser.add_argument('--end', required=True, help='unix timestamp (seconds)')
 
     args = parser.parse_args()
 
-    route_id = args.route
+    route_ids = args.route
     start_time = int(args.start)
     end_time = int(args.end)
 
@@ -27,19 +27,20 @@ if __name__ == '__main__':
     if re.match('^[\w\-]+$', agency) is None:
         raise Exception(f"Invalid agency: {agency}")
 
-    if re.match('^[\w\-]+$', route_id) is None:
-        raise Exception(f"Invalid route id: {route_id}")
+    for route_id in route_ids:
+        if re.match('^[\w\-]+$', route_id) is None:
+            raise Exception(f"Invalid route id: {route_id}")
 
     source_dir = os.path.dirname(os.path.realpath(__file__))
-    local_path = os.path.join(source_dir, 'data', f"state_{agency}_{route_id}_{start_time}_{end_time}.json")
+    local_path = os.path.join(source_dir, 'data', f"state_{agency}_{'+'.join(route_ids)}_{start_time}_{end_time}.json")
 
-    print(f"route = {route_id}")
+    print(f"route = {route_ids}")
     print(f"start = {local_start} ({start_time})")
     print(f"end = {local_end} ({end_time})")
     print(f"local_path = {local_path}")
 
     agency = 'sf-muni'
-    data = trynapi.get_state(agency, start_time*1000, end_time*1000, [route_id])
+    data = trynapi.get_state(agency, start_time*1000, end_time*1000, route_ids)
 
     f = open(local_path, "w")
     f.write(json.dumps(data))

--- a/models/trynapi.py
+++ b/models/trynapi.py
@@ -5,25 +5,27 @@ import json
 def get_state(agency, start_time_ms, end_time_ms, route_ids):
     tryn_agency = 'muni' if agency == 'sf-muni' else agency
 
+    params = f'trynState(agency: {json.dumps(tryn_agency)}, startTime: {json.dumps(str(start_time_ms))}, endTime: {json.dumps(str(end_time_ms))}, routes: {json.dumps(route_ids)})'
+
     query = f"""{{
-      trynState(agency: {json.dumps(tryn_agency)}, startTime: {json.dumps(str(start_time_ms))}, endTime: {json.dumps(str(end_time_ms))}, routes: {json.dumps(route_ids)}) {{
+       {params} {{
         agency
         startTime
         routes {{
           rid
-          stops {{ lat lon sid }}
           routeStates {{
             vtime
             vehicles {{ vid lat lon did }}
           }}
         }}
       }}
-    }}
-    """
+    }}"""
 
-    print(query)
+    print(params)
 
     query_url = "https://06o8rkohub.execute-api.us-west-2.amazonaws.com/dev/graphql?query="+query
     r = requests.get(query_url)
+
+    print(f"   response length = {len(r.text)}")
 
     return json.loads(r.text)

--- a/trips.py
+++ b/trips.py
@@ -35,22 +35,24 @@ if __name__ == '__main__':
     route_config = nextbus.get_route_config(agency, route_id)
 
     s1_info = route_config.get_stop_info(s1)
-    dir = route_config.get_direction_for_stop(s1)
-    if dir is None or s1_info is None:
+    s1_dirs = route_config.get_directions_for_stop(s1)
+    if len(s1_dirs) == 0 or s1_info is None:
         raise Exception(f"invalid stop id {s1}")
 
     s2_info = route_config.get_stop_info(s2)
-    dir2 = route_config.get_direction_for_stop(s2)
-    if dir2 is None or s2_info is None:
+    s2_dirs = route_config.get_directions_for_stop(s2)
+    if len(s1_dirs) == 0 or s2_info is None:
         raise Exception(f"invalid stop id {s2}")
 
     if s1 == s2:
         raise Exception(f"stop {s1} and {s2} are the same")
 
-    if dir != dir2:
+    common_dirs = [dir for dir in s1_dirs if dir in s2_dirs]
+
+    if len(common_dirs) == 0:
         raise Exception(f"stop {s1} and {s2} are in different directions")
 
-    dir_info = route_config.get_direction_info(dir)
+    dir_info = route_config.get_direction_info(common_dirs[0])
 
     for s in dir_info.get_stop_ids():
         if s == s1:
@@ -73,7 +75,7 @@ if __name__ == '__main__':
     print(f"Route: {route_id} ({route_config.title})")
     print(f"From: {s1} ({s1_info.title})")
     print(f"To: {s2} ({s2_info.title})")
-    print(f"Direction: {dir} ({dir_info.title})")
+    print(f"Direction: {','.join(common_dirs)} ({dir_info.title})")
 
     completed_trips_arr = []
 
@@ -87,6 +89,8 @@ if __name__ == '__main__':
         if s1_df.empty:
             print(f"no arrival times found for stop {s1} on {date_str}")
             continue
+
+        s1_df = s1_df.sort_values('TIME', axis=0)
 
         # in case we don't see the vehicle arrive at s2 in the current run,
         # look at the next time the same vehicle arrives back at s1, only look at s2 arrivals before that time

--- a/vehicle.py
+++ b/vehicle.py
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     for d in dates:
         history = arrival_history.get_by_date(agency, route_id, d)
 
-        df = history.get_data_frame(vid=vid, tz=tz, start_time_str=start_time_str, end_time_str=end_time_str)
+        df = history.get_data_frame(vehicle_id=vid, tz=tz, start_time_str=start_time_str, end_time_str=end_time_str)
 
         if df.empty:
             print(f"no arrival times found for vehicle {vid} on {date_str}")
@@ -52,7 +52,6 @@ if __name__ == '__main__':
         for index, row in df.iterrows():
             stop_id = row.SID
             stop_info = route_config.get_stop_info(stop_id)
-            dir = route_config.get_direction_for_stop(stop_id)
-            dir_info = route_config.get_direction_info(dir)
+            dir_info = route_config.get_direction_info(row.DID)
 
-            print(f"t={row.DATE_STR} {row.TIME_STR} ({row.TIME}) vid:{row.VID} stop:{stop_info.title} ({stop_id}) dir: {dir_info.name}")
+            print(f"t={row.DATE_STR} {row.TIME_STR} ({row.TIME}) vid:{row.VID} stop:{stop_info.title} ({stop_id}) dir:{dir_info.title} ({row.DID})")


### PR DESCRIPTION
This PR contains several changes related to computing and using arrival history:

###  Allow computing arrivals for multiple routes (or all routes) at once

Previously, compute_arrivals.py previously worked for one route at a time, but it is probably faster to compute arrivals for multiple routes at once (since tryn-api reads the state data from S3 containing all routes, before dropping the data from any routes that were not requested)

To compute arrivals for all routes, omit the `--route` argument:
```python compute_arrivals.py --date=2019-03-01```

To compute arrivals for multiple named routes, separate the routes by spaces after the `--route` argument:
```python compute_arrivals.py --date=2019-03-01 --route 38 38R 38AX 38BX```

###  Fetch data from tryn-api in chunks to avoid errors

Sometimes tryn-api runs out of memory when fetching 24 hours of data at once. compute_arrivals.py now splits requests into smaller chunks depending on the number of routes requested, so that the data returned in each chunk is typically no more than a few MB. (The python process itself still needs enough memory to hold 24 hours of data for all requested routes.)

###  Support stops that appear in multiple directions for a route

Some routes have multiple "directions" containing the same stop, like route 38 which has separate directions "Outbound to Balboa + 33rd Avenue" and "Outbound to Lands End - 48th Avenue". Previously, arrivals were serialized to JSON assuming that each stop only had one associated direction ID, which is incorrect. Now, to support stops with multiple direction IDs, stops are serialized with a map of direction_id => array of timestamp/vehicle ID, e.g.:

```"stops": {"7620": {"arrivals": {"38___O_S00": [{"t": 1549031959, "v": "6515"}], "38___O_F20": [{"t": 1549025475, "v": "8901"}]}}}```

Since this change is not backwards compatible with the serialized format from last week, the path to S3/cache files has been changed to include "v2". Arrivals already computed with the new format can be found at http://opentransit-stop-arrivals.s3.amazonaws.com/?prefix=v2

### Allow computing headways for multiple routes at the same stop

headways.py now allows specifying multiple routes for the same stop, e.g:
```python headways.py --route 38 38R 38BX --date=2019-02-01 --stop=4288```

###  Use stop info from nextbus API for computing arrival times instead of fetching from tryn-api

Previously metrics-mvp was fetching the stop information from tryn-api, which fetched the information from restbus, which fetched it from the nextbus API. The eclipses algorithm was using that information instead of the stop information it already had cached locally, except that metrics-mvp was also adding the direction ID locally which wasn't returned by tryn-api (and was assuming only 1 direction ID per stop). 

Now metrics-mvp just uses its cached route information from the nextbus API directly, avoiding the need to fetch it from tryn-api repeatedly.