### PR TITLE
Show speed along route

### DIFF
--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { metricsBaseURL } from '../config';
+import { getTimePath, getStatPath } from '../helpers/precomputed.js';
 
 export function fetchGraphData(params) {
   return function(dispatch) {
@@ -76,6 +77,52 @@ export function fetchRoutes() {
   };
 }
 
+export function fetchPrecomputedWaitAndTripData(params) {
+  return function(dispatch, getState) {
+
+    let timeStr = params.start_time ? params.start_time + '-' + params.end_time : '';
+    let dateStr = params.date;
+    
+    const tripTimesCache = getState().routes.tripTimesCache;  
+  
+    let tripTimes = tripTimesCache[params.dateStr + timeStr + 'median']; 
+
+    if (!tripTimes) {
+      let timePath = getTimePath(timeStr);
+      let statPath = getStatPath('median');
+
+      let s3Url = 'https://opentransit-precomputed-stats.s3.amazonaws.com/trip-times/v1/sf-muni/'+
+          dateStr.replace(/-/g, '/')+
+          '/trip-times_v1_sf-muni_'+dateStr+'_'+statPath+timePath+'.json.gz';
+
+      axios.get(s3Url)
+      .then(response => {
+        dispatch({ type: 'RECEIVED_PRECOMPUTED_TRIP_TIMES', payload: [response.data, dateStr + timeStr + 'median'] })
+      })
+      .catch(err => { /* do something? */ })
+    }
+  
+    const waitTimesCache = getState().routes.waitTimesCache;  
+
+    let waitTimes = waitTimesCache[params.dateStr + timeStr + 'median']; 
+
+    if (!waitTimes) {
+      let timePath = getTimePath(timeStr);
+      let statPath = getStatPath('median');
+
+      let s3Url = 'https://opentransit-precomputed-stats.s3.amazonaws.com/wait-times/v1/sf-muni/'+
+      dateStr.replace(/-/g, '/')+
+      '/wait-times_v1_sf-muni_'+dateStr+'_'+statPath+timePath+'.json.gz';
+
+      axios.get(s3Url)
+      .then(response => {
+        dispatch({ type: 'RECEIVED_PRECOMPUTED_WAIT_TIMES', payload: [response.data, dateStr + timeStr + 'median'] })
+      })
+      .catch(err => { /* do something? */ })
+    }
+  }
+}
+
 export function handleSpiderMapClick(stops, latLng) {
   return function(dispatch) {
     dispatch({ type: 'RECEIVED_SPIDER_MAP_CLICK', payload: [stops, latLng] });
@@ -90,6 +137,10 @@ export function handleGraphParams(params) {
     // for debugging: console.log('hGP: ' + graphParams.route_id + ' dirid: ' + graphParams.direction_id + " start: " + graphParams.start_stop_id + " end: " + graphParams.end_stop_id);
     // fetch graph data if all params provided
     // TODO: fetch route summary data if all we have is a route ID.
+    
+    if (graphParams.route_id) {
+      dispatch(fetchPrecomputedWaitAndTripData(graphParams));
+    }
 
     if (graphParams.route_id && graphParams.direction_id &&
         graphParams.start_stop_id && graphParams.end_stop_id) {

--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -85,7 +85,7 @@ export function fetchPrecomputedWaitAndTripData(params) {
     
     const tripTimesCache = getState().routes.tripTimesCache;  
   
-    let tripTimes = tripTimesCache[params.dateStr + timeStr + 'median']; 
+    let tripTimes = tripTimesCache[dateStr + timeStr + 'median']; 
 
     if (!tripTimes) {
       let timePath = getTimePath(timeStr);
@@ -104,7 +104,7 @@ export function fetchPrecomputedWaitAndTripData(params) {
   
     const waitTimesCache = getState().routes.waitTimesCache;  
 
-    let waitTimes = waitTimesCache[params.dateStr + timeStr + 'median']; 
+    let waitTimes = waitTimesCache[dateStr + timeStr + 'median']; 
 
     if (!waitTimes) {
       let timePath = getTimePath(timeStr);

--- a/frontend/src/components/MapStops.jsx
+++ b/frontend/src/components/MapStops.jsx
@@ -108,11 +108,12 @@ class MapStops extends Component {
     let timeStr = graphParams.start_time ? graphParams.start_time + '-' + graphParams.end_time : '';
     let dateStr = graphParams.date;    
     
-    if (!this.props.tripTimesCache[dateStr + timeStr + 'median']) {
+    const tripTimesForDateAndTime = this.props.tripTimesCache[dateStr + timeStr + 'median'];
+    if (!tripTimesForDateAndTime) {
       return -1;
     }
     
-    const tripTimesForRoute = this.props.tripTimesCache[dateStr + timeStr + 'median'].routes[routeID];
+    const tripTimesForRoute = tripTimesForDateAndTime.routes[routeID];
     if (!tripTimesForRoute) {
       return -1;
     }

--- a/frontend/src/components/MapStops.jsx
+++ b/frontend/src/components/MapStops.jsx
@@ -2,6 +2,9 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { Map, TileLayer, CircleMarker, Tooltip, Polyline } from 'react-leaflet';
 import { handleGraphParams } from '../actions';
+import * as d3 from "d3";
+import { milesBetween } from '../helpers/routeCalculations';
+import Control from 'react-leaflet-control'
 
 const RADIUS = 6;
 const STOP_COLORS = ['blue', 'red', 'green', 'purple'];
@@ -35,11 +38,134 @@ class MapStops extends Component {
           </CircleMarker>
         );
       });
+      route.unshift(this.populateSpeed(routeStops, direction_id));
+      
       // put polyline first so clickable markers are drawn on top of it
-      route.unshift(<Polyline key={'polyline-' + direction_id} color={color} positions={routeStops[direction_id]} opacity={0.5} />);
+      route.unshift(<Polyline key={'polyline-' + direction_id} color="white" weight={10} positions={routeStops[direction_id]} opacity={1} />);
     }
     return route;
   }
+
+  // plot speed along a route
+
+  populateSpeed = (routeStops, direction_id) => {
+      
+    const downstreamStops = routeStops[direction_id];
+    let polylines = [];
+    
+    for (let i=0; i < downstreamStops.length-1; i++) {
+      const latLngs = [[ downstreamStops[i].lat, downstreamStops[i].lon ],
+                       [ downstreamStops[i+1].lat, downstreamStops[i+1].lon ]];
+      
+      const speed = this.getSpeed(downstreamStops, i, this.props.tripTimes);
+      polylines.push(
+        <Polyline
+          key={'poly-speed-' + direction_id + '-' + downstreamStops[i].sid} 
+          positions = { latLngs }
+          color = { speed < 0 ? "white" : this.speedColor(speed) }
+          opacity = { 1 }
+          weight = { 5 }
+
+          onClick={e => { // when this segment is clicked, plot only the stops for this route/dir by setting the first stop
+      
+            e.originalEvent.view.L.DomEvent.stopPropagation(e);          
+    
+            /* TODO: decide if clicking on segments changes the stop selection */
+          }
+        }
+        >
+        <Tooltip>
+           { speed < 0 ? "?" : speed.toFixed(1) } mph to { downstreamStops[i+1].title }
+        </Tooltip>
+      </Polyline>);
+
+    } // end for    
+    return polylines;
+  }
+  
+  speedColor(mph) {
+      // should this be multiples of walking speed? 3/6/9/12?
+    return d3.scaleQuantize().domain([2.5,12.5]).range(["#9e1313", "#e60000", "#f07d02", "#84ca50"])(mph);
+    // return d3.scaleQuantize().domain([0, 4]).range(d3.schemeSpectral[5])(mph/15.0*5);
+    // return d3.interpolateRdGy(mph/this.speedMax() /* scale to 0-1 */);
+  }
+  
+  /**
+   * Speed from index to index+1
+   * Using haversine distance for now.
+   */
+  getSpeed = (downstreamStops, index) => {
+    const graphParams = this.props.graphParams;
+    const routeID = graphParams.route_id;
+    const directionID = this.props.graphParams.direction_id;
+    const firstStop = downstreamStops[index];
+    const firstStopID = firstStop.sid;
+    const nextStop = downstreamStops[index+1];
+    const nextStopID = nextStop.sid;
+
+    // refactor time/date handling along with actions/index.js
+    
+    let timeStr = graphParams.start_time ? graphParams.start_time + '-' + graphParams.end_time : '';
+    let dateStr = graphParams.date;    
+    
+    if (!this.props.tripTimesCache[dateStr + timeStr + 'median']) {
+        return -1;
+    }
+    
+    const tripTimesForRoute = this.props.tripTimesCache[dateStr + timeStr + 'median'].routes[routeID];
+    if (!tripTimesForRoute) {
+      return -1;
+    }
+    
+    const tripTimesForDir = tripTimesForRoute[directionID];
+    
+    let time = null;
+    if (tripTimesForDir && tripTimesForDir[firstStopID] && tripTimesForDir[firstStopID][nextStopID]) {
+      time = tripTimesForDir[firstStopID][nextStopID];
+    } else {
+      return -1; // speed not available;
+    }
+    
+    const distance = milesBetween(firstStop, nextStop);
+    
+    return distance/time * 60; // miles per minute -> mph 
+  }
+
+  SpeedLegend = () => {
+      
+    let items = [];
+                
+    const speedColorValues = [ 2.5, 6.25, 8.75, 12.5 ]; // representative values for quantizing
+      // center of scale is 7.5 with quartile boundaries at 5 and 10.
+      
+    const speedColorLabels = [ " < 5", "5-7.5", "7.5-10", "10+" ];
+      
+    for (let speedColorValue of speedColorValues) {
+      items.push(
+        <div key={speedColorValue}>
+          <i style={{
+            backgroundColor: this.speedColor(speedColorValue),
+            width: 18,
+            float: "left"
+            
+            }} >&nbsp;</i> &nbsp;
+          { speedColorLabels[speedColorValues.indexOf(speedColorValue)] } 
+        </div>
+      );
+    }
+      
+    return <Control position="topright">
+                  <div
+                    style={{
+                        backgroundColor: 'white',
+                        padding: '5px',
+                    }}
+                > Speed (mph)
+                { items }
+                </div>
+            </Control> 
+  }
+  
   
   handleStopSelect = (stop, new_direction_id) => {
     let { route_id, start_stop_id, end_stop_id, direction_id} = this.props.graphParams;
@@ -85,7 +211,7 @@ class MapStops extends Component {
 
   
   getStopsInfoInGivenDirection = (selectedRoute, directionId) => {
-      const stopSids = selectedRoute.directions.find(dir => dir.id === directionId);
+    const stopSids = selectedRoute.directions.find(dir => dir.id === directionId);
     
     return stopSids.stops.map(stop => {
       let currentStopInfo = {...selectedRoute.stops[stop]};
@@ -133,6 +259,7 @@ class MapStops extends Component {
           opacity={0.3}
         />
         { populatedRoutes }
+        <this.SpeedLegend/>
         </Map>
         );
       }
@@ -140,6 +267,7 @@ class MapStops extends Component {
     
 const mapStateToProps = state => ({
   graphParams: state.routes.graphParams,
+  tripTimesCache: state.routes.tripTimesCache,
 });
 
 const mapDispatchToProps = dispatch => {

--- a/frontend/src/components/MapStops.jsx
+++ b/frontend/src/components/MapStops.jsx
@@ -57,7 +57,7 @@ class MapStops extends Component {
       const latLngs = [[ downstreamStops[i].lat, downstreamStops[i].lon ],
                        [ downstreamStops[i+1].lat, downstreamStops[i+1].lon ]];
       
-      const speed = this.getSpeed(downstreamStops, i, this.props.tripTimes);
+      const speed = this.getSpeed(downstreamStops, i, direction_id);
       polylines.push(
         <Polyline
           key={'poly-speed-' + direction_id + '-' + downstreamStops[i].sid} 
@@ -94,10 +94,10 @@ class MapStops extends Component {
    * Speed from index to index+1
    * Using haversine distance for now.
    */
-  getSpeed = (downstreamStops, index) => {
+  getSpeed = (downstreamStops, index, directionID) => {
     const graphParams = this.props.graphParams;
     const routeID = graphParams.route_id;
-    const directionID = this.props.graphParams.direction_id;
+
     const firstStop = downstreamStops[index];
     const firstStopID = firstStop.sid;
     const nextStop = downstreamStops[index+1];
@@ -109,7 +109,7 @@ class MapStops extends Component {
     let dateStr = graphParams.date;    
     
     if (!this.props.tripTimesCache[dateStr + timeStr + 'median']) {
-        return -1;
+      return -1;
     }
     
     const tripTimesForRoute = this.props.tripTimesCache[dateStr + timeStr + 'median'].routes[routeID];
@@ -221,10 +221,10 @@ class MapStops extends Component {
   }
 
   render() {
+      
     const {position, zoom, radius } = this.props;
   
     const mapClass = { width: '100%', height: '500px' };
-    
     
     const { routes, graphParams } = this.props;
 

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -261,7 +261,7 @@ function RouteTable(props) {
                   return (
                     <TableRow
                       hover
-                      xxxonClick={event => handleClick(event, row)}
+                      onClick={ null /*event => handleClick(event, row)*/}
                       role="checkbox"
                       aria-checked={isItemSelected}
                       tabIndex={-1}
@@ -275,7 +275,6 @@ function RouteTable(props) {
                       start_stop_id: null,
                       end_stop_id: null,
                     }, query: { route_id: row.id } }} >{row.title}</Link>
-                        <a href="#">{row.title}</a> {/* TODO: use a real /route/... link here or button, React complains about this dummy href */}
                       </TableCell>
                       <TableCell align="right">{row.wait.toFixed(1)}</TableCell>
                       <TableCell align="right">{row.speed}</TableCell>

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -261,7 +261,7 @@ function RouteTable(props) {
                   return (
                     <TableRow
                       hover
-                      onClick={ null /*event => handleClick(event, row)*/}
+                      onClick={ event => handleClick(event, row) }
                       role="checkbox"
                       aria-checked={isItemSelected}
                       tabIndex={-1}

--- a/frontend/src/helpers/precomputed.js
+++ b/frontend/src/helpers/precomputed.js
@@ -1,0 +1,145 @@
+/**
+ * Functions taken from the isochrone branch.
+ * 
+ * Fetching of the precomputed wait/trip time json is done using Redux.
+ * getTripTimesFromStop and getWaitTimeAtStop is commented out but left here for usage reference.
+ */
+export function getTimePath(timeStr)
+{
+    return timeStr ? ('_' + timeStr.replace(/:/g,'').replace('-','_').replace(/\+/g,'%2B')) : '';
+}
+
+/**
+ * 
+ * @param routeId
+ * @param directionId
+ * @param startStopId
+ * @param dateStr  "2019-07-02"
+ * @param timeStr  "0700-1900" or empty string (values from time picker)
+ * @param stat     "median"
+ * @returns
+ */
+/* async function getTripTimesFromStop(routeId, directionId, startStopId, dateStr, timeStr, stat)
+{
+    let tripTimes = tripTimesCache[dateStr + timeStr + stat];
+
+    if (!tripTimes)
+    {
+        let timePath = getTimePath(timeStr);
+        let statPath = getStatPath(stat);
+
+        let s3Url = 'https://opentransit-precomputed-stats.s3.amazonaws.com/trip-times/v1/sf-muni/'+
+            dateStr.replace(/\-/g, '/')+
+            '/trip-times_v1_sf-muni_'+dateStr+'_'+statPath+timePath+'.json.gz?v2';
+
+        tripTimes = tripTimesCache[dateStr + timeStr + stat] = await loadJson(s3Url).catch(function(e) {
+            sendError("error loading trip times: " + e);
+            throw e;
+        });
+    }
+
+    let routeTripTimes = tripTimes.routes[routeId];
+    if (!routeTripTimes)
+    {
+        return null;
+    }
+    let directionTripTimes = routeTripTimes[directionId];
+    if (!directionTripTimes)
+    {
+        return null;
+    }
+    let tripTimeValues = directionTripTimes[startStopId];
+
+    if (stat === 'median')
+    {
+        return tripTimeValues;
+    }
+    if (stat === 'p10')
+    {
+        return getTripTimeStat(tripTimeValues, 0);
+    }
+    if (stat === 'p90')
+    {
+        return getTripTimeStat(tripTimeValues, 2);
+    }
+}
+*/
+
+function getTripTimeStat(tripTimeValues, index)
+{
+    if (!tripTimeValues)
+    {
+        return null;
+    }
+
+    const statValues = {};
+    for (let endStopId in tripTimeValues)
+    {
+        statValues[endStopId] = tripTimeValues[endStopId][index];
+    }
+    return statValues;
+}
+
+export function getStatPath(stat)
+{
+    switch (stat)
+    {
+        case 'median':
+            return 'median';
+        case 'p10':
+        case 'p90':
+            return 'p10-median-p90';
+        default:
+            throw new Error('unknown stat ' + stat);
+    }
+}
+
+/*
+async function getWaitTimeAtStop(routeId, directionId, stopId, dateStr, timeStr, stat)
+{
+    let waitTimes = waitTimesCache[dateStr + timeStr + stat];
+
+    if (!waitTimes)
+    {
+        var timePath = getTimePath(timeStr);
+        let statPath = getStatPath(stat);
+
+        let s3Url = 'https://opentransit-precomputed-stats.s3.amazonaws.com/wait-times/v1/sf-muni/'+
+            dateStr.replace(/\-/g, '/')+
+            '/wait-times_v1_sf-muni_'+dateStr+'_'+statPath+timePath+'.json.gz?v2';
+
+        //console.log(s3Url);
+
+        waitTimes = waitTimesCache[dateStr + timeStr + stat] = await loadJson(s3Url).catch(function(e) {
+            sendError("error loading wait times: " + e);
+            throw e;
+        });
+    }
+
+    let routeWaitTimes = waitTimes.routes[routeId];
+    if (!routeWaitTimes)
+    {
+        return null;
+    }
+
+    let directionWaitTimes = routeWaitTimes[directionId];
+    if (!directionWaitTimes)
+    {
+        return null;
+    }
+    let waitTimeValues = directionWaitTimes[stopId];
+
+    if (stat === 'median')
+    {
+        return waitTimeValues;
+    }
+    if (stat === 'p10')
+    {
+        return waitTimeValues ? waitTimeValues[0] : null;
+    }
+    if (stat === 'p90')
+    {
+        return waitTimeValues ? waitTimeValues[2] : null;
+    }
+}
+*/

--- a/frontend/src/reducers/fetchGraphReducer.js
+++ b/frontend/src/reducers/fetchGraphReducer.js
@@ -1,5 +1,4 @@
 const initialState = {
-  fetching: false,
   graphData: null,
   intervalData: null,
 };
@@ -9,27 +8,24 @@ export default (state = initialState, action) => {
     case 'RECEIVED_GRAPH_DATA':
       return {
         ...state,
-        fetched: true,
         err: null,
         graphData: action.payload,
         graphParams: action.graphParams,
       };
     case 'RESET_GRAPH_DATA':
-      return { ...state, fetched: false, err: null, graphData: null };
+      return { ...state, err: null, graphData: null };
     case 'RECEIVED_GRAPH_ERROR':
       return { ...state, err: action.payload, graphData: null };
 
     case 'RECEIVED_INTERVAL_DATA':
       return {
         ...state,
-        fetched: true,
         intervalErr: null,
         intervalData: action.payload,
       };
     case 'RESET_INTERVAL_DATA':
       return {
         ...state,
-        fetched: false,
         intervalErr: null,
         intervalData: null,
       };

--- a/frontend/src/reducers/routesReducer.js
+++ b/frontend/src/reducers/routesReducer.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-case-declarations */
 const initialState = {
-  fetching: false,
   routes: null,
   spiderSelection: [],
   graphParams: {
@@ -20,18 +19,18 @@ const initialState = {
 export default (state = initialState, action) => {
   switch (action.type) {
     case 'RECEIVED_ROUTES':
-      return { ...state, fetched: true, routes: action.payload };
+      return { ...state, routes: action.payload };
     case 'RECEIVED_SPIDER_MAP_CLICK':
-      return { ...state, fetched: true, spiderSelection: action.payload[0], spiderLatLng: action.payload[1]};
+      return { ...state, spiderSelection: action.payload[0], spiderLatLng: action.payload[1]};
     case 'RECEIVED_GRAPH_PARAMS':
-      return { ...state, fetched: true, graphParams: Object.assign({}, state.graphParams, action.payload) };
+      return { ...state, graphParams: Object.assign({}, state.graphParams, action.payload) };
     case 'RECEIVED_ROUTES_ERROR':
       return state;
     case 'RECEIVED_PRECOMPUTED_TRIP_TIMES':
-      return { ...state, fetched: true, tripTimesCache: { ...state.tripTimesCache,
+      return { ...state, tripTimesCache: { ...state.tripTimesCache,
         [action.payload[1]]: action.payload[0] }} ; // add new dictionary entry into tripTimesCache
     case 'RECEIVED_PRECOMPUTED_WAIT_TIMES':
-      return { ...state, fetched: true, waitTimesCache: { ...state.waitTimesCache,
+      return { ...state, waitTimesCache: { ...state.waitTimesCache,
         [action.payload[1]]: action.payload[0] }} ; // add new dictionary entry into waitTimesCache
     default:
       return state;

--- a/frontend/src/reducers/routesReducer.js
+++ b/frontend/src/reducers/routesReducer.js
@@ -13,6 +13,8 @@ const initialState = {
     date: '2019-06-06',
   },
   spiderLatLng: null, 
+  tripTimesCache: {},
+  waitTimesCache: {},
 };
 
 export default (state = initialState, action) => {
@@ -25,6 +27,12 @@ export default (state = initialState, action) => {
       return { ...state, fetched: true, graphParams: Object.assign({}, state.graphParams, action.payload) };
     case 'RECEIVED_ROUTES_ERROR':
       return state;
+    case 'RECEIVED_PRECOMPUTED_TRIP_TIMES':
+      return { ...state, fetched: true, tripTimesCache: { ...state.tripTimesCache,
+        [action.payload[1]]: action.payload[0] }} ; // add new dictionary entry into tripTimesCache
+    case 'RECEIVED_PRECOMPUTED_WAIT_TIMES':
+      return { ...state, fetched: true, waitTimesCache: { ...state.waitTimesCache,
+        [action.payload[1]]: action.payload[0] }} ; // add new dictionary entry into waitTimesCache
     default:
       return state;
   }


### PR DESCRIPTION
Porting over some more stuff from my experimental branch.  To show speeds along a route, we need to fetch the precomputed trip times from S3.  I used Jesse's isochrone branch as a guide for implementing storage of the trip times and wait times in Redux.  helpers/precomputed.js has some of the same utility methods.

Currently, I'm using the `handleGraphParams` action creator as the trigger for loading the cache, so that when a route is chosen, we make sure the cache is loaded.  Loading the Dashboard screen will probably also have to trigger loading since the RouteTable will use the cache also.

Plotting speeds will probably need some refinement.  Speeds are plotted whether just one or all directions are shown.  If multiple directions are visible, then you can't see all the speeds.

Should be deployed to http://ot-terence.herokuapp.com