### PR TITLE
Fix links in the spider map by using routing.

### DIFF
--- a/frontend/src/components/MapSpider.jsx
+++ b/frontend/src/components/MapSpider.jsx
@@ -11,7 +11,7 @@ import MapShield from './MapShield'
 import Control from 'react-leaflet-control';
 import * as d3 from "d3";
 import { filterRoutes, milesBetween } from '../helpers/routeCalculations';
-import { handleSpiderMapClick, handleGraphParams } from '../actions';
+import { handleSpiderMapClick } from '../actions';
 
 import { push } from 'redux-first-router'
 
@@ -277,23 +277,7 @@ class MapSpider extends Component {
 
             e.originalEvent.view.L.DomEvent.stopPropagation(e);
 
-            // Fire events that select a route, direction, first stop, and second stop.
-
-            /* If this code was integrated with ControlPanel, we would do:
-             *
-             * this.setRouteId(startMarker.routeID);
-             * this.setDirectionId(startMarker.direction.id);
-             * this.onSelectFirstStop(startMarker.stopID, downstreamStops[i+1].stopID);
-             */
-
-            const {onGraphParams} = this.props;
-            onGraphParams({
-              route_id: startMarker.routeID,
-              direction_id: startMarker.direction.id,
-              start_stop_id: startMarker.stopID,
-              end_stop_id: downstreamStops[i+1].stopID,
-            });
-            push('/route');
+            push(`/route/${startMarker.routeID}/direction/${startMarker.direction.id}/start_stop/${startMarker.stopID}/end_stop/${downstreamStops[i+1].stopID}`);
           }}
         >
           <Tooltip> {/* should this hover text be a leaflet control in a fixed position? */}
@@ -348,22 +332,7 @@ class MapSpider extends Component {
 
         e.originalEvent.view.L.DomEvent.stopPropagation(e);
 
-        /* Fire events that select this route and direction.
-         *
-         * If this code was integrated with ControlPanel, we would do:
-         *
-         * this.setRouteId(startMarker.routeID);
-         * this.setDirectionId(startMarker.direction.id);
-         */
-
-        const {onGraphParams} = this.props;
-        onGraphParams({
-          route_id: startMarker.routeID,
-          direction_id: startMarker.direction.id,
-          start_stop_id: startMarker.stopID,
-          end_stop_id: lastStop.stopID,
-        });
-        push('/route');
+        push(`/route/${startMarker.routeID}/direction/${startMarker.direction.id}/start_stop/${startMarker.stopID}/end_stop/${lastStop.stopID}`);
       }}
 
       >
@@ -471,7 +440,6 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => {
   return ({
     onSpiderMapClick: (stops, latLng) => dispatch(handleSpiderMapClick(stops, latLng)),
-    onGraphParams: params => dispatch(handleGraphParams(params))
   })
 }
 


### PR DESCRIPTION
There were click handlers in `MapSpider` that were calling handleGraphParams followed by push('/route').  After Chris' merge, these were returning a 404 page.  Looks like the quickest fix for now is to push a fully parameterized URI.  There may be a better way (like getting the redux state change and the routing change done just by dispatching an action), but this works for now.
