### PR TITLE
Make Gitpod use Python3

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,7 +2,6 @@ ports:
   - port: 3000
     onOpen: open-browser
   - port: 5000
-    onOpen: open-browser
 
 tasks:
 - command: git status

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,8 +7,8 @@ ports:
 tasks:
 - command: git status
 - command: |
-    pip install -r requirements.txt &&
-    FLASK_DEBUG=1 FLASK_APP=metrics-api.py flask run --host=0.0.0.0
+    pip3 install -r requirements.txt &&
+    FLASK_DEBUG=1 FLASK_APP=metrics-api.py python3 -m flask run --host=0.0.0.0
 - command: |
     (cd frontend && yarn install) &&
     CHOKIDAR_USEPOLLING=true NODE_ENV=development REACT_APP_METRICS_BASE_URL=`gp url 5000` npm start


### PR DESCRIPTION
Currently it's impossible to run the app in Gitpod because Gitpod defaults to using Python2 but our app uses Python3, leading to syntax errors. Ideally I would make Gitpod use our Docker image but I can't find a way to install Docker on Gitpod so we can do `docker compose up`. So for now we'll just re-run all the stuff contained in the dockerfile manually.

Thus, for now, we'll just force Gitpod to use Python3. Small patch, but it'll work for now. Again, ideally we would get Gitpod to read from the dockerfile but that's not possible right now.

Fixes #62.