### PR TITLE
fix loading URLs with slashes in production environment

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <base href='/' />
   <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" integrity="sha384-GJzZqFGwb1QTTN6wy59ffF1BuGJpLSa9DkKMp0DgiMDm4iYMj70gZWKYbI706tWS"
     crossorigin="anonymous" />


### PR DESCRIPTION
Currently URLs like http://muni.opentransit.city/route/10 with a slash in the path are broken because create-react-app replaces %PUBLIC_URL% with `frontend/build`, not `/frontend/build` . This PR adds a `base` tag to the HTML so that all relative URLs are loaded relative to the domain root instead of the current "directory" of the URL path.