### PR TITLE
only show wait times between first and last actual arrival

### DIFF
--- a/frontend/src/components/Info.jsx
+++ b/frontend/src/components/Info.jsx
@@ -12,6 +12,7 @@ class Info extends Component {
     const { graphData, graphError } = this.props;
 
     const headwayMin = graphData ? graphData.headway_min : null;
+    const waitTimes = graphData ? graphData.wait_times : null;
     const tripTimes = graphData ? graphData.trip_times : null;
 
     return (
@@ -29,6 +30,31 @@ class Info extends Component {
             <BarChart
               data={[{ values: headwayMin.histogram.map(bin => ({ x: `${bin.value}`, y: bin.count })) }]}
               width={Math.max(100, headwayMin.histogram.length * 70)}
+              className={`css
+                color: 'red'
+              `}
+              height={200}
+              margin={
+                  {
+                    top: 0,
+                    bottom: 50,
+                    left: 0,
+                    right: 20,
+                  }
+                }
+              xAxis={{label: "minutes"}}
+              barPadding={0.3}
+              style={{fill: 'red'}}
+              yAxis={{innerTickSize: 10, label: "number"}}
+            /></div>
+          ) : null }
+        {waitTimes
+          ? (<div>
+            <h4>Wait Times</h4>
+            <p>average wait time {Math.round(waitTimes.avg)} minutes, max wait time {Math.round(waitTimes.max)} minutes</p>
+            <BarChart
+              data={[{ values: waitTimes.histogram.map(bin => ({ x: `${bin.value}`, y: bin.count })) }]}
+              width={Math.max(100, waitTimes.histogram.length * 70)}
               className={`css
                 color: 'red'
               `}

--- a/metrics-api.py
+++ b/metrics-api.py
@@ -130,7 +130,7 @@ def metrics_page():
     directions = [{'id': dir_info.id, 'title': dir_info.title} for dir_info in dir_infos]
 
     headway_min_arr = []
-    #waits = []
+    waits = []
     if end_stop_id:
         completed_trips  = []
 
@@ -144,7 +144,7 @@ def metrics_page():
             df['headway_min'] = metrics.compute_headway_minutes(df)
 
             # temporarily skip calculation of wait times until data is shown in front end
-            #waits.append(wait_times.get_waits(df, start_stop_info, d, tz, route_id, start_time_str, end_time_str))
+            waits.append(wait_times.get_waits(df, start_stop_info, d, tz, route_id, start_time_str, end_time_str))
 
             if end_stop_id and both_stops_same_dir:
                 trips = trip_times.get_trip_times(df, history, tz, start_stop_id, end_stop_id)
@@ -164,7 +164,7 @@ def metrics_page():
             }, indent = 2), status = 404, mimetype = 'application/json')
 
     headway_min = pd.concat(headway_min_arr)
-    #waits = pd.concat(waits)
+    waits = pd.concat(waits)
     if end_stop_id and both_stops_same_dir:
         completed_trips = pd.concat(completed_trips)
 
@@ -181,7 +181,7 @@ def metrics_page():
         'end_stop_title': end_stop_info.title if end_stop_info else None,
         'directions': directions,
         'headway_min': metrics.get_headways_stats(headway_min),
-        #'wait_times': metrics.get_wait_times_stats(waits, tz),
+        'wait_times': metrics.get_wait_times_stats(waits, tz),
         'trip_times': metrics.get_trip_times_stats(completed_trips, start_stop_id, end_stop_id)
             if end_stop_id and both_stops_same_dir else None,
     }

--- a/models/wait_times.py
+++ b/models/wait_times.py
@@ -15,32 +15,30 @@ def get_waits(df: pd.DataFrame, stopinfo: nextbus.StopInfo, d: date, tz: pytz.ti
     waits = df['TIME'].copy(deep = True)
     waits = pd.DataFrame({"ARRIVAL" : waits,
                           "TIME_FLOOR" : waits - (waits % 60)})
-    # get corresponding timetable to determine the time interval for which to compute wait times
-    # TODO: get stop_id from route_config (enable route_config to do this)
-    stop_id = stopinfo.location_id
-    route_timetable = timetable.get_timetable(route, stop_id, d)
-    first_bus = route_timetable["DATE_TIME"].min().replace(second = 0)
-    last_bus = route_timetable["DATE_TIME"].max().replace(second = 0)
+
+    # stop_id = stopinfo.location_id
+    # route_timetable = timetable.get_timetable(route, stop_id, d)
+    first_bus = df["TIME"].min()
+    last_bus = df["TIME"].max()
 
     # get the minute range in timestamp form
     # truncate time interval to minute before first bus/minute after last bus leave
-    if start_time_str is None or \
-        (start_time_str is not None and (time.fromisoformat(start_time_str) < first_bus.time())):
-        start_timestamp = first_bus.timestamp()
+    if start_time_str is None:
+        start_timestamp = first_bus
     else:
-        start_timestamp = util.get_localized_datetime(d, start_time_str).timestamp()
+        start_timestamp = max(first_bus, util.get_localized_datetime(d, start_time_str).timestamp())
 
-    if end_time_str is None or \
-        (end_time_str is not None and (time.fromisoformat(end_time_str) > last_bus.time())):
-        end_timestamp = last_bus.timestamp()
+    if end_time_str is None:
+        end_timestamp = last_bus
     else:
-        end_timestamp = util.get_localized_datetime(d, end_time_str).timestamp()
+        end_timestamp = min(last_bus, util.get_localized_datetime(d, end_time_str).timestamp())
 
     minutes_range = [start_timestamp + (60 * i) for i in range(int((end_timestamp - start_timestamp)/60))]
 
     # the remaining first arrivals can be obtained by joining the existing waits to a df
     # containing the rest of the timestamps and backfilling
-    all_waits = pd.DataFrame({'DATE_TIME' : minutes_range}).join(waits.set_index('TIME_FLOOR'), on = 'DATE_TIME', how = 'outer').sort_values("DATE_TIME")
+    all_waits = pd.DataFrame({'DATE_TIME' : minutes_range}) \
+        .join(waits.set_index('TIME_FLOOR'), on = 'DATE_TIME', how = 'outer').sort_values("DATE_TIME")
     all_waits['ARRIVAL'] = all_waits['ARRIVAL'].fillna(method = 'bfill')
     all_waits.index = [datetime.fromtimestamp(t, tz = tz).time() for t in all_waits['DATE_TIME']]
 


### PR DESCRIPTION
Using the timetable data for first/last bus times was causing the maximum wait time for most routes to be very large, which threw off the statistics, so I just changed it to use the first/last actual arrival for now.

![image](https://user-images.githubusercontent.com/343100/56334784-a7ad3300-614e-11e9-84f7-daeac54e905e.png)
