### PR TITLE
Make app say "OpenTransit" instead of "React App"

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -28,7 +28,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>OpenTransit</title>
     <style>
 @import url('https://fonts.googleapis.com/css?family=Oswald:300,400|Roboto');
 </style>


### PR DESCRIPTION
Minor change to just change the landing page's title