### PR TITLE
Refactoring speed computation and using actual median waits in RouteTable

### DIFF
--- a/frontend/src/components/MapStops.jsx
+++ b/frontend/src/components/MapStops.jsx
@@ -5,6 +5,7 @@ import { handleGraphParams } from '../actions';
 import * as d3 from "d3";
 import { milesBetween } from '../helpers/routeCalculations';
 import Control from 'react-leaflet-control'
+import { getTripTimesFromStop } from '../helpers/precomputed';
 
 const RADIUS = 6;
 const STOP_COLORS = ['blue', 'red', 'green', 'purple'];
@@ -103,26 +104,11 @@ class MapStops extends Component {
     const nextStop = downstreamStops[index+1];
     const nextStopID = nextStop.sid;
 
-    // refactor time/date handling along with actions/index.js
-    
-    let timeStr = graphParams.start_time ? graphParams.start_time + '-' + graphParams.end_time : '';
-    let dateStr = graphParams.date;    
-    
-    const tripTimesForDateAndTime = this.props.tripTimesCache[dateStr + timeStr + 'median'];
-    if (!tripTimesForDateAndTime) {
-      return -1;
-    }
-    
-    const tripTimesForRoute = tripTimesForDateAndTime.routes[routeID];
-    if (!tripTimesForRoute) {
-      return -1;
-    }
-    
-    const tripTimesForDir = tripTimesForRoute[directionID];
+    const tripTimesFromStop = getTripTimesFromStop(this.props.tripTimesCache, graphParams, routeID, directionID, firstStopID);
     
     let time = null;
-    if (tripTimesForDir && tripTimesForDir[firstStopID] && tripTimesForDir[firstStopID][nextStopID]) {
-      time = tripTimesForDir[firstStopID][nextStopID];
+    if (tripTimesFromStop && tripTimesFromStop[nextStopID]) {
+      time = tripTimesFromStop[nextStopID];
     } else {
       return -1; // speed not available;
     }

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -229,7 +229,7 @@ function RouteTable(props) {
       if (!waitForDir) {
           return NaN;
       }
-      return total + getWaitTimeForDirection(waitTimesCache, graphParams, route.id, direction.id).median;  
+      return total + waitForDir.median;  
     }, 0);
     return sumOfMedians/directions.length;
   }

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -178,8 +178,8 @@ function RouteTable(props) {
   const dense = true;
 
   useEffect(() => {
-    props.fetchPrecomputedWaitAndTripData(props.graphParams); // like componentDidMount, runs only once
-  }, []);
+    props.fetchPrecomputedWaitAndTripData(props.graphParams);
+  }, []);  // like componentDidMount, this runs only on first render
   
   function handleRequestSort(event, property) {
     const isDesc = orderBy === property && order === 'desc';
@@ -216,12 +216,13 @@ function RouteTable(props) {
   }
 
   /**
+   * Averages together the median wait in all directions for a route.
    * 
    * @param {any} waitTimesCache
    * @param {any} graphParams
    * @param {any} route
    */
-  function getMedianWait(waitTimesCache, graphParams, route) {
+  function getAverageOfMedianWait(waitTimesCache, graphParams, route) {
     const directions = route.directions;
     const sumOfMedians = directions.reduce((total, direction) => {
       const waitForDir = getWaitTimeForDirection(waitTimesCache, graphParams, route.id, direction.id);
@@ -246,7 +247,7 @@ function RouteTable(props) {
   }
   
   routes = routes.map(route => {
-    route.wait = getMedianWait(props.waitTimesCache, props.graphParams, route);     
+    route.wait = getAverageOfMedianWait(props.waitTimesCache, props.graphParams, route);     
     return route;
   });
 
@@ -303,58 +304,6 @@ function RouteTable(props) {
       </Paper>
    </div>
   );    
-}
-
-
-/**
- * These are static placeholder precomputed average waits per route values.  This will be replaced
- * eventually by values generated from the precomputed wait times for all stops on a route.
- * 
- * These are used to draw routes in three widths by frequency: widest is the top third most frequent,
- * medium width for middle third of frequency, and thinnest for the third least frequent.
- */
-function getAllWaits() {
-  const allWaits = 
-
-[{"routeID":"38BX","wait":169.84285714285716},{"routeID":"38AX","wait":159.70769230769233},
-  {"routeID":"1BX","wait":130.49655172413796},{"routeID":"41","wait":110.75636363636364},
-  {"routeID":"7X","wait":106.77532467532468},{"routeID":"1AX","wait":102.53235294117647},
-  {"routeID":"31BX","wait":97.9939393939394},{"routeID":"8AX","wait":81.05306122448978},
-  {"routeID":"82X","wait":77.36500000000002},{"routeID":"30X","wait":72.21538461538461},
-  {"routeID":"31AX","wait":48.3780487804878},{"routeID":"14X","wait":45.76607142857143},
-  {"routeID":"S","wait":42.98648648648649},{"routeID":"81X","wait":34.93750000000001},
-  {"routeID":"56","wait":26.305769230769233},{"routeID":"36","wait":23.021428571428572},
-  {"routeID":"23","wait":21.24701492537313},{"routeID":"25","wait":20.81190476190476},
-  {"routeID":"67","wait":19.99772727272727},{"routeID":"39","wait":18.764102564102565},
-  {"routeID":"18","wait":15.71111111111111},{"routeID":"12","wait":15.61954022988506},
-  {"routeID":"52","wait":15.015492957746478},{"routeID":"C","wait":14.902702702702705},
-  {"routeID":"PM","wait":14.210869565217392},{"routeID":"8BX","wait":13.026881720430108},
-  {"routeID":"PH","wait":12.933333333333332},{"routeID":"54","wait":12.680722891566266},
-  {"routeID":"8","wait":12.673636363636362},{"routeID":"35","wait":12.5109375},
-  {"routeID":"31","wait":12.00990990990991},{"routeID":"3","wait":11.955172413793104},
-  {"routeID":"37","wait":11.766315789473683},{"routeID":"88","wait":11.75263157894737},
-  {"routeID":"48","wait":11.725000000000001},{"routeID":"M","wait":11.183636363636365},
-  {"routeID":"57","wait":11.163529411764706},{"routeID":"19","wait":11.15373134328358},
-  {"routeID":"66","wait":10.487499999999999},{"routeID":"9R","wait":10.371264367816094},
-  {"routeID":"10","wait":9.95},{"routeID":"33","wait":9.621839080459772},
-  {"routeID":"5","wait":9.588750000000001},{"routeID":"2","wait":9.172},
-  {"routeID":"38","wait":8.974850299401195},{"routeID":"27","wait":8.712631578947367},
-  {"routeID":"9","wait":8.483185840707964},{"routeID":"KT","wait":8.379761904761907},
-  {"routeID":"6","wait":8.184210526315788},{"routeID":"55","wait":7.946428571428571},
-  {"routeID":"24","wait":7.747899159663866},{"routeID":"J","wait":7.675000000000001},
-  {"routeID":"29","wait":7.4916201117318435},{"routeID":"21","wait":7.115789473684211},
-  {"routeID":"7","wait":7.017757009345793},{"routeID":"28R","wait":7.000000000000001},
-  {"routeID":"43","wait":6.9662857142857115},{"routeID":"30","wait":6.941176470588235},
-  {"routeID":"44","wait":6.82734375},{"routeID":"28","wait":6.578481012658228},
-  {"routeID":"45","wait":6.361016949152543},{"routeID":"L","wait":6.295833333333333},
-  {"routeID":"22","wait":6.107608695652175},{"routeID":"F","wait":6.010000000000001},
-  {"routeID":"NX","wait":5.9375},{"routeID":"N","wait":5.803030303030303},
-  {"routeID":"5R","wait":5.579365079365079},{"routeID":"47","wait":5.460344827586206},
-  {"routeID":"14","wait":5.4173913043478255},{"routeID":"49","wait":5.0628205128205135},
-  {"routeID":"14R","wait":4.806521739130435},{"routeID":"1","wait":3.921875},
-  {"routeID":"38R","wait":3.68125}];
-
-  return allWaits;
 }
 
 const mapStateToProps = state => ({

--- a/frontend/src/helpers/precomputed.js
+++ b/frontend/src/helpers/precomputed.js
@@ -1,4 +1,9 @@
 /**
+ * Access of precomputed wait and trip times.
+ * 
+ * See https://github.com/trynmaps/metrics-mvp/pull/143 for an overview of the file structure and
+ * json structure.
+ * 
  * Functions taken from the isochrone branch.
  * 
  * Fetching of the precomputed wait/trip time json is done using Redux.
@@ -62,15 +67,15 @@ export function getTripTimesFromStop(tripTimesCache, graphParams, routeId, direc
   }
   const tripTimeValues = directionTripTimes[startStopId];
 
-  if (stat === 'median')
+  if (stat === 'median') // using the median stat group (see getStatPath)
   {
     return tripTimeValues;
   }
-  if (stat === 'p10')
+  if (stat === 'p10') // using the p10-median-p90 stat group (see getStatPath)
   {
     return getTripTimeStat(tripTimeValues, 0);
   }
-  if (stat === 'p90')
+  if (stat === 'p90') // using the p10-median-p90 stat group (see getStatPath)
   {
     return getTripTimeStat(tripTimeValues, 2);
   }
@@ -95,7 +100,9 @@ function getTripTimeStat(tripTimeValues, index)
 }
 
 /**
- * Maps the given stat to a stat group (part of the file path).
+ * Maps the given stat to a stat group (part of the file path).  Example stat groups are
+ * "median" and "p10-median-p90".  When fetching an individual stat, this function returns
+ * which group should be used, favoring more compact groups over larger ones.
  * 
  * @param stat
  */

--- a/frontend/src/helpers/precomputed.js
+++ b/frontend/src/helpers/precomputed.js
@@ -2,7 +2,11 @@
  * Functions taken from the isochrone branch.
  * 
  * Fetching of the precomputed wait/trip time json is done using Redux.
- * getTripTimesFromStop and getWaitTimeAtStop is commented out but left here for usage reference.
+ * getWaitTimeAtStop is commented out but left here for usage reference.
+ */
+
+/**
+ * Maps time range to a file path (used by Redux action).
  */
 export function getTimePath(timeStr)
 {
@@ -10,6 +14,36 @@ export function getTimePath(timeStr)
 }
 
 /**
+ * Gets trip times for a given route and direction.
+ * 
+ * @param tripTimesCache
+ * @param graphParams -- date and time values
+ * @param routeId
+ * @param directionId
+ * @param stat
+ * @returns
+ */
+export function getTripTimesForDirection(tripTimesCache, graphParams, routeId, directionId, stat = 'median') {
+
+  const [timeStr, dateStr] = getTimeStrAndDateStr(graphParams);
+  
+  const tripTimes = tripTimesCache[dateStr + timeStr + stat];
+
+  if (!tripTimes) {
+    return null;
+  }
+
+  const routeTripTimes = tripTimes.routes[routeId];
+  if (!routeTripTimes) {
+    return null;
+  }
+
+  const directionTripTimes = routeTripTimes[directionId];
+  return directionTripTimes;
+}
+
+/**
+ * Gets the downstream trip times for a given route, direction, and stop.
  * 
  * @param routeId
  * @param directionId
@@ -19,67 +53,52 @@ export function getTimePath(timeStr)
  * @param stat     "median"
  * @returns
  */
-/* async function getTripTimesFromStop(routeId, directionId, startStopId, dateStr, timeStr, stat)
+export function getTripTimesFromStop(tripTimesCache, graphParams, routeId, directionId, startStopId, stat = 'median')
 {
-    let tripTimes = tripTimesCache[dateStr + timeStr + stat];
+  const directionTripTimes = getTripTimesForDirection(tripTimesCache, graphParams, routeId, directionId);
+  if (!directionTripTimes)
+  {
+    return null;
+  }
+  const tripTimeValues = directionTripTimes[startStopId];
 
-    if (!tripTimes)
-    {
-        let timePath = getTimePath(timeStr);
-        let statPath = getStatPath(stat);
-
-        let s3Url = 'https://opentransit-precomputed-stats.s3.amazonaws.com/trip-times/v1/sf-muni/'+
-            dateStr.replace(/\-/g, '/')+
-            '/trip-times_v1_sf-muni_'+dateStr+'_'+statPath+timePath+'.json.gz?v2';
-
-        tripTimes = tripTimesCache[dateStr + timeStr + stat] = await loadJson(s3Url).catch(function(e) {
-            sendError("error loading trip times: " + e);
-            throw e;
-        });
-    }
-
-    let routeTripTimes = tripTimes.routes[routeId];
-    if (!routeTripTimes)
-    {
-        return null;
-    }
-    let directionTripTimes = routeTripTimes[directionId];
-    if (!directionTripTimes)
-    {
-        return null;
-    }
-    let tripTimeValues = directionTripTimes[startStopId];
-
-    if (stat === 'median')
-    {
-        return tripTimeValues;
-    }
-    if (stat === 'p10')
-    {
-        return getTripTimeStat(tripTimeValues, 0);
-    }
-    if (stat === 'p90')
-    {
-        return getTripTimeStat(tripTimeValues, 2);
-    }
+  if (stat === 'median')
+  {
+    return tripTimeValues;
+  }
+  if (stat === 'p10')
+  {
+    return getTripTimeStat(tripTimeValues, 0);
+  }
+  if (stat === 'p90')
+  {
+    return getTripTimeStat(tripTimeValues, 2);
+  }
 }
-*/
 
+/**
+ * Pulls a data series from a collection by index.
+ */
 function getTripTimeStat(tripTimeValues, index)
 {
-    if (!tripTimeValues)
-    {
-        return null;
-    }
+  if (!tripTimeValues)
+  {
+    return null;
+  }
 
-    const statValues = {};
-    for (let endStopId in tripTimeValues)
-    {
-        statValues[endStopId] = tripTimeValues[endStopId][index];
-    }
-    return statValues;
+  const statValues = {};
+  for (let endStopId in tripTimeValues)
+  {
+    statValues[endStopId] = tripTimeValues[endStopId][index];
+  }
+  return statValues;
 }
 
+/**
+ * Maps the given stat to a stat group (part of the file path).
+ * 
+ * @param stat
+ */
 export function getStatPath(stat)
 {
     switch (stat)
@@ -92,6 +111,48 @@ export function getStatPath(stat)
         default:
             throw new Error('unknown stat ' + stat);
     }
+}
+
+/**
+ * Utility method to pull time and date out of graphParams as strings
+ */
+export function getTimeStrAndDateStr(graphParams) {
+  let timeStr = graphParams.start_time ? graphParams.start_time + '-' + graphParams.end_time : '';
+  let dateStr = graphParams.date;
+  return [timeStr, dateStr];
+}
+
+/**
+ * Gets the wait time info for a given route and direction.
+ * 
+ * @param waitTimesCache
+ * @param graphParams -- used for date and time values
+ * @param routeId
+ * @param directionId
+ * @param stat
+ */
+export function getWaitTimeForDirection(waitTimesCache, graphParams, routeId, directionId, stat = 'median') {
+  
+  const [timeStr, dateStr] = getTimeStrAndDateStr(graphParams);
+
+  let waitTimes = waitTimesCache[dateStr + timeStr + stat];
+
+  if (!waitTimes) {
+    return null;
+  }
+
+  let routeWaitTimes = waitTimes.routes[routeId];
+  if (!routeWaitTimes)
+  {
+      return null;
+  }
+
+  let directionWaitTimes = routeWaitTimes[directionId];
+  if (!directionWaitTimes)
+  {
+      return null;
+  }
+  return directionWaitTimes;
 }
 
 /*


### PR DESCRIPTION
I moved the speed calculation code that deals with the trip times cache back into `precomputed.js` so that it can be reused.  The diff is hard to read, but basically `precomputed.js` is back to being like Jesse's isochrone functions.  I put in some JSDocs for each function.  The differences are that fetching of the s3 files is done elsewhere, and date and time are passed in using graphParams.

The routes table on the Dashboard screen is now using the wait times cache, to show the median wait for each route.  Actually, it's average of the median wait in each direction.