### PR TITLE
Optimize arrival time calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 
 data/*.json
 data/*.csv
+data/arrivals_*
+data/state_*
 
 ### Eclipse ###
 .metadata

--- a/compute_arrivals.py
+++ b/compute_arrivals.py
@@ -7,7 +7,6 @@ import pytz
 import time
 import boto3
 import gzip
-#import cProfile, pstats
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Compute and cache arrival history')
@@ -68,18 +67,10 @@ if __name__ == '__main__':
 
             t1 = time.time()
 
-            #pr = cProfile.Profile()
-            #pr.enable()
-
             history = arrival_history.compute_from_state(agency, route_id, start_time, end_time, route_state, d, tz)
-
-            #pr.disable()
 
             print(f'{route_id}: {round(time.time()-t1,1)} saving arrival history')
 
             arrival_history.save_for_date(history, d, args.s3)
 
             print(f'{route_id}: {round(time.time()-t1,1)} done')
-
-            #ps = pstats.Stats(pr).sort_stats('cumulative')
-            #ps.print_stats()

--- a/compute_arrivals.py
+++ b/compute_arrivals.py
@@ -4,8 +4,10 @@ import math
 import argparse
 from datetime import datetime, timedelta
 import pytz
+import time
 import boto3
 import gzip
+#import cProfile, pstats
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Compute and cache arrival history')
@@ -14,8 +16,8 @@ if __name__ == '__main__':
     parser.add_argument('--start-date', help='Start date (yyyy-mm-dd)')
     parser.add_argument('--end-date', help='End date (yyyy-mm-dd), inclusive')
     parser.add_argument('--s3', dest='s3', action='store_true', help='store in s3')
-    parser.add_argument('--cache-state', dest='cache_state', action='store_true', help='cache state on filesystem (make it faster when running multiple times)')
-    parser.set_defaults(s3=False, cache_state=False)
+    parser.add_argument('--continue-route', help='Continue at a particular route after an error')
+    parser.set_defaults(s3=False)
 
     args = parser.parse_args()
     route_ids = args.route
@@ -37,6 +39,8 @@ if __name__ == '__main__':
 
     incr = timedelta(days=1)
 
+    continue_index = route_ids.index(args.continue_route) if args.continue_route is not None else None
+
     for d in dates:
         start_dt = tz.localize(datetime(d.year,d.month, d.day, hour=3)) # start each "day" at 3 AM local time so midnight-3am buses are associated with previous day
         end_dt = start_dt + incr
@@ -46,14 +50,36 @@ if __name__ == '__main__':
 
         print(f"time = [{start_dt}, {end_dt})")
 
-        route_state_map = trynapi.get_state(agency, start_time, end_time, route_ids, args.cache_state)
+        t1 = time.time()
 
-        for route_id in route_ids:
-            if route_id not in route_state_map:
+        state = trynapi.get_state(agency, d, start_time, end_time, route_ids)
+
+        print(f'retrieved state in {round(time.time()-t1,1)} sec')
+
+        for i, route_id in enumerate(route_ids):
+            if continue_index is not None and i < continue_index:
+                continue
+
+            route_state = state.get_for_route(route_id)
+
+            if route_state is None:
                 print(f'no state for route {route_id}')
                 continue
 
-            route_state = route_state_map[route_id]
+            t1 = time.time()
 
-            history = arrival_history.compute_from_state(agency, route_id, start_time, end_time, route_state)
+            #pr = cProfile.Profile()
+            #pr.enable()
+
+            history = arrival_history.compute_from_state(agency, route_id, start_time, end_time, route_state, d, tz)
+
+            #pr.disable()
+
+            print(f'{route_id}: {round(time.time()-t1,1)} saving arrival history')
+
             arrival_history.save_for_date(history, d, args.s3)
+
+            print(f'{route_id}: {round(time.time()-t1,1)} done')
+
+            #ps = pstats.Stats(pr).sort_stats('cumulative')
+            #ps.print_stats()

--- a/compute_arrivals.py
+++ b/compute_arrivals.py
@@ -73,4 +73,4 @@ if __name__ == '__main__':
 
             arrival_history.save_for_date(history, d, args.s3)
 
-            print(f'{route_id}: {round(time.time()-t1,1)} done')
+            print(f'{route_id}: {round(time.time()-t1,2)} done')

--- a/compute_arrivals.py
+++ b/compute_arrivals.py
@@ -1,4 +1,4 @@
-from models import arrival_history, util, trynapi, nextbus
+from models import arrival_history, util, trynapi, nextbus, eclipses
 import json
 import math
 import argparse
@@ -65,9 +65,13 @@ if __name__ == '__main__':
                 print(f'no state for route {route_id}')
                 continue
 
+            route_config = nextbus.get_route_config(agency, route_id)
+
             t1 = time.time()
 
-            history = arrival_history.compute_from_state(agency, route_id, start_time, end_time, route_state, d, tz)
+            arrivals_df = eclipses.find_arrivals(route_state, route_config, d, tz)
+
+            history = arrival_history.from_data_frame(agency, route_id, arrivals_df, start_time, end_time)
 
             print(f'{route_id}: {round(time.time()-t1,1)} saving arrival history')
 

--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -19,7 +19,7 @@ class ControlPanel extends Component {
       secondStopList: [],
       firstStopId: null,
       secondStopId: null,
-      date: new Date('2019-04-08T03:50'),
+      date: new Date('2019-05-24T03:50'),
       startTimeStr: null,
       endTimeStr: null,
     };
@@ -55,7 +55,7 @@ class ControlPanel extends Component {
       };
       const intervalParams = Object.assign({}, graphParams);
       delete intervalParams.start_time; // for interval api, clear out start/end time and use defaults for now
-      delete intervalParams.end_time;   // because the hourly graph is spiky and can trigger panda "empty axes" errors. 
+      delete intervalParams.end_time;   // because the hourly graph is spiky and can trigger panda "empty axes" errors.
       this.props.fetchData(graphParams, intervalParams);
     }
   }
@@ -91,15 +91,15 @@ class ControlPanel extends Component {
     const secondStopInfo = this.getStopsInfoInGivenDirection(selectedRoute, directionId);
     const secondStopListIndex = secondStopInfo.stops.indexOf(stopId);
     const secondStopList = secondStopInfo.stops.slice(secondStopListIndex + 1);
-    
+
     let newSecondStopId = secondStopId;
-    
+
     // If the "to stop" is not set or is not valid for the current "from stop",
     // set a default "to stop" that is some number of stops down.  If there aren't
     // enough stops, use the end of the line.
-    
+
     const nStops = 5;
-    
+
     if (secondStopId == null || !secondStopList.includes(secondStopId)) {
         newSecondStopId = secondStopList.length >= nStops ? secondStopList[nStops-1] :
             secondStopList[secondStopList.length-1];
@@ -134,7 +134,7 @@ class ControlPanel extends Component {
   getStopsInfoInGivenDirectionName = (selectedRoute, name) => {
     const stopSids= selectedRoute.directions.find(dir => dir.name === name);
     return stopSids.stops.map(stop => selectedRoute.stops[stop]);
-    
+
   }
 
   selectedDirectionChanged = () => {
@@ -189,7 +189,7 @@ class ControlPanel extends Component {
       selectedDirection = selectedRoute.directions.find(dir => dir.id === directionId);
       this.sendRouteStopsToMap();
     }
-    
+
     return (
       <div className={css`
           color: #fff;

--- a/models/arrival_history.py
+++ b/models/arrival_history.py
@@ -146,13 +146,9 @@ def compute_from_state(agency, route_id, start_time, end_time, route_state, d: d
 
     route_config = nextbus.get_route_config(agency, route_id)
 
-    buses = eclipses.produce_buses(route_state)
+    arrivals = eclipses.find_arrivals(route_state, route_config, d, tz)
 
-    if not buses.empty:
-        arrivals = eclipses.find_arrivals(buses, route_config, d, tz)
-        stops_data = make_stops_data(arrivals)
-    else:
-        stops_data = {}
+    stops_data = make_stops_data(arrivals)
 
     return ArrivalHistory(agency, route_id, stops_data=stops_data, start_time=start_time, end_time=end_time)
 

--- a/models/arrival_history.py
+++ b/models/arrival_history.py
@@ -141,16 +141,9 @@ class ArrivalHistory:
             'stops': self.stops_data,
         }
 
-def compute_from_state(agency, route_id, start_time, end_time, route_state, d: date, tz) -> ArrivalHistory:
-    # note: arrivals module uses timestamps in seconds, but tryn-api uses ms
-
-    route_config = nextbus.get_route_config(agency, route_id)
-
-    arrivals = eclipses.find_arrivals(route_state, route_config, d, tz)
-
-    stops_data = make_stops_data(arrivals)
-
-    return ArrivalHistory(agency, route_id, stops_data=stops_data, start_time=start_time, end_time=end_time)
+def from_data_frame(agency, route_id, arrivals_df: pd.DataFrame, start_time, end_time) -> ArrivalHistory:
+    # note: arrival_history module uses timestamps in seconds, but tryn-api uses ms
+    return ArrivalHistory(agency, route_id, stops_data=make_stops_data(arrivals_df), start_time=start_time, end_time=end_time)
 
 def make_stops_data(arrivals: pd.DataFrame):
     stops_data = {}
@@ -161,7 +154,7 @@ def make_stops_data(arrivals: pd.DataFrame):
         for stop_id, stop_arrivals in arrivals.groupby(arrivals['SID']):
             stop_directions_data = {}
 
-            for stop_direction_id, stop_direction_arrivals in stop_arrivals.groupby(stop_arrivals['STOP_DID']):
+            for stop_direction_id, stop_direction_arrivals in stop_arrivals.groupby(stop_arrivals['DID']):
                 arrivals_data = []
 
                 for row in stop_direction_arrivals.itertuples():

--- a/models/eclipses.py
+++ b/models/eclipses.py
@@ -484,20 +484,6 @@ def filter_arrivals_by_actual_direction(dir_arrivals: pd.DataFrame) -> pd.DataFr
     # not the actual direction the bus is going :(
     # note: assumes route has at least 4 stops
 
-    # this is a faster way of doing the following in pandas but without
-    # the overhead of creating several Pandas series
-    '''
-     stop_index = dir_arrivals['STOP_INDEX']
-     prev2_stop_index = stop_index.shift(2)
-     prev_stop_index = stop_index.shift(1)
-     next_stop_index = stop_index.shift(-1)
-     next2_stop_index = stop_index.shift(-2)
-     return dir_arrivals[
-         ((stop_index - prev_stop_index > 0) & (prev_stop_index - prev2_stop_index > 0)) |
-        ((next_stop_index - stop_index > 0) & (next2_stop_index - next_stop_index > 0))
-    ]
-    '''
-
     stop_index_values = dir_arrivals['STOP_INDEX'].values
 
     num_arrivals = len(stop_index_values)

--- a/models/nextbus.py
+++ b/models/nextbus.py
@@ -29,7 +29,8 @@ class RouteInfo:
         self.title = data['title']
 
 class RouteConfig:
-    def __init__(self, data):
+    def __init__(self, agency_id, data):
+        self.agency_id = agency_id
         self.data = data
         self.id = data['tag']
         self.title = data['title']
@@ -141,7 +142,7 @@ def get_route_config(agency_id, route_id) -> RouteConfig:
             with open(cache_path, mode='r', encoding='utf-8') as f:
                 data_str = f.read()
                 try:
-                    return RouteConfig(json.loads(data_str)['route'])
+                    return RouteConfig(agency_id, json.loads(data_str)['route'])
                 except Exception as err:
                     print(err)
     except FileNotFoundError as err:
@@ -160,4 +161,4 @@ def get_route_config(agency_id, route_id) -> RouteConfig:
     with open(cache_path, mode='w', encoding='utf-8') as f:
         f.write(response.text)
 
-    return RouteConfig(data['route'])
+    return RouteConfig(agency_id, data['route'])

--- a/models/trip_times.py
+++ b/models/trip_times.py
@@ -22,7 +22,7 @@ def get_trip_times(df: pd.DataFrame, history: arrival_history.ArrivalHistory, tz
         return history.find_next_arrival_time(s2, row.VID, row.TIME, next_return_time)
 
     s1_df['dest_arrival_time'] = s1_df.apply(find_dest_arrival_time, axis=1)
-    s1_df['trip_min'] = (s1_df.dest_arrival_time - s1_df.TIME)/60
+    s1_df['trip_min'] = (s1_df.dest_arrival_time - s1_df.DEPARTURE_TIME)/60
     s1_df['dest_arrival_time_str'] = s1_df['dest_arrival_time'].apply(lambda timestamp: datetime.fromtimestamp(timestamp, tz).time() if not np.isnan(timestamp) else None)
 
     return s1_df

--- a/models/trynapi.py
+++ b/models/trynapi.py
@@ -2,23 +2,47 @@ import requests
 import urllib
 import hashlib
 import os
+import re
 import json
 import math
+from pathlib import Path
+from datetime import date
 
-def get_state(agency, start_time, end_time, route_ids, cache=False):
+class CachedState:
+    def __init__(self):
+        self.cache_paths = {}
+
+    def add(self, route_id, cache_path):
+        self.cache_paths[route_id] = cache_path
+
+    def get_for_route(self, route_id):
+        cache_path = self.cache_paths[route_id]
+        print(f'loading state for route {route_id} from cache: {cache_path}')
+        with open(cache_path, "r") as f:
+            return json.loads(f.read())
+
+def get_state(agency, d: date, start_time, end_time, route_ids) -> CachedState:
+    # saves state to local file system, since keeping the state for all routes in memory
+    # while computing arrival times causes causes Python to spend more time doing GC
+    state = CachedState()
+
+    uncached_route_ids = []
+    for route_id in route_ids:
+        cache_path = get_cache_path(agency, d, start_time, end_time, route_id)
+        if Path(cache_path).exists():
+            state.add(route_id, cache_path)
+        else:
+            uncached_route_ids.append(route_id)
+
+    if len(uncached_route_ids) == 0:
+        print('state already cached')
+        return state
+
+    route_state_map = {}
+
     # Request data from trynapi in smaller chunks to avoid internal server errors.
     # The more routes we have, the smaller our chunk size needs to be in order to
     # avoid getting internal server errors from trynapi.
-
-    if cache:
-        cache_path = get_cache_path(agency, start_time, end_time, route_ids)
-        try:
-            with open(cache_path, "r") as f:
-                print(f'state in cache: {cache_path}')
-                text = f.read()
-                return json.loads(text)
-        except FileNotFoundError as err:
-            pass
 
     # likely need to set smaller max chunk size via TRYNAPI_MAX_CHUNK env var
     # if trynapi is reading from orion-raw bucket because trynapi loads a ton of extra
@@ -35,7 +59,6 @@ def get_state(agency, start_time, end_time, route_ids, cache=False):
 
     print(f"chunk_minutes = {chunk_minutes}")
 
-    route_state_map = {}
     chunk_start_time = start_time
     while chunk_start_time < end_time:
 
@@ -46,7 +69,7 @@ def get_state(agency, start_time, end_time, route_ids, cache=False):
         # the beginning of the next chunk. Since chunk_end_time is always the first second in a UTC minute,
         # subtracting 1 from the corresponding millisecond will be the last millisecond in the previous minute,
         # so it should avoid fetching duplicate vehicle states at chunk boundaries
-        chunk_state = get_state_raw(agency, chunk_start_time*1000, chunk_end_time*1000 - 1, route_ids)
+        chunk_state = get_state_raw(agency, chunk_start_time*1000, chunk_end_time*1000 - 1, uncached_route_ids)
 
         if 'errors' in chunk_state: # trynapi returns an internal server error if you ask for too much data at once
             raise Exception(f"trynapi error for time range {chunk_start_time}-{chunk_end_time}: {chunk_state['errors']}")
@@ -67,23 +90,34 @@ def get_state(agency, start_time, end_time, route_ids, cache=False):
 
         chunk_start_time = chunk_end_time
 
-    if cache:
+    # cache state per route so we don't have to request it again if a route appears in a different list of routes
+    for route_id in uncached_route_ids:
+        cache_path = get_cache_path(agency, d, start_time, end_time, route_id)
+
+        if route_id not in route_state_map:
+            route_state_map[route_id] = None
+
+        cache_dir = Path(cache_path).parent
+        if not cache_dir.exists():
+            cache_dir.mkdir(parents = True, exist_ok = True)
+
         with open(cache_path, "w") as f:
-            print(f'writing state to cache: {cache_path}')
-            f.write(json.dumps(route_state_map))
+            print(f'writing state for route {route_id} to cache: {cache_path}')
+            f.write(json.dumps(route_state_map[route_id]))
 
-    return route_state_map
+        state.add(route_id, cache_path)
 
-def get_cache_path(agency: str, start_time, end_time, route_ids) -> str:
+    return state
+
+def get_cache_path(agency_id: str, d: date, start_time, end_time, route_id) -> str:
+    if re.match('^[\w\-]+$', agency_id) is None:
+        raise Exception(f"Invalid agency: {agency_id}")
+
+    if re.match('^[\w\-]+$', route_id) is None:
+        raise Exception(f"Invalid route id: {route_id}")
+
     source_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-
-    route_ids_slug = '+'.join(route_ids)
-
-    if len(route_ids_slug) > 100:
-        # avoid long filenames that may cause errors
-        route_ids_slug = hashlib.sha1(route_ids_slug.encode('utf-8')).hexdigest()
-
-    return os.path.join(source_dir, 'data', f"state_{agency}_{route_ids_slug}_{start_time}_{end_time}.json")
+    return os.path.join(source_dir, 'data', f"state_{agency_id}/{str(d)}/state_{agency_id}_{route_id}_{int(start_time)}_{int(end_time)}.json")
 
 def get_state_raw(agency, start_time_ms, end_time_ms, route_ids):
     tryn_agency = 'muni' if agency == 'sf-muni' else agency
@@ -98,7 +132,7 @@ def get_state_raw(agency, start_time_ms, end_time_ms, route_ids):
 
     secs_since_report_field = 'secsSinceReport' if trynapi_version > 1 else ''
 
-    params = f'trynState(agency: {json.dumps(tryn_agency)}, startTime: {json.dumps(str(start_time_ms))}, endTime: {json.dumps(str(end_time_ms))}, routes: {json.dumps(route_ids)})'
+    params = f'trynState(agency: {json.dumps(tryn_agency)}, startTime: {json.dumps(str(int(start_time_ms)))}, endTime: {json.dumps(str(int(end_time_ms)))}, routes: {json.dumps(route_ids)})'
 
     query = f"""{{
        {params} {{

--- a/models/util.py
+++ b/models/util.py
@@ -2,13 +2,14 @@ from datetime import datetime, date, timedelta
 import os
 import pytz
 
+def parse_date(date_str):
+    (y,m,d) = date_str.split('-')
+    return date(int(y),int(m),int(d))
+
 # todo: allow specifying day(s) of week
 def get_dates_in_range(start_date_str, end_date_str, max_dates=1000):
-    (start_year,start_month,start_day) = start_date_str.split('-')
-    start_date = date(int(start_year),int(start_month), int(start_day))
-
-    (end_year,end_month,end_day) = end_date_str.split('-')
-    end_date = date(int(end_year),int(end_month), int(end_day))
+    start_date = parse_date(start_date_str)
+    end_date = parse_date(end_date_str)
 
     delta = end_date - start_date
     if delta.days < 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ numpy==1.16.1
 pandas==0.24.1
 python-dateutil==2.8.0
 pytz==2018.9
-requests==2.21.0
+requests==2.22.0
 six==1.12.0
 urllib3>=1.24.2
 Werkzeug==0.14.1

--- a/route.py
+++ b/route.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
                 dwell_time_str = ', '.join([util.render_dwell_time(q) for q in dwell_time_quantiles])
                 min_dist_str = ', '.join([render_distance(min_dist) for min_dist in min_dist_quantiles])
 
-                print(f"{'%3d' % num_arrivals} arrivals ({dwell_time_str}) ({min_dist_str}) \u0394 {render_distance(delta_dist)} @ {stop_info.id} - {stop_info.title}")
+                print(f"{'%3d' % num_arrivals} arrivals ({dwell_time_str}) ({min_dist_str}) \u0394 {render_distance(delta_dist)} @ {stop_info.id} [{dir_index}] - {stop_info.title}")
                 stop_rows.append((route_id, dir_info.id, stop_id, dir_index, stop_info.lat, stop_info.lon, delta_dist, num_arrivals))
                 prev_stop_info = stop_info
 

--- a/vehicle.py
+++ b/vehicle.py
@@ -62,10 +62,15 @@ if __name__ == '__main__':
             stop_info = route_config.get_stop_info(stop_id)
             dir_info = route_config.get_direction_info(row.DID)
 
+            try:
+                stop_index = dir_info.get_stop_ids().index(stop_id)
+            except ValueError:
+                stop_index = None
+
             dwell_time = util.render_dwell_time(row.DEPARTURE_TIME - row.TIME)
             dist_str = f'{row.DIST}'.rjust(3)
 
-            print(f"t={row.DATE_STR} {row.TIME_STR} ({row.TIME}) {dwell_time} vid:{row.VID} {dist_str}m stop:{stop_id} {stop_info.title if stop_info else '?'} dir:{dir_info.title if dir_info else '?'} ({row.DID})")
+            print(f"t={row.DATE_STR} {row.TIME_STR} ({row.TIME}) {dwell_time} vid:{row.VID} {dist_str}m stop:{stop_id} {row.DID}[{stop_index}] {stop_info.title if stop_info else '?'} dir:{dir_info.title if dir_info else '?'}")
 
             num_stops += 1
 


### PR DESCRIPTION
This PR implements several changes to the algorithm for computing arrival times from GPS observations to improve correctness and performance.

**Variable eclipse distance**

Instead of using a fixed 200m radius to determine when a bus reaches a stop, it now uses the smaller of 200m or the distance to the nearest adjacent stop along the route. It also requires the bus to be closer to that stop than the previous or next stop. This fixes most weird issues near the end of certain routes where the bus never leaves a 200m radius of the second-to-last (or third-to-last) stop.

There are still some unfixed edge cases like the 30 to Jefferson Loop which reaches the corner of Chestnut and Divisadero twice while going in the same "direction".

**Second pass to add missing stops**

Sometimes the first pass of the algorithm will find an arrival at stop `i` and stop `i+2` but not stop `i+1` for some reason. If this occurs there is now a second pass that fills in small gaps of 1 or 2 stops by checking for arrivals again with a 300m radius in the relevant time period and not requiring the vehicle to be closer to that stop than the previous or next stop.

**One-way only routes**

There are some routes that only run inbound in the morning and outbound in the afternoon, but the algorithm was computing arrivals when the bus was returning along the route in the opposite direction but presumably not picking up passengers. For now these routes are hardcoded to ignore certain directions based on the time of day. Perhaps that could be determined dynamically once we have schedule data.

**Performance improvements**

This code computes arrival times about 7 times faster than before. Assuming the state from tryn-api is already cached locally, it takes about 2.5 minutes (on my dev machine) to compute 1 day of arrival times for all SF Muni routes. 

The improved performance will make it more feasible to compute historical arrival times from the route state that is already stored, and eventually to provide near-real-time arrival stats for the current day.

Computing arrivals for one route typically takes a couple of seconds, e.g.:

```
# time python compute_arrivals.py --date=2019-05-24 --route=KT
time = [2019-05-24 03:00:00-07:00, 2019-05-25 03:00:00-07:00)
state already cached
retrieved state in 0.0 sec
loading state for route KT from cache: /app/data/state_sf-muni/2019-05-24/state_sf-muni_KT_1558692000_1558778400.json
KT: 0.0 generating data frame of GPS observations
KT: 0.2 resampling 128906 GPS observations
KT: 0.9 computing distances from 280373 resampled GPS observations to stops
KT: 1.8 computing possible arrivals
KT: 2.3 cleaning arrivals
KT: 2.9 found 6672 arrivals
KT: 3.0 saving arrival history
KT: 3.02 done

real    0m3.767s
user    0m3.430s
sys     0m0.350s
```

Much of this performance increase was achieved by avoiding expensive operations on pandas series/dataframes in inner loops and using numpy operations instead. I used cProfile a lot to figure out where the code was being slow, e.g.:

```
# python -m cProfile -s cumtime compute_arrivals.py --date=2019-05-24 --route=KT
```

For example, apparently simple Pandas operations like `bus['DT'] = bus.TIME - bus.PREV_TIME` turn out to involve a lot of overhead in creating pandas series, doing operations on series, and adding new series to a data frame. It is much faster to extract the numpy arrays from the series using `.values`, and then do operations directly on numpy arrays like this:

```
time_values = bus['TIME'].values
prev_time_values = np.r_[np.nan, time_values[:-1]]
dt_values = time_values - prev_time_values
```

Probably the biggest increase in performance was from optimizing `get_possible_arrivals_for_stop` to avoid calling `.groupby` by using the fact that each "eclipse" was just a contiguous range within the eclipses data frame, so the relevant data for each eclipse could be retrieved from a slice of the numpy arrays in the eclipses data frame.

**Route state caching**

compute_arrivals.py now always stores downloaded route state locally, with a separate file per route per day. When compute_arrivals.py is called without a `--route` argument, it will first download the entire day's worth of state for all routes from tryn-api, then save the state for each route in a separate cache file. Then, it will load only that route's cache file from disk when computing arrivals for the route. 

This ends up making the arrival computations for all routes faster because there is more free memory and the Python garbage collector doesn't need to work as hard. 

Storing each route's state in a separate cache file also allows rerunning compute_arrivals.py with a different `--route` argument without needing to re-download the state from tryn-api. 

**Cache path subdirectories**

Arrival and route state cache data files are now stored in date-specific subdirectories of data/ to make it easier to navigate and delete stale data.