### PR TITLE
frontend/public directory is not used in production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,6 @@ RUN mkdir /usr/share/nginx/html/frontend && \
     mkdir /var/cache/nginx/api-cache && \
     rm -rf /etc/nginx/conf.d
 COPY --from=react-build /app/frontend/build /usr/share/nginx/html/frontend/build
-COPY --from=react-build /app/frontend/public /usr/share/nginx/html/frontend/public
 RUN gzip -k9 /usr/share/nginx/html/frontend/build/static/css/*.css && \
     gzip -k9 /usr/share/nginx/html/frontend/build/static/js/*.js
 COPY ./nginx/conf.d /etc/nginx/conf.d

--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ To make changes, make sure you've been added to the trynmaps organization on Git
 
 Commit your local changes to a feature branch (i.e. not master), then submit a pull request on GitHub.
 
+## Frontend code
+
+The frontend React code is in the /frontend directory and is built using Create React App.
+For more information, see https://facebook.github.io/create-react-app/docs/folder-structure
 
 ## Tech Stack Decisions
 
@@ -229,6 +233,7 @@ Commit your local changes to a feature branch (i.e. not master), then submit a p
 - Functional Components - We migrated away from ES6 React Components and introduced [Functional Components](https://reactjs.org/docs/components-and-props.html) instead due to the simplification of component logic and the ability to use React Hooks
 - Redux Thunk - We use Redux for state management and to simplify our application and component interaction, and Thunk as middleware
 - React Hooks - We use React Hooks to manage interactions with state management
+
 
 ## Notes for developers
 

--- a/metrics-api.py
+++ b/metrics-api.py
@@ -284,10 +284,6 @@ if os.environ.get('METRICS_ALL_IN_ONE') == '1':
     def frontend_build(path):
         return send_from_directory('frontend/build', path)
 
-    @app.route('/frontend/public/<path:path>')
-    def frontend_public(path):
-        return send_from_directory('frontend/public', path)
-
     @app.route('/', defaults={'path': ''})
     @app.route('/<path:path>')
     def wildcard(path):


### PR DESCRIPTION
The frontend/public directory includes source files that are not used in production. Only the frontend/build directory is needed to serve the production frontend.