### PR TITLE
Updated documentation to regenerate production

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ and will run the Flask backend in development mode at http://localhost:5000.
 Your local directory will be shared within the docker container at /app.
 When you edit files in your local directory, the React and Flask containers should automatically update with the new code.
 
+To rebuild the production files that are served on port 5000, run:
+```
+npm run build
+``` 
+
 To start a shell within the Flask Docker container, run:
 ```
 docker exec -it metrics-flask bash

--- a/README.md
+++ b/README.md
@@ -17,11 +17,6 @@ and will run the Flask backend in development mode at http://localhost:5000.
 Your local directory will be shared within the docker container at /app.
 When you edit files in your local directory, the React and Flask containers should automatically update with the new code.
 
-To rebuild the production files that are served on port 5000, run:
-```
-npm run build
-``` 
-
 To start a shell within the Flask Docker container, run:
 ```
 docker exec -it metrics-flask bash
@@ -35,6 +30,13 @@ If you need to install some new dependencies in the Docker images, you can rebui
 
 If you don't want to handle installing anything locally, just **[use this cloud editor](http://gitpod.io#https://github.com/trynmaps/metrics-mvp)**.
 This will automatically install requirements on a cloud machine and get the app running for you instantly.
+
+## Commands to know
+
+To rebuild the production files that are served on port 5000, run:
+```
+npm run build
+``` 
 
 ## Computing Arrival Times
 


### PR DESCRIPTION
Clearing this task:

https://trello.com/c/vpEJ46hF/130-update-documentation-to-tell-people-to-use-npm-run-build-to-make-a-prod-build