### PR TITLE
Roadmap UI: Allow the UI to load all route configs up front instead of one at a time on demand.

### DIFF
--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -29,7 +29,9 @@ class ControlPanel extends Component {
     const selectedRoute = this.getSelectedRouteInfo();
     if (selectedRoute) {
       if (!selectedRoute.directions) {
-        this.props.fetchRouteConfig(this.state.routeId);
+        console.log("Shouldn't happen.");
+        debugger;
+        // xxx this.props.fetchRouteConfig(this.state.routeId);
       } else if (!this.state.directionId && selectedRoute.directions.length > 0) {
         this.setState({ directionId: selectedRoute.directions[0].id });
       }
@@ -121,7 +123,9 @@ class ControlPanel extends Component {
     //onRouteSelect(selectedRoute);
     if (!selectedRoute.directions) {
       this.setDirectionId(null);
-      this.props.fetchRouteConfig(routeId);
+      console.log("also shouldn't happen");
+      debugger;
+      //xxx this.props.fetchRouteConfig(routeId);
     } else {
       const directionId = selectedRoute.directions.length > 0 ? selectedRoute.directions[0].id : null;
       this.setDirectionId(directionId);

--- a/metrics-api.py
+++ b/metrics-api.py
@@ -30,7 +30,19 @@ def ping():
 @app.route('/routes', methods=['GET'])
 def routes():
     route_list = nextbus.get_route_list('sf-muni')
-    data = [{'id': route.id, 'title': route.title} for route in route_list]
+    
+    data = [{
+        'id': route.id,
+        'title': route.title,
+        'directions': [{
+            'id': dir.id,
+            'title': dir.title,
+            'name': dir.name,
+            'stops': dir.get_stop_ids()
+        } for dir in route.get_direction_infos()],
+        'stops': {stop.id: {'title': stop.title, 'lat': stop.lat, 'lon': stop.lon} for stop in route.get_stop_infos()}
+    } for route in route_list]
+    
     return Response(json.dumps(data, indent=2), mimetype='application/json')
 
 @app.route('/route', methods=['GET'])

--- a/metrics-api.py
+++ b/metrics-api.py
@@ -43,7 +43,7 @@ def routes():
         'stops': {stop.id: {'title': stop.title, 'lat': stop.lat, 'lon': stop.lon} for stop in route.get_stop_infos()}
     } for route in route_list]
     
-    return Response(json.dumps(data, indent=2), mimetype='application/json')
+    return Response(json.dumps(data), mimetype='application/json') # no prettyprinting to save bandwidth
 
 @app.route('/route', methods=['GET'])
 def route_config():
@@ -61,7 +61,7 @@ def route_config():
         } for dir in route.get_direction_infos()],
         'stops': {stop.id: {'title': stop.title, 'lat': stop.lat, 'lon': stop.lon} for stop in route.get_stop_infos()}
     }
-    return Response(json.dumps(data, indent=2), mimetype='application/json')
+    return Response(json.dumps(data), mimetype='application/json') # no prettyprinting to save bandwidth
 
 @app.route('/metrics', methods=['GET'])
 def metrics_page():

--- a/models/nextbus.py
+++ b/models/nextbus.py
@@ -89,10 +89,10 @@ def get_route_list(agency_id):
     if re.match('^[\w\-]+$', agency_id) is None:
         raise Exception(f"Invalid agency id: {agency_id}")
 
-    cache_path = os.path.join(util.get_data_dir(), f"routes_{agency_id}.json")
+    cache_path = os.path.join(util.get_data_dir(), f"routeConfigs_{agency_id}.json")
 
     def route_list_from_data(data):
-        return [RouteInfo(route) for route in data['route']]
+        return [RouteConfig(agency_id, route) for route in data['route']]
 
     try:
         mtime = os.stat(cache_path).st_mtime
@@ -107,7 +107,7 @@ def get_route_list(agency_id):
     except FileNotFoundError as err:
         pass
 
-    response = requests.get(f"http://webservices.nextbus.com/service/publicJSONFeed?command=routeList&a={agency_id}&t=0&terse")
+    response = requests.get(f"http://webservices.nextbus.com/service/publicJSONFeed?command=routeConfig&a={agency_id}&t=0&terse")
 
     data = response.json()
 
@@ -131,7 +131,7 @@ def get_route_config(agency_id, route_id) -> RouteConfig:
         raise Exception(f"Invalid route id: {route_id}")
 
     # cache route config locally to reduce number of requests to nextbus API and improve performance
-    cache_path = os.path.join(util.get_data_dir(), f"route_{agency_id}_{route_id}.json")
+    cache_path = os.path.join(util.get_data_dir(), f"routeConfigs_{agency_id}.json")
 
     try:
         mtime = os.stat(cache_path).st_mtime
@@ -142,13 +142,16 @@ def get_route_config(agency_id, route_id) -> RouteConfig:
             with open(cache_path, mode='r', encoding='utf-8') as f:
                 data_str = f.read()
                 try:
-                    return RouteConfig(agency_id, json.loads(data_str)['route'])
+                    jsonData = json.loads(data_str)['route']
+                    for jsonRoute in jsonData:
+                        if route_id == jsonRoute['tag']:
+                            return RouteConfig(agency_id, jsonRoute)
                 except Exception as err:
                     print(err)
     except FileNotFoundError as err:
         pass
 
-    response = requests.get(f"http://webservices.nextbus.com/service/publicJSONFeed?command=routeConfig&a={agency_id}&r={route_id}&t=0&terse")
+    response = requests.get(f"http://webservices.nextbus.com/service/publicJSONFeed?command=routeConfig&a={agency_id}&t=0&terse")
 
     data = response.json()
 
@@ -161,4 +164,6 @@ def get_route_config(agency_id, route_id) -> RouteConfig:
     with open(cache_path, mode='w', encoding='utf-8') as f:
         f.write(response.text)
 
-    return RouteConfig(agency_id, data['route'])
+    for jsonRoute in data['route']:
+        if route_id == jsonRoute['tag']:
+            return RouteConfig(agency_id, jsonRoute)

--- a/models/nextbus.py
+++ b/models/nextbus.py
@@ -122,6 +122,11 @@ def get_route_list(agency_id):
 
     return route_list_from_data(data)
 
+# TODO: if we stay with fetching all the route configs at once, then
+# this method can be refactored with get_route_list since they are now
+# mostly identical.  That is, get_route_config can call get_route_list,
+# then return only the requested RouteConfig.
+
 def get_route_config(agency_id, route_id) -> RouteConfig:
 
     if re.match('^[\w\-]+$', agency_id) is None:


### PR DESCRIPTION
The UI design in our roadmap works best with full route configs loaded up front.  This is so that the "spider" map can show all routes that stop near a point, and so that the "home" screen can list all routes and directions (directions are not part of the current route list).  The route configs will be used together with the precomputed trip/wait isochrone data to show grades and rankings for all routes.  Instead of a `/routes` and `/routeConfig` endpoints, there is just a single `\routes` endpoint that returns all route configs.

The volume of data fetched from Nextbus is about 780kb, and with added whitespace becomes 900kb sent from the back end to the front end.

This change is meant to be easily reversible in case issues are discovered with it.  There are other ways for the front end to load all the route configs progressively (such as making one `/routeConfig` call per route) but avoiding the complexity of having only some configs loaded for now.  If we decide to keep this change permanently, then there is some cleanup on the UI side to remove fetchRouteConfig and on the back end to refactor common code in get_route_config and get_route_list.

Note that the Nextbus API only allows 100 routes to be fetched this way.  Muni currently has 84.

The backend now caches a single route config file, instead of one file per route, for up to a day.
