### PR TITLE
allow filtering by time range

### DIFF
--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -17,6 +17,8 @@ class ControlPanel extends Component {
       firstStopId: null,
       secondStopId: null,
       date: new Date('2019-04-08T03:50'),
+      startTimeStr: null,
+      endTimeStr: null,
     };
   }
 
@@ -33,7 +35,7 @@ class ControlPanel extends Component {
 
   updateGraphData = () => {
     const {
-      routeId, directionId, firstStopId, date, secondStopId,
+      routeId, directionId, firstStopId, date, secondStopId, startTimeStr, endTimeStr
     } = this.state;
 
     this.props.resetGraphData();
@@ -44,6 +46,8 @@ class ControlPanel extends Component {
         direction_id: directionId,
         start_stop_id: firstStopId,
         end_stop_id: secondStopId,
+        start_time: startTimeStr,
+        end_time: endTimeStr,
         date: formattedDate,
       };
       this.props.fetchGraphData(params);
@@ -56,6 +60,15 @@ class ControlPanel extends Component {
   }
 
   setDate = date => this.setState({ date }, this.updateGraphData)
+
+  setTimeRange = timeRange => {
+    if (!timeRange) {
+      this.setState({ startTimeStr: null, endTimeStr: null }, this.updateGraphData);
+    } else {
+      var timeRangeParts = timeRange.split('-');
+      this.setState({ startTimeStr: timeRangeParts[0], endTimeStr: timeRangeParts[1] }, this.updateGraphData);
+    }
+  }
 
   setRouteId = routeId => this.setState({ routeId }, this.selectedRouteChanged)
 
@@ -103,7 +116,7 @@ class ControlPanel extends Component {
       ? this.getStopsInfoInGivenDirection(selectedRoute, directionId) : null;
     if (firstStopId) {
       if (!selectedDirection || selectedDirection.stops.indexOf(firstStopId) === -1) {
-        this.setState({ firstStopId: null, secondStopId: null });
+        this.setState({ firstStopId: null, secondStopId: null }, this.selectedStopChanged);
       }
     }
   }
@@ -129,8 +142,10 @@ class ControlPanel extends Component {
   render() {
     const { routes } = this.props;
     const {
-      date, routeId, directionId, firstStopId, secondStopId, secondStopList,
+      date, routeId, directionId, firstStopId, secondStopId, secondStopList, startTimeStr, endTimeStr
     } = this.state;
+
+    const timeRange = (startTimeStr || endTimeStr) ? (startTimeStr + '-' + endTimeStr) : '';
 
     const selectedRoute = this.getSelectedRouteInfo();
     const selectedDirection = (selectedRoute && selectedRoute.directions && directionId)
@@ -158,6 +173,26 @@ class ControlPanel extends Component {
            width: 100%
          `}
           />
+        <ListGroup.Item>
+          <DropdownControl
+            title="Time Range"
+            name="time_range"
+            variant="info"
+            value={timeRange}
+            onSelect={this.setTimeRange}
+            options={
+                [
+                    {label:'All Day', key:''},
+                    {label:'Daytime (7AM - 7PM)', key:'07:00-19:00'},
+                    {label:'Early Morning (3AM - 7AM)', key:'03:00-07:00'},
+                    {label:'AM Peak (7AM - 10AM)', key:'07:00-10:00'},
+                    {label:'Midday (10AM - 4PM)', key:'10:00-16:00'},
+                    {label:'PM Peak (4PM - 7PM)', key:'16:00-19:00'},
+                    {label:'Late Evening (7PM - 3AM)', key:'19:00-03:00+1'},
+                ]
+        }
+          />
+        </ListGroup.Item>
           <ListGroup variant="flush">
             <ListGroup.Item>
               <DropdownControl

--- a/models/arrival_history.py
+++ b/models/arrival_history.py
@@ -39,6 +39,11 @@ class ArrivalHistory:
         stops = self.stops_data
         data = []
 
+        d = datetime.fromtimestamp(self.start_time, tz).date()
+
+        start_dt = util.get_localized_datetime(d, start_time_str, tz) if start_time_str is not None else None
+        end_dt = util.get_localized_datetime(d, end_time_str, tz) if end_time_str is not None else None
+
         has_dist = has_departure_time = self.version and self.version[1] >= '3'
 
         columns = ("VID", "TIME", "DEPARTURE_TIME", "SID", "DID", "DIST")
@@ -64,12 +69,11 @@ class ArrivalHistory:
                     values = (v, timestamp, departure_time, s, did, dist)
                     if tz:
                         dt = datetime.fromtimestamp(timestamp, tz)
-                        time_str = dt.strftime('%H:%M:%S')
-                        if start_time_str is not None and time_str < start_time_str:
+                        if start_dt is not None and dt < start_dt:
                             continue
-                        if end_time_str is not None and time_str >= end_time_str:
+                        if end_dt is not None and dt >= end_dt:
                             break # arrivals for each stop+direction are in timestamp order, so can stop here
-                        values = values + (dt, dt.strftime('%Y-%m-%d'), time_str)
+                        values = values + (dt, dt.strftime('%Y-%m-%d'), dt.strftime('%H:%M:%S'))
 
                     data.append(values)
 
@@ -123,7 +127,7 @@ class ArrivalHistory:
             start_time = data['start_time'],
             end_time = data['end_time'],
             stops_data = data['stops'],
-            version = data['version'] if 'version' in data else 'v2'
+            version = data['version'] if 'version' in data else 'v2',
         )
 
     def get_data(self):

--- a/models/util.py
+++ b/models/util.py
@@ -36,11 +36,19 @@ def render_dwell_time(seconds):
 def get_data_dir():
     return f"{os.path.dirname(os.path.dirname(os.path.realpath(__file__)))}/data"
 
-def get_localized_datetime(d: date, time_str: str):
-    dt_str = f"{d.isoformat()} {time_str}"
-    pst = pytz.timezone('US/Pacific')
+def get_localized_datetime(d: date, time_str: str, tz: pytz.timezone):
 
-    try:
-        return pst.localize(datetime.strptime(dt_str, "%Y-%m-%d %H:%M:%S"))
-    except ValueError:
-        return pst.localize(datetime.strptime(dt_str, "%Y-%m-%d %H:%M"))
+    time_str_parts = time_str.split('+') # + number of days
+
+    if len(time_str_parts[0].split(':')) == 2:
+        format = "%Y-%m-%d %H:%M"
+    else:
+        format = "%Y-%m-%d %H:%M:%S"
+
+    dt_str = f"{d.isoformat()} {time_str_parts[0]}"
+
+    dt = datetime.strptime(dt_str, format)
+    if len(time_str_parts) > 1:
+        dt = dt + timedelta(days=int(time_str_parts[1]))
+
+    return tz.localize(dt)

--- a/models/wait_times.py
+++ b/models/wait_times.py
@@ -12,34 +12,37 @@ from . import timetable, util, nextbus
 def get_waits(df: pd.DataFrame, stopinfo: nextbus.StopInfo, d: date, tz: pytz.timezone, route: str, start_time_str = None, end_time_str = None):
     # for each arrival time, rounding down to the nearest minute gives us the
     # corresponding minute for which that arrival is first arrival
-    waits = df['TIME'].copy(deep = True)
-    waits = pd.DataFrame({"ARRIVAL" : waits,
-                          "TIME_FLOOR" : waits - (waits % 60)})
 
-    # stop_id = stopinfo.location_id
-    # route_timetable = timetable.get_timetable(route, stop_id, d)
-    first_bus = df["TIME"].min()
-    last_bus = df["TIME"].max()
+    arrival_times = df['TIME'].copy(deep = True)
+    waits = pd.DataFrame({"ARRIVAL" : arrival_times,
+                          "TIME_FLOOR" : arrival_times - (arrival_times % 60)})
 
-    # get the minute range in timestamp form
-    # truncate time interval to minute before first bus/minute after last bus leave
-    if start_time_str is None:
-        start_timestamp = first_bus
+    if not df.empty:
+        # stop_id = stopinfo.location_id
+        # route_timetable = timetable.get_timetable(route, stop_id, d)
+        first_bus = df["TIME"].min()
+        last_bus = df["TIME"].max()
+
+        # get the minute range in timestamp form
+        # truncate time interval to minute before first bus/minute after last bus leave
+        if start_time_str is None:
+            start_timestamp = first_bus
+        else:
+            start_timestamp = max(first_bus, util.get_localized_datetime(d, start_time_str, tz).timestamp())
+
+        if end_time_str is None:
+            end_timestamp = last_bus
+        else:
+            end_timestamp = min(last_bus, util.get_localized_datetime(d, end_time_str, tz).timestamp())
+
+        minutes_range = [start_timestamp + (60 * i) for i in range(int((end_timestamp - start_timestamp)/60))]
+
+        # the remaining first arrivals can be obtained by joining the existing waits to a df
+        # containing the rest of the timestamps and backfilling
+        all_waits = pd.DataFrame({'DATE_TIME' : minutes_range}) \
+            .join(waits.set_index('TIME_FLOOR'), on = 'DATE_TIME', how = 'outer').sort_values("DATE_TIME")
+        all_waits['ARRIVAL'] = all_waits['ARRIVAL'].fillna(method = 'bfill')
+        all_waits.index = [datetime.fromtimestamp(t, tz = tz).time() for t in all_waits['DATE_TIME']]
+        return all_waits
     else:
-        start_timestamp = max(first_bus, util.get_localized_datetime(d, start_time_str).timestamp())
-
-    if end_time_str is None:
-        end_timestamp = last_bus
-    else:
-        end_timestamp = min(last_bus, util.get_localized_datetime(d, end_time_str).timestamp())
-
-    minutes_range = [start_timestamp + (60 * i) for i in range(int((end_timestamp - start_timestamp)/60))]
-
-    # the remaining first arrivals can be obtained by joining the existing waits to a df
-    # containing the rest of the timestamps and backfilling
-    all_waits = pd.DataFrame({'DATE_TIME' : minutes_range}) \
-        .join(waits.set_index('TIME_FLOOR'), on = 'DATE_TIME', how = 'outer').sort_values("DATE_TIME")
-    all_waits['ARRIVAL'] = all_waits['ARRIVAL'].fillna(method = 'bfill')
-    all_waits.index = [datetime.fromtimestamp(t, tz = tz).time() for t in all_waits['DATE_TIME']]
-
-    return all_waits
+        return waits


### PR DESCRIPTION
In order to support filtering by times after midnight, this introduces the convention of adding "+1" at the end of the time string, like "03:00+1". Instead of using an alphabetic comparison of the time string, we can call util.get_localized_datetime to get a datetime for the time string, and then compare datetimes.

![image](https://user-images.githubusercontent.com/343100/56404461-b31a6000-621b-11e9-8ca8-4fe896521a6e.png)
