### PR TITLE
Extract route geometry from GTFS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ Scrape timetables from GTFS data stored locally in `inpath` and extract them to 
 python gtfs_scraper.py --inpath=path/to/google_transit
 ```
 
+Merge route information from Nextbus API and GTFS
+```
+python save_routes.py
+```
+
 ## AWS Credentials
 
 If you need to write files to S3 from your development environment (e.g. running compute_arrivals.py with the --s3 flag),

--- a/frontend/public/isochrone-worker.js
+++ b/frontend/public/isochrone-worker.js
@@ -23,6 +23,7 @@ let curComputeId = null;
 let tripTimesCache = {};
 let waitTimesCache = {};
 let baseUrl = thisUrl.searchParams.get('base');
+let routesUrl = thisUrl.searchParams.get('routes_url');
 
 function loadJson(url)
 {
@@ -58,7 +59,7 @@ function loadRoutes()
     }
     else
     {
-        return loadJson("https://opentransit-precomputed-stats.s3.amazonaws.com/routes_v2_sf-muni.json.gz").then(function(data) {
+        return loadJson(routesUrl).then(function(data) {
             allRoutes = data.routes;
             return allRoutes;
         });

--- a/frontend/public/isochrone-worker.js
+++ b/frontend/public/isochrone-worker.js
@@ -58,9 +58,9 @@ function loadRoutes()
     }
     else
     {
-        return loadJson("/api/routes?v4").then(function(routes) {
-            allRoutes = routes;
-            return routes;
+        return loadJson("https://opentransit-precomputed-stats.s3.amazonaws.com/routes_v1_sf-muni.json.gz?v3").then(function(data) {
+            allRoutes = data.routes;
+            return allRoutes;
         });
     }
 }

--- a/frontend/public/isochrone-worker.js
+++ b/frontend/public/isochrone-worker.js
@@ -58,7 +58,7 @@ function loadRoutes()
     }
     else
     {
-        return loadJson("https://opentransit-precomputed-stats.s3.amazonaws.com/routes_v1_sf-muni.json.gz?v3").then(function(data) {
+        return loadJson("https://opentransit-precomputed-stats.s3.amazonaws.com/routes_v2_sf-muni.json.gz").then(function(data) {
             allRoutes = data.routes;
             return allRoutes;
         });

--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -65,7 +65,7 @@ export function resetIntervalData() {
 export function fetchRoutes() {
   return function(dispatch) {
     axios
-      .get('https://opentransit-precomputed-stats.s3.amazonaws.com/routes_v1_sf-muni.json.gz?v3')
+      .get('https://opentransit-precomputed-stats.s3.amazonaws.com/routes_v2_sf-muni.json.gz')
       .then(response => {
         dispatch({ type: 'RECEIVED_ROUTES', payload: response.data.routes });
       })

--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -65,11 +65,9 @@ export function resetIntervalData() {
 export function fetchRoutes() {
   return function(dispatch) {
     axios
-      .get('/api/routes', {
-        baseURL: metricsBaseURL,
-      })
+      .get('https://opentransit-precomputed-stats.s3.amazonaws.com/routes_v1_sf-muni.json.gz?v3')
       .then(response => {
-        dispatch({ type: 'RECEIVED_ROUTES', payload: response.data });
+        dispatch({ type: 'RECEIVED_ROUTES', payload: response.data.routes });
       })
       .catch(err => {
         dispatch({ type: 'RECEIVED_ROUTES_ERROR', payload: err });

--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -2,6 +2,8 @@ import axios from 'axios';
 import { metricsBaseURL } from '../config';
 import { getTimePath, getStatPath } from '../helpers/precomputed.js';
 
+export const routesUrl = 'https://opentransit-precomputed-stats.s3.amazonaws.com/routes_v2_sf-muni.json.gz';
+
 export function fetchGraphData(params) {
   return function(dispatch) {
     axios
@@ -65,7 +67,7 @@ export function resetIntervalData() {
 export function fetchRoutes() {
   return function(dispatch) {
     axios
-      .get('https://opentransit-precomputed-stats.s3.amazonaws.com/routes_v2_sf-muni.json.gz')
+      .get(routesUrl)
       .then(response => {
         dispatch({ type: 'RECEIVED_ROUTES', payload: response.data.routes });
       })

--- a/frontend/src/components/MapSpider.jsx
+++ b/frontend/src/components/MapSpider.jsx
@@ -391,7 +391,6 @@ class MapSpider extends Component {
           url="https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png"
           opacity={0.3}
         /> {/* see http://maps.stamen.com for details */}
-
         <this.DownstreamLines/>
         <this.StartMarkers/>
 

--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -273,7 +273,6 @@ class Isochrone extends React.Component {
                                 {
                                     tripPoints.push(fromStopInfo);
                                     for (let i = fromStopGeometry.after_index + 1; i <= toStopGeometry.after_index; i++) {
-                                        // this.tripLayers.push(L.circle(dirInfo.coords[i], 40, {color:'#009', fillOpacity:0.8, stroke:false}).addTo(map));
                                         tripPoints.push(dirInfo.coords[i]);
                                     }
                                     tripPoints.push(toStopInfo);
@@ -294,10 +293,13 @@ class Isochrone extends React.Component {
 
                                 if (tripPoints.length)
                                 {
+                                    // draw line segments along the route between fromStop and toStop
                                     let polyLine = L.polyline(tripPoints).addTo(map);
                                     polyLine.bindTooltip(routeInfo.id, {direction:'center', opacity:0.9, permanent:true});
 
                                     this.tripLayers.push(polyLine);
+
+                                    // draw small circles at fromStop and toStop
                                     this.tripLayers.push(L.circle(fromStopInfo, 40, {color:'#090', fillOpacity:0.8, stroke:false}).addTo(map));
                                     this.tripLayers.push(L.circle(toStopInfo, 40, {color:'#900', fillOpacity: 0.8, stroke:false}).addTo(map));
                                 }

--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -5,7 +5,7 @@ import L from 'leaflet';
 import Control from 'react-leaflet-control';
 import * as turf from '@turf/turf';
 
-import { fetchRoutes } from '../actions';
+import { fetchRoutes, routesUrl } from '../actions';
 import { ServiceArea, DefaultDisabledRoutes } from '../agencies/sf-muni';
 import { metricsBaseURL } from '../config';
 
@@ -85,6 +85,8 @@ class Isochrone extends React.Component {
         {
             workerUrl += '&base=' + encodeURIComponent(metricsBaseURL);
         }
+
+        workerUrl += '&routes_url=' + encodeURIComponent(routesUrl);
 
         let isochroneWorker = new Worker(workerUrl);
 

--- a/metrics-api.py
+++ b/metrics-api.py
@@ -28,56 +28,6 @@ CORS(app)
 def ping():
     return "pong"
 
-@app.route('/api/routes', methods=['GET'])
-def routes():
-    route_list = nextbus.get_route_list('sf-muni')
-
-    data = [{
-        'id': route.id,
-        'title': route.title,
-        'directions': [{
-            'id': dir.id,
-            'title': dir.title,
-            'name': dir.name,
-            'stops': dir.get_stop_ids()
-        } for dir in route.get_direction_infos()],
-        'stops': {stop.id: {'title': stop.title, 'lat': stop.lat, 'lon': stop.lon} for stop in route.get_stop_infos()}
-    } for route in route_list]
-
-    res = Response(json.dumps(data), mimetype='application/json') # no prettyprinting to save bandwidth
-    if not DEBUG:
-        res.headers['Cache-Control'] = 'max-age=3600'
-    return res
-
-@app.route('/api/route', methods=['GET'])
-def route_config():
-    route_id = request.args.get('route_id')
-    params = {'route_id': route_id}
-
-    if route_id is None:
-        return make_error_response(params, "Missing route_id", 400)
-
-    route = nextbus.get_route_config('sf-muni', route_id)
-
-    if route is None:
-        return make_error_response(params, f"Invalid route ID {route_id}", 404)
-
-    data = {
-        'id': route_id,
-        'title': route.title,
-        'directions': [{
-            'id': dir.id,
-            'title': dir.title,
-            'name': dir.name,
-            'stops': dir.get_stop_ids()
-        } for dir in route.get_direction_infos()],
-        'stops': {stop.id: {'title': stop.title, 'lat': stop.lat, 'lon': stop.lon} for stop in route.get_stop_infos()}
-    }
-    res = Response(json.dumps(data), mimetype='application/json') # no prettyprinting to save bandwidth
-    if not DEBUG:
-        res.headers['Cache-Control'] = 'max-age=3600'
-    return res
-
 @app.route('/api/metrics', methods=['GET'])
 def metrics_page():
     metrics_start = time.time()

--- a/save_routes.py
+++ b/save_routes.py
@@ -1,5 +1,6 @@
 from datetime import date
 from models import gtfs, nextbus, util
+import argparse
 import shapely
 import partridge as ptg
 import numpy as np
@@ -11,201 +12,306 @@ import gzip
 import math
 import zipfile
 
+# Downloads and parses the GTFS specification (hardcoded for Muni for now),
+# matches up GTFS shapes with Nextbus directions and stops,
+# and saves the configuration for all routes to S3.
+# The S3 object contains data merged from Nextbus and GTFS.
+# The frontend can then request this S3 URL directly without hitting the Python backend.
+
+# For each direction, the JSON object contains a coords array defining the shape of the route,
+# where the values are objects containing lat/lon properties:
+#
+# "coords":[
+#  {"lat":37.80707,"lon":-122.41727}
+#  {"lat":37.80727,"lon":-122.41562},
+#  {"lat":37.80748,"lon":-122.41398},
+#  {"lat":37.80768,"lon":-122.41234},
+#  ...
+# ]
+#
+# For each direction, the JSON object also contains a stop_geometry object where the keys are stop IDs
+# and the values are objects with a distance property (cumulative distance in meters to that stop along the GTFS # shape),
+# and an after_index property (index into the coords array of the last coordinate before that stop).
+#
+# "stop_geometry":{
+#    "5184":{"distance":8,"after_index":0},
+#    "3092":{"distance":279,"after_index":1},
+#    "3095":{"distance":573,"after_index":3},
+#    "4502":{"distance":1045,"after_index":8},
+#    ...
+#}
+#
+# In order to match a Nextbus direction with a GTFS shape_id, this finds the GTFS shape_id for that route where
+# distance(first coordinate of shape, first stop location) + distance(last coordinate of shape, last stop location)
+# is a minimum.
+#
+# In order to determine where a Nextbus stop appears along a GTFS shape, this finds the closest coordinate of the
+# GTFS shape to the Nextbus stop, then determines whether the stop is closer to the line between that GTFS shape coordinate
+# and the previous GTFS coordinate, or the line between that GTFS shape coordinate and the next GTFS coordinate.
+# (This may not always be correct for shapes that loop back on themselves.)
+#
+# Currently the script just overwrites the one S3 path, but this process could be extended in the future to
+# store different paths for different dates, to allow fetching historical data for route configurations.
+#
+
 agency_id = 'sf-muni'
 gtfs_url = 'http://gtfs.sfmta.com/transitdata/google_transit.zip'
 center_lat = 37.772
 center_lon = -122.442
-save_to_s3 = True
-
-gtfs_cache_dir = f'{util.get_data_dir()}/gtfs-{agency_id}'
-
-cache_dir = Path(gtfs_cache_dir)
-if not cache_dir.exists():
-    print(f'downloading gtfs data from {gtfs_url}')
-    r = requests.get(gtfs_url)
-
-    if r.status_code != 200:
-        raise Exception(f"Error fetching {gtfs_url}: HTTP {r.status_code}: {r.text}")
-
-    zip_path = f'{util.get_data_dir()}/gtfs-{agency_id}.zip'
-
-    with open(zip_path, 'wb') as f:
-        f.write(r.content)
-
-    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-        zip_ref.extractall(gtfs_cache_dir)
-
-gtfs_scraper = gtfs.GtfsScraper(gtfs_cache_dir, agency_id, 'v1')
-
-routes = nextbus.get_route_list(agency_id)
-
-routes_data = []
+version = 'v2'
 
 deg_lat_dist = util.haver_distance(center_lat, center_lon, center_lat-0.1, center_lon)*10
 deg_lon_dist = util.haver_distance(center_lat, center_lon, center_lat, center_lon-0.1)*10
 
+# projection function from lon/lat coordinates in degrees (z ignored) to x/y coordinates in meters.
+# satisfying the interface of shapely.ops.transform (https://shapely.readthedocs.io/en/stable/manual.html#shapely.ops.transform).
+# This makes it possible to use shapely methods to calculate the distance in meters between geometries
 def project_xy(lon, lat, z=None):
     return (round((lon - center_lon) * deg_lon_dist, 1), round((lat - center_lat) * deg_lat_dist, 1))
 
-def distance(x1, x2, y1, y2):
-    return np.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2)
+def get_stop_geometry(route, stop_id, xy_geometry, shape_lat, shape_lon, shape_cumulative_dist):
+    stop_info = route.get_stop_info(stop_id)
 
-for route in routes:
+    stop_dist_to_shape_coords = util.haver_distance(shape_lat, shape_lon, stop_info.lat, stop_info.lon)
 
-    route_id = route.id
+    closest_index = int(np.argmin(stop_dist_to_shape_coords))
 
-    try:
-        gtfs_route_id = gtfs_scraper.get_gtfs_route_id(route_id)
-    except gtfs.NoRouteError as ex:
-        print(ex)
-        gtfs_route_id = None
+    # determine the offset distance between the stop and the line after the closest coord,
+    # and between the stop and the line after the closest coord.
+    # Need to project lon/lat coords to x/y here in order for shapely to determine the distance between
+    # a point and a line (shapely doesn't support distance for lon/lat coords)
 
-    trips_df = gtfs_scraper.feed.trips
-    shapes = gtfs_scraper.feed.shapes
+    stop_xy = shapely.geometry.Point(project_xy(stop_info.lon, stop_info.lat))
 
-    print(f'{route_id} = {gtfs_route_id}')
+    geom_length = len(xy_geometry.coords)
 
-    route_data = {
-        'id': route.id,
-        'title': route.title,
-        'gtfs_route_id': gtfs_route_id,
-        'directions': [],
-        'stops': {stop.id: {'title': stop.title, 'lat': stop.lat, 'lon': stop.lon} for stop in route.get_stop_infos()}
-    }
-    routes_data.append(route_data)
+    if closest_index < geom_length - 1:
+        next_line = shapely.geometry.LineString(xy_geometry.coords[closest_index:closest_index+2])
+        next_line_offset = next_line.distance(stop_xy)
 
-    if gtfs_route_id is not None:
-        route_trips = trips_df[(trips_df['route_id'] == gtfs_route_id)]
-        route_shape_ids, route_shape_id_counts = np.unique(route_trips['shape_id'].values, return_counts=True)
+    if closest_index > 0:
+        prev_line = shapely.geometry.LineString(xy_geometry.coords[closest_index-1:closest_index+1])
+        prev_line_offset = prev_line.distance(stop_xy)
 
-        # sort from most common -> least common (used as tiebreak for two shapes with the same total distance to first/last stop)
-        route_shape_id_order = np.argsort(-1 * route_shape_id_counts)
-
-        route_shape_ids = route_shape_ids[route_shape_id_order]
-        route_shape_id_counts = route_shape_id_counts[route_shape_id_order]
+    if closest_index == 0:
+        stop_after_index = 0
+        offset = next_line_offset
+    elif closest_index + 1 >= geom_length:
+        stop_after_index = closest_index - 1
+        offset = prev_line_offset
     else:
-        route_shape_ids = None
+        offset = min(next_line_offset, prev_line_offset)
+        stop_after_index = closest_index if next_line_offset < prev_line_offset else closest_index - 1
 
-    used_shape_ids = {}
+    stop_dist = shape_cumulative_dist[stop_after_index] + stop_dist_to_shape_coords[stop_after_index]
 
-    for direction_id in route.get_direction_ids():
-        dir_info = route.get_direction_info(direction_id)
+    return {
+        'distance': int(stop_dist), # total distance in meters along the route shape to this stop
+        'after_index': stop_after_index, # the index of the coordinate of the shape just before this stop
+        'offset': int(offset) # distance in meters between this stop and the closest line segment of shape
+    }
 
-        dir_data = {
-            'id': dir_info.id,
-            'title': dir_info.title,
-            'name': dir_info.name,
-            'stops': dir_info.get_stop_ids(),
-            'stop_geometry': {},
+def download_gtfs_data(agency_id, gtfs_url, gtfs_cache_dir):
+    cache_dir = Path(gtfs_cache_dir)
+    if not cache_dir.exists():
+        print(f'downloading gtfs data from {gtfs_url}')
+        r = requests.get(gtfs_url)
+
+        if r.status_code != 200:
+            raise Exception(f"Error fetching {gtfs_url}: HTTP {r.status_code}: {r.text}")
+
+        zip_path = f'{util.get_data_dir()}/gtfs-{agency_id}.zip'
+
+        with open(zip_path, 'wb') as f:
+            f.write(r.content)
+
+        with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+            zip_ref.extractall(gtfs_cache_dir)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Merge route information from Nextbus API and GTFS')
+    parser.add_argument('--s3', dest='s3', action='store_true', help='store in s3')
+    parser.set_defaults(s3=False)
+
+    args = parser.parse_args()
+
+    gtfs_cache_dir = f'{util.get_data_dir()}/gtfs-{agency_id}'
+
+    download_gtfs_data(agency_id, gtfs_url, gtfs_cache_dir)
+
+    gtfs_scraper = gtfs.GtfsScraper(gtfs_cache_dir, agency_id, 'v1')
+
+    routes = nextbus.get_route_list(agency_id)
+
+    routes_data = []
+
+    for route in routes:
+
+        route_id = route.id
+
+        try:
+            gtfs_route_id = gtfs_scraper.get_gtfs_route_id(route_id)
+        except gtfs.NoRouteError as ex:
+            print(ex)
+            gtfs_route_id = None
+
+        trips_df = gtfs_scraper.feed.trips
+        shapes = gtfs_scraper.feed.shapes
+
+        print(f'{route_id} = {gtfs_route_id}')
+
+        route_data = {
+            'id': route.id,
+            'title': route.title,
+            'gtfs_route_id': gtfs_route_id,
+            'directions': [],
+            'stops': {
+                stop.id: {
+                    'title': stop.title,
+                    'lat': stop.lat,
+                    'lon': stop.lon
+                } for stop in route.get_stop_infos()
+            }
         }
-        route_data['directions'].append(dir_data)
+        routes_data.append(route_data)
 
-        if gtfs_route_id is None:
-            continue
+        if gtfs_route_id is not None:
+            route_trips = trips_df[(trips_df['route_id'] == gtfs_route_id)]
+            route_shape_ids, route_shape_id_counts = np.unique(route_trips['shape_id'].values, return_counts=True)
 
-        dir_stop_ids = dir_info.get_stop_ids()
+            # sort from most common -> least common (used as tiebreak for two shapes with the same total distance to first/last stop)
+            route_shape_id_order = np.argsort(-1 * route_shape_id_counts)
 
-        terminal_dists = []
+            route_shape_ids = route_shape_ids[route_shape_id_order]
+            route_shape_id_counts = route_shape_id_counts[route_shape_id_order]
+        else:
+            route_shape_ids = None
 
-        first_stop_info = route.get_stop_info(dir_stop_ids[0])
-        last_stop_info = route.get_stop_info(dir_stop_ids[-1])
+        used_shape_ids = {}
 
-        first_stop_xy = shapely.geometry.Point(project_xy(first_stop_info.lon, first_stop_info.lat))
-        last_stop_xy = shapely.geometry.Point(project_xy(last_stop_info.lon, last_stop_info.lat))
+        for direction_id in route.get_direction_ids():
+            dir_info = route.get_direction_info(direction_id)
 
-        geometries = []
+            dir_data = {
+                'id': dir_info.id,
+                'title': dir_info.title,
+                'name': dir_info.name,
+                'stops': dir_info.get_stop_ids(),
+                'stop_geometry': {},
+            }
+            route_data['directions'].append(dir_data)
 
-        for shape_id in route_shape_ids:
-            geometry = shapes[shapes['shape_id'] == shape_id]['geometry'].values[0]
-            geometries.append(geometry)
+            if gtfs_route_id is None:
+                continue
 
-            shape_start_xy = shapely.geometry.Point(project_xy(*geometry.coords[0]))
-            shape_end_xy = shapely.geometry.Point(project_xy(*geometry.coords[-1]))
+            dir_stop_ids = dir_info.get_stop_ids()
 
-            start_dist = distance(first_stop_xy.x, shape_start_xy.x, first_stop_xy.y, shape_start_xy.y)
+            terminal_dists = []
 
-            end_dist = distance(last_stop_xy.x, shape_end_xy.x, last_stop_xy.y, shape_end_xy.y)
+            first_stop_info = route.get_stop_info(dir_stop_ids[0])
+            last_stop_info = route.get_stop_info(dir_stop_ids[-1])
 
-            terminal_dist = start_dist + end_dist
+            # partridge returns GTFS geometries for each shape_id as a shapely LineString
+            # (https://shapely.readthedocs.io/en/stable/manual.html#linestrings).
+            # Each coordinate is an array in [lon,lat] format (note: longitude first, latitude second)
+            geometries = []
 
-            terminal_dists.append(terminal_dist)
+            # Determine distance between first stop and start of GTFS shape,
+            # plus distance between last stop and end of GTFS shape,
+            # for all GTFS shapes for this route.
+            for shape_id in route_shape_ids:
+                geometry = shapes[shapes['shape_id'] == shape_id]['geometry'].values[0]
+                geometries.append(geometry)
 
-        terminal_dist_order = np.argsort(terminal_dists)
+                shape_start = geometry.coords[0]
+                shape_end = geometry.coords[-1]
 
-        best_shape_index = terminal_dist_order[0]
+                start_dist = util.haver_distance(first_stop_info.lat, first_stop_info.lon, shape_start[1], shape_start[0])
+                end_dist = util.haver_distance(last_stop_info.lat, last_stop_info.lon, shape_end[1], shape_end[0])
 
-        shape_id = route_shape_ids[best_shape_index]
-        used_shape_ids[shape_id] = True
+                terminal_dist = start_dist + end_dist
+                terminal_dists.append(terminal_dist)
 
-        print(f'  {direction_id} = {shape_id} (n={route_shape_id_counts[best_shape_index]})')
+            terminal_dist_order = np.argsort(terminal_dists)
 
-        geometry = geometries[best_shape_index]
+            best_shape_index = terminal_dist_order[0] # index of the "best" shape for this direction, with the minimum terminal_dist
 
-        xy_geometry = shapely.ops.transform(project_xy, geometry)
+            shape_id = route_shape_ids[best_shape_index]
+            best_terminal_dist = terminal_dists[best_shape_index]
 
-        dir_data['gtfs_shape_id'] = shape_id
-        dir_data['coords'] = [{'lat': round(coord[1], 5), 'lon': round(coord[0], 5)} for coord in geometry.coords]
-        dir_data['distance'] = int(xy_geometry.length)
+            used_shape_ids[shape_id] = True
 
-        geom_length = len(xy_geometry.coords)
-        xy_array = np.array(xy_geometry)
-        x_array = xy_array.T[0]
-        y_array = xy_array.T[1]
+            print(f'  {direction_id} = {shape_id} (n={route_shape_id_counts[best_shape_index]}) (terminal_dist={int(best_terminal_dist)}) {" (questionable match)" if best_terminal_dist > 300 else ""}')
 
-        prev_x_array = np.r_[x_array[0], x_array[:-1]]
-        prev_y_array = np.r_[y_array[0], y_array[:-1]]
-        geom_dist = np.cumsum(distance(x_array, prev_x_array, y_array, prev_y_array))
+            geometry = geometries[best_shape_index]
 
-        for stop_id in dir_stop_ids:
-            stop_info = route.get_stop_info(stop_id)
-            stop_xy = shapely.geometry.Point(project_xy(stop_info.lon, stop_info.lat))
+            xy_geometry = shapely.ops.transform(project_xy, geometry)
 
-            stop_geom_dist = distance(x_array, stop_xy.x, y_array, stop_xy.y)
+            dir_data['gtfs_shape_id'] = shape_id
+            dir_data['coords'] = [
+                {
+                    'lat': round(coord[1], 5),
+                    'lon': round(coord[0], 5)
+                } for coord in geometry.coords
+            ]
 
-            closest_index = int(np.argmin(stop_geom_dist))
+            shape_lon_lat = np.array(geometry).T
+            shape_lon = shape_lon_lat[0]
+            shape_lat = shape_lon_lat[1]
 
-            if closest_index == 0:
-                stop_geom_index = 0
-            elif closest_index + 1 >= geom_length:
-                stop_geom_index = closest_index - 1
-            else:
-                next_line = shapely.geometry.LineString(xy_geometry.coords[closest_index:closest_index+2])
-                next_line_dist = next_line.distance(stop_xy)
+            shape_prev_lon = np.r_[shape_lon[0], shape_lon[:-1]]
+            shape_prev_lat = np.r_[shape_lat[0], shape_lat[:-1]]
 
-                prev_line = shapely.geometry.LineString(xy_geometry.coords[closest_index-1:closest_index+1])
-                prev_line_dist = prev_line.distance(stop_xy)
+            # shape_cumulative_dist[i] is the cumulative distance in meters along the shape geometry from 0th to ith coordinate
+            shape_cumulative_dist = np.cumsum(util.haver_distance(shape_lon, shape_lat, shape_prev_lon, shape_prev_lat))
 
-                stop_geom_index = closest_index if next_line_dist < prev_line_dist else closest_index - 1
+            # this is the total distance of the GTFS shape, which may not be exactly the same as the
+            # distance along the route between the first and last Nextbus stop
+            dir_data['distance'] = int(shape_cumulative_dist[-1])
 
-            stop_dist = geom_dist[stop_geom_index] + stop_geom_dist[stop_geom_index]
+            prev_after_index = None
 
-            dir_data['stop_geometry'][stop_id] = {'distance': int(stop_dist), 'after_index': stop_geom_index}
+            for stop_id in dir_stop_ids:
+                stop_geometry = get_stop_geometry(route, stop_id, xy_geometry, shape_lat, shape_lon, shape_cumulative_dist)
 
-    if route_shape_ids is not None:
-        for i, shape_id in enumerate(route_shape_ids):
-            if shape_id not in used_shape_ids:
-                print(f'  ? = {shape_id} (n={route_shape_id_counts[i]})')
+                if prev_after_index is not None and stop_geometry['after_index'] < prev_after_index:
+                    print(f"    !! bad geometry for stop {stop_id}: after_index {stop_geometry['after_index']} not in ascending order")
+                    continue
 
-data_str = json.dumps({
-    'version': 'v1',
-    'routes': routes_data
-}, separators=(',', ':'))
+                if stop_geometry['offset'] > 100:
+                    print(f"    !! bad geometry for stop {stop_id}: {stop_geometry['offset']} m from route line segment")
+                    continue
 
-cache_path = f'{util.get_data_dir()}/routes_v1_{agency_id}.json'
+                dir_data['stop_geometry'][stop_id] = stop_geometry
 
-with open(cache_path, "w") as f:
-    f.write(data_str)
+                prev_after_index = stop_geometry['after_index']
 
-if save_to_s3:
-    s3 = boto3.resource('s3')
-    s3_path = f'routes_v1_{agency_id}.json.gz'
-    s3_bucket = 'opentransit-precomputed-stats'
-    print(f'saving to s3://{s3_bucket}/{s3_path}')
-    object = s3.Object(s3_bucket, s3_path)
-    object.put(
-        Body=gzip.compress(bytes(data_str, 'utf-8')),
-        CacheControl='max-age=86400',
-        ContentType='application/json',
-        ContentEncoding='gzip',
-        ACL='public-read'
-    )
+
+        if route_shape_ids is not None:
+            for i, shape_id in enumerate(route_shape_ids):
+                if shape_id not in used_shape_ids:
+                    print(f'  ? = {shape_id} (n={route_shape_id_counts[i]})')
+
+    data_str = json.dumps({
+        'version': version,
+        'routes': routes_data
+    }, separators=(',', ':'))
+
+    cache_path = f'{util.get_data_dir()}/routes_{version}_{agency_id}.json'
+
+    with open(cache_path, "w") as f:
+        f.write(data_str)
+
+    if args.s3:
+        s3 = boto3.resource('s3')
+        s3_path = f'routes_{version}_{agency_id}.json.gz'
+        s3_bucket = 'opentransit-precomputed-stats'
+        print(f'saving to s3://{s3_bucket}/{s3_path}')
+        object = s3.Object(s3_bucket, s3_path)
+        object.put(
+            Body=gzip.compress(bytes(data_str, 'utf-8')),
+            CacheControl='max-age=86400',
+            ContentType='application/json',
+            ContentEncoding='gzip',
+            ACL='public-read'
+        )

--- a/save_routes.py
+++ b/save_routes.py
@@ -1,0 +1,218 @@
+from datetime import date
+from models import gtfs, nextbus, util
+import shapely
+import partridge as ptg
+import numpy as np
+from pathlib import Path
+import requests
+import json
+import boto3
+import gzip
+import math
+import zipfile
+
+agency_id = 'sf-muni'
+gtfs_cache_dir = f'{util.get_data_dir()}/gtfs-{agency_id}'
+gtfs_url = 'http://gtfs.sfmta.com/transitdata/google_transit.zip'
+center_lat = 37.772
+center_lon = -122.442
+
+cache_dir = Path(gtfs_cache_dir)
+if not cache_dir.exists():
+    print(f'downloading gtfs data from {gtfs_url}')
+    r = requests.get(gtfs_url)
+
+    if r.status_code != 200:
+        raise Exception(f"Error fetching {gtfs_url}: HTTP {r.status_code}: {r.text}")
+
+    zip_path = f'{util.get_data_dir()}/gtfs-{agency_id}.zip'
+
+    with open(zip_path, 'wb') as f:
+        f.write(r.content)
+
+    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
+        zip_ref.extractall(gtfs_cache_dir)
+
+gtfs_scraper = gtfs.GtfsScraper(gtfs_cache_dir, agency_id, 'v1')
+
+routes = nextbus.get_route_list(agency_id)
+
+routes_data = []
+
+deg_lat_dist = util.haver_distance(center_lat, center_lon, center_lat-0.1, center_lon)*10
+deg_lon_dist = util.haver_distance(center_lat, center_lon, center_lat, center_lon-0.1)*10
+
+def project_xy(lon, lat, z=None):
+    return (round((lon - center_lon) * deg_lon_dist, 1), round((lat - center_lat) * deg_lat_dist, 1))
+
+def distance(x1, x2, y1, y2):
+    return np.sqrt((x1 - x2) ** 2 + (y1 - y2) ** 2)
+
+for route in routes:
+
+    route_id = route.id
+
+    try:
+        gtfs_route_id = gtfs_scraper.get_gtfs_route_id(route_id)
+    except gtfs.NoRouteError as ex:
+        print(ex)
+        gtfs_route_id = None
+
+    trips_df = gtfs_scraper.feed.trips
+    shapes = gtfs_scraper.feed.shapes
+
+    print(f'{route_id} = {gtfs_route_id}')
+
+    route_data = {
+        'id': route.id,
+        'title': route.title,
+        'gtfs_route_id': gtfs_route_id,
+        'directions': [],
+        'stops': {stop.id: {'title': stop.title, 'lat': stop.lat, 'lon': stop.lon} for stop in route.get_stop_infos()}
+    }
+    routes_data.append(route_data)
+
+    if gtfs_route_id is not None:
+        route_trips = trips_df[(trips_df['route_id'] == gtfs_route_id)]
+        route_shape_ids, route_shape_id_counts = np.unique(route_trips['shape_id'].values, return_counts=True)
+
+        # sort from most common -> least common (used as tiebreak for two shapes with the same total distance to first/last stop)
+        route_shape_id_order = np.argsort(-1 * route_shape_id_counts)
+
+        route_shape_ids = route_shape_ids[route_shape_id_order]
+        route_shape_id_counts = route_shape_id_counts[route_shape_id_order]
+    else:
+        route_shape_ids = None
+
+    used_shape_ids = {}
+
+    for direction_id in route.get_direction_ids():
+        dir_info = route.get_direction_info(direction_id)
+
+        dir_data = {
+            'id': dir_info.id,
+            'title': dir_info.title,
+            'name': dir_info.name,
+            'stops': dir_info.get_stop_ids(),
+            'stop_geometry': {},
+        }
+        route_data['directions'].append(dir_data)
+
+        if gtfs_route_id is None:
+            continue
+
+        dir_stop_ids = dir_info.get_stop_ids()
+
+        terminal_dists = []
+
+        first_stop_info = route.get_stop_info(dir_stop_ids[0])
+        last_stop_info = route.get_stop_info(dir_stop_ids[-1])
+
+        first_stop_xy = shapely.geometry.Point(project_xy(first_stop_info.lon, first_stop_info.lat))
+        last_stop_xy = shapely.geometry.Point(project_xy(last_stop_info.lon, last_stop_info.lat))
+
+        #print(f'first_stop_xy = {first_stop_xy}')
+        #print(f'last_stop_xy = {last_stop_xy}')
+
+        geometries = []
+
+        for shape_id in route_shape_ids:
+            geometry = shapes[shapes['shape_id'] == shape_id]['geometry'].values[0]
+            geometries.append(geometry)
+
+            shape_start_xy = shapely.geometry.Point(project_xy(*geometry.coords[0]))
+            shape_end_xy = shapely.geometry.Point(project_xy(*geometry.coords[-1]))
+
+            start_dist = distance(first_stop_xy.x, shape_start_xy.x, first_stop_xy.y, shape_start_xy.y)
+            #print(f'shape_start_xy = {shape_start_xy} ({start_dist} m)')
+
+            end_dist = distance(last_stop_xy.x, shape_end_xy.x, last_stop_xy.y, shape_end_xy.y)
+            #print(f'shape_end_xy = {shape_end_xy} ({end_dist} m)')
+
+            terminal_dist = start_dist + end_dist
+
+            terminal_dists.append(terminal_dist)
+
+            #print(f'{shape_id} {terminal_dist}')
+
+        terminal_dist_order = np.argsort(terminal_dists)
+
+        best_shape_index = terminal_dist_order[0]
+
+        shape_id = route_shape_ids[best_shape_index]
+        used_shape_ids[shape_id] = True
+
+        print(f'  {direction_id} = {shape_id} (n={route_shape_id_counts[best_shape_index]})')
+
+        geometry = geometries[best_shape_index]
+
+        xy_geometry = shapely.ops.transform(project_xy, geometry)
+
+        #dir_data['gtfs_direction_id'] = gtfs_direction_id
+        dir_data['gtfs_shape_id'] = shape_id
+        dir_data['coords'] = [{'lat': round(coord[1], 5), 'lon': round(coord[0], 5)} for coord in geometry.coords]
+        dir_data['distance'] = int(xy_geometry.length)
+
+        geom_length = len(xy_geometry.coords)
+        xy_array = np.array(xy_geometry)
+        x_array = xy_array.T[0]
+        y_array = xy_array.T[1]
+
+        prev_x_array = np.r_[x_array[0], x_array[:-1]]
+        prev_y_array = np.r_[y_array[0], y_array[:-1]]
+        geom_dist = np.cumsum(distance(x_array, prev_x_array, y_array, prev_y_array))
+
+        for stop_id in dir_stop_ids:
+            stop_info = route.get_stop_info(stop_id)
+            stop_xy = shapely.geometry.Point(project_xy(stop_info.lon, stop_info.lat))
+
+            stop_geom_dist = distance(x_array, stop_xy.x, y_array, stop_xy.y)
+
+            closest_index = int(np.argmin(stop_geom_dist))
+
+            if closest_index == 0:
+                stop_geom_index = 0
+            elif closest_index + 1 >= geom_length:
+                stop_geom_index = closest_index - 1
+            else:
+                next_line = shapely.geometry.LineString(xy_geometry.coords[closest_index:closest_index+2])
+                next_line_dist = next_line.distance(stop_xy)
+
+                prev_line = shapely.geometry.LineString(xy_geometry.coords[closest_index-1:closest_index+1])
+                prev_line_dist = prev_line.distance(stop_xy)
+
+                stop_geom_index = closest_index if next_line_dist < prev_line_dist else closest_index - 1
+
+            stop_dist = geom_dist[stop_geom_index] + stop_geom_dist[stop_geom_index]
+
+            dir_data['stop_geometry'][stop_id] = {'distance': int(stop_dist), 'after_index': stop_geom_index}
+
+    if route_shape_ids is not None:
+        for i, shape_id in enumerate(route_shape_ids):
+            if shape_id not in used_shape_ids:
+                print(f'  ? = {shape_id} (n={route_shape_id_counts[i]})')
+
+data_str = json.dumps({
+    'version': 'v1',
+    'routes': routes_data
+}, separators=(',', ':'))
+
+cache_path = f'{util.get_data_dir()}/routes_v1_{agency_id}.json'
+
+with open(cache_path, "w") as f:
+    f.write(data_str)
+
+save_to_s3 = True
+if save_to_s3:
+    s3 = boto3.resource('s3')
+    s3_path = f'routes_v1_{agency_id}.json.gz'
+    s3_bucket = 'opentransit-precomputed-stats'
+    print(f'saving to s3://{s3_bucket}/{s3_path}')
+    object = s3.Object(s3_bucket, s3_path)
+    object.put(
+        Body=gzip.compress(bytes(data_str, 'utf-8')),
+        CacheControl='max-age=86400',
+        ContentType='application/json',
+        ContentEncoding='gzip',
+        ACL='public-read'
+    )


### PR DESCRIPTION
This PR makes it possible for the frontend to draw the actual route traveled between two stops (instead of drawing straight lines between each stop), and to get the distance along a route between two stops, which can be used to for more accurate speed calculations.

The command line script save_routes.py downloads and parses the GTFS specification (hardcoded for Muni for now), matches up GTFS shapes with Nextbus directions and stops, and saves the configuration for all routes to S3 (https://opentransit-precomputed-stats.s3.amazonaws.com/routes_v1_sf-muni.json.gz). The S3 object contains data merged from Nextbus and GTFS, extending the JSON data structure previously returned by /api/routes. The frontend can then request this S3 URL instead of /api/routes .

For each direction, the JSON object contains a coords array defining the shape of the route, where the values are objects containing lat/lon properties:
```
"coords":[
  {"lat":37.80707,"lon":-122.41727}
  {"lat":37.80727,"lon":-122.41562},
  {"lat":37.80748,"lon":-122.41398},
  {"lat":37.80768,"lon":-122.41234},
  ...
]
```

For each direction, the JSON object also contains a stop_geometry object where the keys are stop IDs and the values are objects with a distance property (cumulative distance in meters to that stop along the GTFS shape), and an after_index property (index into the coords array of the last coordinate *before* that stop). 
```
"stop_geometry":{
    "5184":{"distance":8,"after_index":0},
    "3092":{"distance":279,"after_index":1},
    "3095":{"distance":573,"after_index":3},
    "4502":{"distance":1045,"after_index":8},
    ...
}
```

Isochrone.jsx shows how to draw the route between any two stops as a Polyline: draw first stop, draw coords from index firstStop.after_index + 1 to lastStop.after_index, then draw the last stop.

In order to match a Nextbus direction with a GTFS shape_id, save_routes.py finds the GTFS shape_id for that route where distance(first coordinate of shape, first stop location) + distance(last coordinate of shape, last stop location) is a minimum. 

In order to determine where a Nextbus stop appears along a GTFS shape, save_routes.py finds the closest coordinate of the GTFS shape to the Nextbus stop, then finds whether the stop is closer to the line between that GTFS shape coordinate and the previous GTFS coordinate, or the line between that GTFS shape coordinate and the next GTFS coordinate. (This may not always be correct for shapes that loop back on themselves.)

To calculate distances, save_routes.py projects the lat/lon coordinates of the GTFS shape and Nextbus stops (in degrees) to x/y coordinates (in meters). Since the number of meters per degree longitude doesn't vary much over a city like SF, this projection approximates the number of meters per degree longitude as a constant based on a chosen latitude in the city.

This script stores the route configuration in the S3 bucket opentransit-precomputed-stats . We could create a new bucket for this. However could also consider whether it would be better to only use one S3 bucket for all data since it would make it easier for other people to set up their own S3 backend with a different bucket.

Currently the script just overwrites the one S3 path, but this process could be extended in the future to store different paths for different dates, to allow fetching historical data for route configurations.