### PR TITLE
Travel time chart x-axis is now distance instead of stop number

### DIFF
--- a/frontend/src/components/TravelTimeChart.jsx
+++ b/frontend/src/components/TravelTimeChart.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import { XYPlot, HorizontalGridLines, VerticalGridLines,
-  XAxis, YAxis, LineSeries, ChartLabel, Crosshair } from 'react-vis';
+  XAxis, YAxis, LineMarkSeries, ChartLabel, Crosshair } from 'react-vis';
 import DiscreteColorLegend from 'react-vis/dist/legends/discrete-color-legend';
 import '../../node_modules/react-vis/dist/style.css';
 import { getEndToEndTripTime, getTripDataSeries } from '../helpers/routeCalculations'
@@ -73,23 +73,29 @@ function TravelTimeChart(props) {
   
   return direction_id ? <Grid item xs={12}>
 
-            <Typography variant="h5">Travel time across stops</Typography>
+            <Typography variant="h5">Travel time along route</Typography>
 
-            Full travel time: { tripTimeForDirection } minutes<br/>
+            Full travel time: { tripTimeForDirection } minutes &nbsp;&nbsp; Stops: {tripData[tripData.length-1].stopIndex + 1 }<br/>
             
             {/* set the y domain to start at zero and end at highest value (which is not always
              the end to end travel time due to spikes in the data) */}
             
-            <XYPlot height={300} width={400} yDomain={[0, tripData.reduce((max, coord) => coord.y > max ? coord.y : max, 0)]}
+            <XYPlot height={300} width={400}
+              xDomain={[0, tripData.reduce((max, coord) => coord.x > max ? coord.x : max, 0)]}
+              yDomain={[0, tripData.reduce((max, coord) => coord.y > max ? coord.y : max, 0)]}
               onMouseLeave={_onMouseLeave}>
             <HorizontalGridLines />
             <VerticalGridLines />
             <XAxis tickPadding={4} />
             <YAxis hideLine={true} tickPadding={4} />
 
-            <LineSeries data={ tripData }
+            <LineMarkSeries data={ tripData }
                stroke="#aa82c5"
-               strokeWidth="4"
+               color="aa82c5"              
+               style={{
+                 strokeWidth: '3px'
+               }}              
+               size="1"
                onNearestX={_onNearestTripX} />
             {/*<LineSeries data={ scheduleData }
                stroke="#a4a6a9"
@@ -112,10 +118,10 @@ function TravelTimeChart(props) {
             />       
 
             <ChartLabel 
-            text="Stop Number"
+            text="Distance Along Route (miles)"
             className="alt-x-label"
             includeMargin={true}
-            xPercent={0.6}
+            xPercent={0.7}
             yPercent={0.86}
             style={{
               textAnchor: 'end'
@@ -130,6 +136,7 @@ function TravelTimeChart(props) {
                       <p>{ Math.round(crosshairValues[0].y)} min</p>
                       {/*<p>Scheduled: { Math.round(crosshairValues[1].y)} min</p>*/}
                       <p>{crosshairValues[0].title}</p>
+                      <p>(Stop #{crosshairValues[0].stopIndex + 1})</p>
                     </div>                 
             </Crosshair>)}
 

--- a/frontend/src/components/TravelTimeChart.jsx
+++ b/frontend/src/components/TravelTimeChart.jsx
@@ -75,7 +75,8 @@ function TravelTimeChart(props) {
 
             <Typography variant="h5">Travel time along route</Typography>
 
-            Full travel time: { tripTimeForDirection } minutes &nbsp;&nbsp; Stops: {tripData[tripData.length-1].stopIndex + 1 }<br/>
+            
+            Full travel time: { tripTimeForDirection } minutes &nbsp;&nbsp; Stops: {tripData[tripData.length-1] ? tripData[tripData.length-1].stopIndex + 1 : '?' }<br/>
             
             {/* set the y domain to start at zero and end at highest value (which is not always
              the end to end travel time due to spikes in the data) */}

--- a/frontend/src/helpers/routeCalculations.js
+++ b/frontend/src/helpers/routeCalculations.js
@@ -308,11 +308,12 @@ export function getTripDataSeries(props, routeID, directionID) {
   // Drop trip data points with no data.
 
   directionInfo.stops.slice(1).map((stop, index) => {
-    if (tripTimesForFirstStop[stop]) {
+    if (tripTimesForFirstStop[stop] && directionInfo.stop_geometry[stop]) {
       dataSeries.push({
-        x: index + 1,
+        x: metersToMiles(directionInfo.stop_geometry[stop].distance),
         y: tripTimesForFirstStop[stop],
         title: route.stops[stop].title,
+        stopIndex: index,
       });
     }
     return null;

--- a/frontend/src/helpers/routeCalculations.js
+++ b/frontend/src/helpers/routeCalculations.js
@@ -308,7 +308,9 @@ export function getTripDataSeries(props, routeID, directionID) {
   // Drop trip data points with no data.
 
   directionInfo.stops.slice(1).map((stop, index) => {
-    if (!directionInfo.stop_geometry[stop]) { console.log('no geometry for ' + routeID + ' ' + directionID + ' ' + stop);}
+    if (!directionInfo.stop_geometry[stop]) {
+      //console.log('no geometry for ' + routeID + ' ' + directionID + ' ' + stop);
+    }
     if (tripTimesForFirstStop[stop] && directionInfo.stop_geometry[stop]) {
       dataSeries.push({
         x: metersToMiles(directionInfo.stop_geometry[stop].distance),

--- a/frontend/src/helpers/routeCalculations.js
+++ b/frontend/src/helpers/routeCalculations.js
@@ -308,6 +308,7 @@ export function getTripDataSeries(props, routeID, directionID) {
   // Drop trip data points with no data.
 
   directionInfo.stops.slice(1).map((stop, index) => {
+    if (!directionInfo.stop_geometry[stop]) { console.log('no geometry for ' + routeID + ' ' + directionID + ' ' + stop);}
     if (tripTimesForFirstStop[stop] && directionInfo.stop_geometry[stop]) {
       dataSeries.push({
         x: metersToMiles(directionInfo.stop_geometry[stop].distance),


### PR DESCRIPTION
![Screen Shot 2019-08-03 at 7 15 48 PM](https://user-images.githubusercontent.com/44861283/62418645-4046c080-b623-11e9-826f-72fea693f5a8.png)

Shown is the 8AX inbound.  Stop number is now part of the `Crosshair` tooltip and total number of stops is shown with full route length.

The stop index business has always been a little funny since stop index 0 is the "first stop" after we slice off the starting terminal, which always has zero travel time.  Not sure if we should just plot times starting from the terminal, was copying nycbusstats by doing the slice.

Deployed to http://ot-terence.herokuapp.com 