### PR TITLE
use Google managed SSL certificate in GKE

### DIFF
--- a/kubernetes/managed-certificate.yaml
+++ b/kubernetes/managed-certificate.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  name: muni-certificate
+spec:
+  domains:
+    - muni.opentransit.city

--- a/kubernetes/web-ingress.yaml
+++ b/kubernetes/web-ingress.yaml
@@ -1,0 +1,10 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: web-ingress
+  annotations:
+    networking.gke.io/managed-certificates: muni-certificate
+spec:
+  backend:
+    serviceName: web
+    servicePort: 80

--- a/kubernetes/web-service.yaml
+++ b/kubernetes/web-service.yaml
@@ -11,4 +11,4 @@ spec:
     targetPort: 80
   selector:
     run: web
-  type: LoadBalancer
+  type: NodePort


### PR DESCRIPTION
I already applied these YAML files were applied to the GKE cluster to create a Google-managed certificate for muni.opentransit.city and an HTTPS load balancer that routes https://muni.opentransit.city/ and http://muni.opentransit.city/ to the web service. The web service is now exposed on port 80 on each host in the cluster instead of using a TCP load balancer like before (which didn't support SSL termination). 

With this configuration Google will automatically renew the SSL certificate as long as muni.opentransit.city points to the load balancer.

I generally followed the instructions at https://cloud.google.com/kubernetes-engine/docs/how-to/managed-certs but without creating a reserved IP address (not sure if this means that GKE will automatically delete the IP address if the Ingress is deleted)