### PR TITLE
update docker-compose to use node_modules folder created when docker container originally built

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 # Created by https://www.gitignore.io/api/node,macos,flask,python,eclipse,intellij
 # Edit at https://www.gitignore.io/?templates=node,macos,flask,python,eclipse,intellij
 
+data/*.json
+data/*.csv
+
 ### Eclipse ###
 .metadata
 bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,14 @@
 FROM python:3.7.2-slim-stretch
 
 # Install python and node in the same image
-# so that 'yarn build' can generate production frontend build
+# so that 'npm run build' can generate production frontend build
 # that will be served by metrics-api.py (Flask) at /
 
 RUN apt-get update
 RUN apt-get install -y curl nano less sudo
 RUN curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 RUN apt-get install -y nodejs
-RUN curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update
-#apt-get install yarn
 
 RUN mkdir /app
 
@@ -28,6 +25,6 @@ WORKDIR /app
 
 ENV FLASK_APP=metrics-api.py
 
-# Override this command with ["npm","start"]
+# Override this command with ["react-scripts","start"]
 # to run frontend React server in dev mode
 CMD ["flask", "run", "--host", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,11 @@ services:
       context: .
       dockerfile: Dockerfile
     working_dir: /app/frontend
-    command: ["npm", "run", "install-start"]
+    command: ["npm", "start"]
     volumes:
-      - .:/app
+      - ./frontend/build:/app/frontend/build
+      - ./frontend/public:/app/frontend/public
+      - ./frontend/src:/app/frontend/src
     ports:
       - '3000:3000'
     environment:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,6 @@
     "redux-thunk": "^2.3.0"
   },
   "scripts": {
-    "install-start": "npm install && react-scripts start",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",


### PR DESCRIPTION
After switching from yarn to npm, `docker-compose up` has been taking a very long time to start the react container, due to the call to `npm install`, which sometimes seems to hang forever. (Also tried `npm ci` but it didn't seem to help.)

With this change, the react docker container uses the package.json, package.lock, and node_modules from when the docker image was originally built (which happens the first time you run `docker-compose up`), and only the `/frontend/{build,public,src}` subdirectories are shared between the host and the container. This makes it no longer necessary to run `npm install` during `docker-compose up`, so now the react container starts quickly (~5 seconds).

The downside is that any time node dependencies are changed in package.json, the docker container must be rebuilt (via `docker-compose build`). If a new node module is added by someone else, all other developers using old docker containers will get errors when trying to run code referencing the new module until they rebuild their docker containers. This will be annoying, but hopefully we won't be changing the dependencies in package.json very often. I think overall it will save time since developers run `docker-compose up` run much more often, and it will be much faster after this change.