### PR TITLE
change flask/web deployments to request 0.03 cpu instead of 0.1 cpu 

### DIFF
--- a/kubernetes/flask-deployment.yaml
+++ b/kubernetes/flask-deployment.yaml
@@ -22,6 +22,9 @@ spec:
       - image: gcr.io/poetic-genius-233804/metrics-flask:latest
         imagePullPolicy: IfNotPresent
         name: flask
+        resources:
+          requests:
+            cpu: 0.03
         ports:
           - name: http
             containerPort: 5000

--- a/kubernetes/web-deployment.yaml
+++ b/kubernetes/web-deployment.yaml
@@ -22,6 +22,9 @@ spec:
       - image: gcr.io/poetic-genius-233804/metrics-web:latest
         imagePullPolicy: IfNotPresent
         name: web
+        resources:
+          requests:
+            cpu: 0.03
         ports:
           - name: http
             containerPort: 80


### PR DESCRIPTION
Currently our Kubernetes cluster has one n1-standard-1 instance which has 0.94 allocatable "CPU units". Kubernetes built-in services automatically request about 0.60 CPU units, leaving only 0.34 CPU units for requests from our app. By default, each container requests 0.1 CPU units, so it is only possible to run 3 containers in the cluster before Kubernetes is unable to schedule new pods because of insufficient CPU. Currently the instance shows about 10% CPU utilization on average, so the containers are not actually using all the CPU units that are allocated to them. 

By only requesting 0.03 CPU units per container, we can run 10 containers on our current instance before getting an error from Kubernetes about insufficient CPU. It is possible for the containers to use more CPU than they request, so it doesn't actually slow things down until all of the containers need to use more CPU than the instance can provide. If we were expecting actual users, we may need to increase the CPU requests or set maximum CPU limits on certain containers.

`kubectl describe nodes` shows the resource requests from all pods (Kubernetes built-in services are in the `kube-system` namespace):

```
Capacity:
 attachable-volumes-gce-pd:  128
 cpu:                        1
 ephemeral-storage:          98868448Ki
 hugepages-2Mi:              0
 memory:                     3786936Ki
 pods:                       110
Allocatable:
 attachable-volumes-gce-pd:  128
 cpu:                        940m
 ephemeral-storage:          47093746742
 hugepages-2Mi:              0
 memory:                     2701496Ki
 pods:                       110
Non-terminated Pods:         (12 in total)
  Namespace                  Name                                                             CPU Requests  CPU Limits  Memory Requests  Memory Limits  AGE
  ---------                  ----                                                             ------------  ----------  ---------------  -------------  ---
  default                    flask-6444cfd5d4-8phdn                                           30m (3%)      0 (0%)      0 (0%)           0 (0%)         3d12h
  default                    web-78bbf84fc8-lxrpn                                             30m (3%)      0 (0%)      0 (0%)           0 (0%)         3d12h
  kube-system                event-exporter-v0.2.4-5f7d5d7dd4-b44mt                           0 (0%)        0 (0%)      0 (0%)           0 (0%)         3d1h
  kube-system                fluentd-gcp-scaler-59b7b75cd7-hb7xv                              0 (0%)        0 (0%)      0 (0%)           0 (0%)         3d1h
  kube-system                fluentd-gcp-v3.2.0-nk6rg                                         100m (10%)    1 (106%)    200Mi (7%)       500Mi (18%)    8d
  kube-system                heapster-v1.6.0-beta.1-cf7f8f68f-8v7gm                           63m (6%)      63m (6%)    215440Ki (7%)    215440Ki (7%)  3d1h
  kube-system                kube-dns-76dbb796c5-ss2pc                                        260m (27%)    0 (0%)      110Mi (4%)       170Mi (6%)     8d
  kube-system                kube-dns-autoscaler-bb58c6784-2j7vq                              20m (2%)      0 (0%)      10Mi (0%)        0 (0%)         3d1h
  kube-system                kube-proxy-gke-metrics-mvp-cluster-default-pool-9bae025f-xf31    100m (10%)    0 (0%)      0 (0%)           0 (0%)         8d
  kube-system                l7-default-backend-7ff48cffd7-sn9nx                              10m (1%)      10m (1%)    20Mi (0%)        20Mi (0%)      3d1h
  kube-system                metrics-server-v0.3.1-57c75779f-ssp2m                            48m (5%)      143m (15%)  105Mi (3%)       355Mi (13%)    3d1h
  kube-system                prometheus-to-sd-b84pf                                           1m (0%)       3m (0%)     20Mi (0%)        20Mi (0%)      8d
Allocated resources:
  (Total limits may be over 100 percent, i.e., overcommitted.)
  Resource                   Requests        Limits
  --------                   --------        ------
  cpu                        662m (70%)      1219m (129%)
  memory                     691600Ki (25%)  1306000Ki (48%)
  ephemeral-storage          0 (0%)          0 (0%)
  attachable-volumes-gce-pd  0               0
```

Adding another instance or upgrading our current instance to e.g. a n1-standard-2 would also allow running more containers in the cluster. Currently our Kubernetes cluster has one n1-standard-1 which has 1 virtual CPU and 3.75 GB of memory costs about $24/month as well as a 100 GB standard persistent disk which costs about $3/month, and a HTTP load balancer which costs $18/month (total about $45/month). This cost is currently deducted from our free GCP credits. We currently have $627 in GCP credits remaining which expire next March. This allows us to spend about $70/month for the next 9 months on average before running out of free credits. 