### PR TITLE
Replacing react-d3-components charts with react-vis

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,6 @@
     "react": "^16.8.6",
     "react-bootstrap": "^1.0.0-beta.5",
     "react-bootstrap-datetimepicker": "^0.0.22",
-    "react-d3-components": "^0.9.1",
     "react-date-picker": "^7.2.0",
     "react-dom": "^16.8.6",
     "react-gradient-timepicker": "^0.0.3",

--- a/frontend/src/UIConstants.js
+++ b/frontend/src/UIConstants.js
@@ -8,3 +8,5 @@ export const PLANNING_PERCENTILE = 90; // use this percentile (e.g. 90th) for wa
 // the idea here is to filter out extreme/maximum wait/travel values so that the user knows long the trip
 // will "usually" take.  So for 90th percentile this would be the historic performance 9 times out of 10.
 
+export const REACT_VIS_CROSSHAIR_NO_LINE = {line:{background: 'none'}}; // a commonly used style option for react-vis
+// Crosshairs (hovers) where we don't want a crosshair line spanning the chart, just the hover.

--- a/frontend/src/components/Info.jsx
+++ b/frontend/src/components/Info.jsx
@@ -1,16 +1,21 @@
 import React, { Component } from 'react';
 import { css } from 'emotion';
-import { BarChart } from 'react-d3-components';
 import Card from 'react-bootstrap/Card';
 import InfoIntervalsOfDay from './InfoIntervalsOfDay';
-import { getPercentileValue } from '../helpers/graphData'; 
+import { getPercentileValue, getBinMin, getBinMax } from '../helpers/graphData'; 
 import { PLANNING_PERCENTILE } from '../UIConstants';
 import * as d3 from 'd3';
+import { XYPlot, HorizontalGridLines, XAxis, YAxis, VerticalRectSeries,
+  ChartLabel, Crosshair } from 'react-vis';
+
 
 class Info extends Component {
   constructor(props) {
     super(props);
-    this.state = 0;
+    this.state = {
+        crosshairValues: { }, // tooltip starts out empty
+    };
+
   }
   
   computeGrades(headwayMin, waitTimes, tripTimes, speed) {
@@ -188,6 +193,34 @@ class Info extends Component {
 
     return miles;
   }
+  
+  
+  /**
+   * Event handler for onMouseLeave.
+   * @private
+   */
+  _onMouseLeave = () => {
+    this.setState({crosshairValues: {}});
+  };
+
+  /**
+   * Event handler for onNearestX.
+   * @param {Object} value Selected value.
+   * @param {index} index Index of the value in the data array.
+   * @private
+   */
+  _onNearestXHeadway = (value, {index}) => {
+    this.setState({crosshairValues: { headway: [this.headwayData[index]]}});
+  };
+
+  _onNearestXWaitTimes = (value, {index}) => {
+    this.setState({crosshairValues: { wait: [this.waitData[index]]}});
+  };
+
+  _onNearestXTripTimes = (value, {index}) => {
+    this.setState({crosshairValues: { trip: [this.tripData[index]]}});
+  };
+
 
   render() {
     const {
@@ -197,11 +230,15 @@ class Info extends Component {
     const headwayMin = graphData ? graphData.headway_min : null;
     const waitTimes = graphData ? graphData.wait_times : null;
     const tripTimes = graphData ? graphData.trip_times : null;
-
+    
+    this.headwayData = graphData ? headwayMin.histogram.map(bin => ({ x0: getBinMin(bin), x: getBinMax(bin), y: bin.count })) : null;
+    this.waitData = graphData ? waitTimes.histogram.map(bin => ({ x0: getBinMin(bin), x: getBinMax(bin), y: (100 * bin.count / (waitTimes.histogram.reduce((acc, bin) => acc + bin.count, 0))) })) : null;
+    this.tripData = graphData ? tripTimes.histogram.map(bin => ({ x0: getBinMin(bin), x: getBinMax(bin), y: bin.count })) : null;
+    
     const distance = this.computeDistance(graphParams, routes);
     const speed = tripTimes ? (distance / (tripTimes.avg / 60.0)).toFixed(1) : 0; // convert avg trip time to hours for mph
     const grades = this.computeGrades(headwayMin, waitTimes, tripTimes, speed);
-
+    
     return (
       <div
         className={css`
@@ -336,26 +373,43 @@ minutes, max headway
                 {' '}
 minutes
               </p>
-              <BarChart
-                data={[{ values: headwayMin.histogram.map(bin => ({ x: `${bin.value}`, y: bin.count })) }]}
-                width={Math.max(100, headwayMin.histogram.length * 70)}
-                className={`css
-                color: 'red'
-              `}
-                height={200}
-                margin={
-                  {
-                    top: 10,
-                    bottom: 30,
-                    left: 50,
-                    right: 10,
-                  }
-                }
-                xAxis={{ label: 'minutes' }}
-                barPadding={0.3}
-                style={{ fill: 'red' }}
-                yAxis={{ innerTickSize: 10, label: 'arrivals', tickArguments: [5] }}
-              />
+              <XYPlot xDomain={[0, Math.max(60, Math.round(headwayMin.max)+5)]} height={200} width={400} onMouseLeave={this._onMouseLeave}>
+
+                <HorizontalGridLines />
+                <XAxis />
+                <YAxis hideLine />
+
+                <VerticalRectSeries data={ this.headwayData } onNearestX={this._onNearestXHeadway} stroke="white" style={{strokeWidth: 2}}/>
+                
+                <ChartLabel 
+                text="arrivals"
+                className="alt-y-label"
+                includeMargin={false}
+                xPercent={0.06}
+                yPercent={0.06}
+                style={{
+                  transform: 'rotate(-90)',
+                  textAnchor: 'end'
+                }}       
+                />       
+  
+                <ChartLabel 
+                text="minutes"
+                className="alt-x-label"
+                includeMargin={false}
+                xPercent={0.90}
+                yPercent={0.94}
+                />       
+
+                { this.state.crosshairValues.headway && (
+                    <Crosshair values={this.state.crosshairValues.headway}
+                      style={{line:{background: 'none'}}} >
+                           <div className= 'rv-crosshair__inner__content'>
+                             Arrivals: { Math.round(this.state.crosshairValues.headway[0].y)}
+                           </div>                 
+                   </Crosshair>)}
+
+              </XYPlot>
             </div>
           ) : null }
         {waitTimes
@@ -371,28 +425,43 @@ minutes, max wait time
                 {' '}
 minutes
               </p>
-              <BarChart
-                data={[{ values: waitTimes.histogram.map(bin => ({ x: `${bin.value}`, y: (bin.count / (waitTimes.histogram.reduce((acc, bin) => acc + bin.count, 0))) })) }]}
-                width={Math.max(100, waitTimes.histogram.length * 70)}
-                className={`css
-                color: 'red'
-              `}
-                height={200}
-                margin={
-                  {
-                    top: 10,
-                    bottom: 30,
-                    left: 50,
-                    right: 10,
-                  }
-                }
-                xAxis={{ label: 'minutes' }}
-                barPadding={0.3}
-                style={{ fill: 'red' }}
-                yAxis={{
-                  innerTickSize: 10, label: 'chance', tickArguments: [5], tickFormat: d3.format('.0%'),
-                }}
-              />
+              <XYPlot xDomain={[0, Math.max(60, Math.round(waitTimes.max))+5]} height={200} width={400} onMouseLeave={this._onMouseLeave}>
+
+                <HorizontalGridLines />
+                <XAxis />
+                <YAxis hideLine tickFormat={v => `${v}%`} />
+
+                <VerticalRectSeries data={ this.waitData } onNearestX={this._onNearestXWaitTimes} stroke="white" style={{strokeWidth: 2}}/>
+
+                <ChartLabel 
+                text="chance"
+                className="alt-y-label"
+                includeMargin={false}
+                xPercent={0.06}
+                yPercent={0.06}
+                style={{
+                  transform: 'rotate(-90)',
+                  textAnchor: 'end'
+                }}       
+                />       
+  
+                <ChartLabel 
+                text="minutes"
+                className="alt-x-label"
+                includeMargin={false}
+                xPercent={0.90}
+                yPercent={0.94}
+                />       
+
+                { this.state.crosshairValues.wait && (
+                    <Crosshair values={this.state.crosshairValues.wait}
+                      style={{line:{background: 'none'}}} >
+                           <div className= 'rv-crosshair__inner__content'>
+                             Chance: { Math.round(this.state.crosshairValues.wait[0].y)}%
+                           </div>                 
+                   </Crosshair>)}
+
+              </XYPlot>
             </div>
           ) : null }
         {tripTimes
@@ -412,23 +481,43 @@ minutes, max
                 {' '}
 minutes
               </p>
-              <BarChart
-                data={[{ values: tripTimes.histogram.map(bin => ({ x: `${bin.value}`, y: bin.count })) }]}
-                width={Math.max(100, tripTimes.histogram.length * 70)}
-                height={200}
-                margin={
-                  {
-                    top: 10,
-                    bottom: 30,
-                    left: 50,
-                    right: 10,
-                  }
-                }
-                xAxis={{ label: 'minutes' }}
-                barPadding={0.3}
-                style={{ fill: 'red' }}
-                yAxis={{ innerTickSize: 10, label: 'trips', tickArguments: [5] }}
-              />
+              <XYPlot xDomain={[0, Math.max(60, Math.round(tripTimes.max))+5]} xxxType="ordinal" height={200} width={400} onMouseLeave={this._onMouseLeave}>
+
+              <HorizontalGridLines />
+              <XAxis />
+              <YAxis hideLine />
+
+              <VerticalRectSeries data={ this.tripData } onNearestX={this._onNearestXTripTimes} stroke="white" style={{strokeWidth: 2}}/>
+
+                <ChartLabel 
+                text="trips"
+                className="alt-y-label"
+                includeMargin={false}
+                xPercent={0.06}
+                yPercent={0.06}
+                style={{
+                  transform: 'rotate(-90)',
+                  textAnchor: 'end'
+                }}       
+                />       
+  
+                <ChartLabel 
+                text="minutes"
+                className="alt-x-label"
+                includeMargin={false}
+                xPercent={0.90}
+                yPercent={0.94}
+                />       
+
+                { this.state.crosshairValues.trip && (
+                  <Crosshair values={this.state.crosshairValues.trip}
+                    style={{line:{background: 'none'}}} >
+                         <div className= 'rv-crosshair__inner__content'>
+                           Trips: { Math.round(this.state.crosshairValues.trip[0].y)}
+                         </div>                 
+                 </Crosshair>)}
+
+              </XYPlot>
             </div>
           ) : null }
         <code>

--- a/frontend/src/components/Info.jsx
+++ b/frontend/src/components/Info.jsx
@@ -3,7 +3,7 @@ import { css } from 'emotion';
 import Card from 'react-bootstrap/Card';
 import InfoIntervalsOfDay from './InfoIntervalsOfDay';
 import { getPercentileValue, getBinMin, getBinMax } from '../helpers/graphData'; 
-import { PLANNING_PERCENTILE } from '../UIConstants';
+import { PLANNING_PERCENTILE, CHART_COLORS, REACT_VIS_CROSSHAIR_NO_LINE } from '../UIConstants';
 import * as d3 from 'd3';
 import { XYPlot, HorizontalGridLines, XAxis, YAxis, VerticalRectSeries,
   ChartLabel, Crosshair } from 'react-vis';
@@ -379,7 +379,7 @@ minutes
                 <XAxis />
                 <YAxis hideLine />
 
-                <VerticalRectSeries data={ this.headwayData } onNearestX={this._onNearestXHeadway} stroke="white" style={{strokeWidth: 2}}/>
+                <VerticalRectSeries data={ this.headwayData } onNearestX={this._onNearestXHeadway} stroke="white" fill={CHART_COLORS[0]} style={{strokeWidth: 2}}/>
                 
                 <ChartLabel 
                 text="arrivals"
@@ -403,7 +403,7 @@ minutes
 
                 { this.state.crosshairValues.headway && (
                     <Crosshair values={this.state.crosshairValues.headway}
-                      style={{line:{background: 'none'}}} >
+                      style={REACT_VIS_CROSSHAIR_NO_LINE} >
                            <div className= 'rv-crosshair__inner__content'>
                              Arrivals: { Math.round(this.state.crosshairValues.headway[0].y)}
                            </div>                 
@@ -431,7 +431,7 @@ minutes
                 <XAxis />
                 <YAxis hideLine tickFormat={v => `${v}%`} />
 
-                <VerticalRectSeries data={ this.waitData } onNearestX={this._onNearestXWaitTimes} stroke="white" style={{strokeWidth: 2}}/>
+                <VerticalRectSeries data={ this.waitData } onNearestX={this._onNearestXWaitTimes} stroke="white" fill={CHART_COLORS[0]} style={{strokeWidth: 2}}/>
 
                 <ChartLabel 
                 text="chance"
@@ -455,7 +455,7 @@ minutes
 
                 { this.state.crosshairValues.wait && (
                     <Crosshair values={this.state.crosshairValues.wait}
-                      style={{line:{background: 'none'}}} >
+                      style={REACT_VIS_CROSSHAIR_NO_LINE} >
                            <div className= 'rv-crosshair__inner__content'>
                              Chance: { Math.round(this.state.crosshairValues.wait[0].y)}%
                            </div>                 
@@ -487,7 +487,7 @@ minutes
               <XAxis />
               <YAxis hideLine />
 
-              <VerticalRectSeries data={ this.tripData } onNearestX={this._onNearestXTripTimes} stroke="white" style={{strokeWidth: 2}}/>
+              <VerticalRectSeries data={ this.tripData } onNearestX={this._onNearestXTripTimes} stroke="white" fill={CHART_COLORS[1]} style={{strokeWidth: 2}}/>
 
                 <ChartLabel 
                 text="trips"
@@ -511,7 +511,7 @@ minutes
 
                 { this.state.crosshairValues.trip && (
                   <Crosshair values={this.state.crosshairValues.trip}
-                    style={{line:{background: 'none'}}} >
+                    style={REACT_VIS_CROSSHAIR_NO_LINE} >
                          <div className= 'rv-crosshair__inner__content'>
                            Trips: { Math.round(this.state.crosshairValues.trip[0].y)}
                          </div>                 

--- a/frontend/src/components/Info.jsx
+++ b/frontend/src/components/Info.jsx
@@ -425,7 +425,7 @@ minutes, max wait time
                 {' '}
 minutes
               </p>
-              <XYPlot xDomain={[0, Math.max(60, Math.round(waitTimes.max))+5]} height={200} width={400} onMouseLeave={this._onMouseLeave}>
+              <XYPlot xDomain={[0, Math.max(60, Math.round(waitTimes.max)+5)]} height={200} width={400} onMouseLeave={this._onMouseLeave}>
 
                 <HorizontalGridLines />
                 <XAxis />
@@ -481,7 +481,7 @@ minutes, max
                 {' '}
 minutes
               </p>
-              <XYPlot xDomain={[0, Math.max(60, Math.round(tripTimes.max))+5]} xxxType="ordinal" height={200} width={400} onMouseLeave={this._onMouseLeave}>
+              <XYPlot xDomain={[0, Math.max(60, Math.round(tripTimes.max)+5)]} height={200} width={400} onMouseLeave={this._onMouseLeave}>
 
               <HorizontalGridLines />
               <XAxis />

--- a/frontend/src/components/InfoIntervalsOfDay.jsx
+++ b/frontend/src/components/InfoIntervalsOfDay.jsx
@@ -5,7 +5,7 @@ import DiscreteColorLegend from 'react-vis/dist/legends/discrete-color-legend';
 import Form from 'react-bootstrap/Form';
 import Card from 'react-bootstrap/Card';
 import { getPercentileValue } from '../helpers/graphData';
-import { CHART_COLORS, PLANNING_PERCENTILE } from '../UIConstants';
+import { CHART_COLORS, PLANNING_PERCENTILE, REACT_VIS_CROSSHAIR_NO_LINE } from '../UIConstants';
 import '../../node_modules/react-vis/dist/style.css'
 
 /**
@@ -152,7 +152,7 @@ class InfoIntervalsOfDay extends Component {
                  
               { this.state.crosshairValues.length > 0 && (
                <Crosshair values={this.state.crosshairValues}
-                 style={{line:{background: 'none'}}} >
+                 style={REACT_VIS_CROSSHAIR_NO_LINE} >
                       <div className= 'rv-crosshair__inner__content'>
                         <p>Onboard time: { Math.round(this.state.crosshairValues[1].y)}</p>
                         <p>Wait time: { Math.round(this.state.crosshairValues[0].y)}</p>

--- a/frontend/src/helpers/graphData.js
+++ b/frontend/src/helpers/graphData.js
@@ -14,3 +14,17 @@ export function getPercentileValue(histogram, percentile) {
     return 0;
   }
 }
+
+/**
+ * Given a histogram bin value like "5-10", return "5".
+ */
+export function getBinMin(bin) {
+  return bin.value.split("-")[0];
+}
+
+/**
+ * Given a histogram bin value like "5-10", return "10".
+ */
+export function getBinMax(bin) {
+  return bin.value.split("-")[1];
+}


### PR DESCRIPTION
As mentioned in https://github.com/trynmaps/metrics-mvp/issues/90 , we wanted to replace the react-d3-components charts with react-vis charts.  These new charts are more customizable, allow hover tooltips, and for now, have a fixed width so that the page doesn't get super wide for unusual histograms.  If needed, later we can make these flexible width.

Normal histograms:

![Screen Shot 2019-05-30 at 3 28 56 AM](https://user-images.githubusercontent.com/44861283/58627509-51bec580-828c-11e9-951c-b7ff6fef0727.png)

Unusual histograms:

![Screen Shot 2019-05-30 at 3 29 49 AM](https://user-images.githubusercontent.com/44861283/58627513-53888900-828c-11e9-87e6-722c02b20847.png)
