### PR TITLE
Update gtfs scraper to update date_ranges.csv

### DIFF
--- a/models/errors.py
+++ b/models/errors.py
@@ -6,3 +6,6 @@ class ArrivalHistoryNotFoundError(Exception):
 
 class InvalidInputError(Exception):
    pass
+
+class TimetableError(Exception):
+   pass

--- a/models/gtfs.py
+++ b/models/gtfs.py
@@ -168,17 +168,17 @@ class GtfsScraper:
         print(f"{datetime.now().time().isoformat()}: Uploaded {s3_path} to s3 bucket.")
 
     def save_date_ranges(self, s3 = False, ver = "v1"):
-        df = self.get_date_ranges()
         filepath = f"{get_schedule_dir()}/date_ranges_{ver}.csv"
+
+        # if the file exists, update it, otherwise create the file
+        df = pd.concat([pd.read_csv(filepath), self.get_date_ranges()], sort = True) if Path(filepath).is_file() else self.get_date_ranges
 
         if s3:
             s3_path = f"date_ranges_{ver}.csv"
             self.upload_to_s3(s3_path, df)
-        
-        if Path(filepath).is_file():
-            print(f"{datetime.now().time().isoformat()}: Date ranges have already been cached locally.")
-        else:
-            df.to_csv(filepath)
+
+        df.to_csv(filepath)
+        print(f"{datetime.now().time().isoformat()}: date ranges have been updated locally.")
 
     def save_all_stops(self, s3 = False):
         date_ranges = self.get_date_ranges()
@@ -220,6 +220,9 @@ class GtfsScraper:
                         df = pd.concat(stops)
 
                     self.upload_to_s3(s3_path, df)
+
+                if local_file_exists:
+                    print(f"{datetime.now().time().isoformat()}: {filename} has been cached locally.")
             except NoRouteError as err:
                 print(f"{datetime.now()}: {err}")
                 continue

--- a/models/gtfs.py
+++ b/models/gtfs.py
@@ -167,6 +167,8 @@ class GtfsScraper:
         
         print(f"{datetime.now().time().isoformat()}: Uploaded {s3_path} to s3 bucket.")
 
+    # uploads date ranges df to s3 and saves a copy locally as a csv
+    # if date_ranges.csv exists locally, then this updates the file with the additional date ranges and overwrites the file in the s3 bucket
     def save_date_ranges(self, s3 = False, ver = "v1"):
         filepath = f"{get_schedule_dir()}/date_ranges_{ver}.csv"
 
@@ -177,6 +179,7 @@ class GtfsScraper:
             s3_path = f"date_ranges_{ver}.csv"
             self.upload_to_s3(s3_path, df)
 
+        # save/update date ranges locally
         df.to_csv(filepath)
         print(f"{datetime.now().time().isoformat()}: date ranges have been updated locally.")
 

--- a/models/timetable.py
+++ b/models/timetable.py
@@ -8,7 +8,7 @@ from io import StringIO
 import pandas as pd
 import numpy as np
 
-from . import nextbus, arrival_history, util, gtfs, constants
+from . import nextbus, arrival_history, util, gtfs, constants, errors
 
 class Timetable:
     def __init__(self, agency, route_id, timetable, date):
@@ -100,6 +100,6 @@ def get_date_period(agency: str, d: date, ver: str):
     elif len(period) > 0:
         date_range = period.date_range.iloc[0]
     else:
-        raise Exception(f"No timetable data for {d.isoformat()}")
+        raise errors.TimetableError(f"No timetable data for {d.isoformat()}")
 
     return [date_range[0], date_range[-1]]


### PR DESCRIPTION
Previously, the GTFS scraper wouldn't update the list of possible date ranges for timetables when adding additional timetables, which would cause errors when fetching timetables for certain dates. Now the scraper will append additional date ranges to `date_ranges.csv` when it runs.