### PR TITLE
Weird arrivals error

### DIFF
--- a/errors.py
+++ b/errors.py
@@ -1,3 +1,7 @@
 class StopNotOnRouteError(Exception):
    """Raised when stop does not exist on route"""
    pass
+
+class FirstBusOfDayError(Exception):
+   """Raised for errors when calculating timing before the first bus of the day"""
+   pass


### PR DESCRIPTION
For some reason, this combo of params:
<img width="675" alt="Screen Shot 2019-06-03 at 11 54 00 PM" src="https://user-images.githubusercontent.com/4792589/58857793-e5acda80-865a-11e9-9543-a272ca75feec.png">
errors the `metrics_by_interval` param out as it is the first bus of the day. Put together this hacky solution for now because I don't think I understand what the code is doing here enough, but the endpoint will end up returning `null` if `06:00-07:00` is within a timeframe that is being calculated by the interval for this particular line in this direction. Would like to hear advice/relevant context.