### PR TITLE
add the app bar to the isochrone map and use its date/time selector; add instructions to isochrone map

### DIFF
--- a/frontend/public/isochrone-worker.js
+++ b/frontend/public/isochrone-worker.js
@@ -129,7 +129,7 @@ async function getTripTimesFromStop(routeId, directionId, startStopId, dateStr, 
 
         let s3Url = 'https://opentransit-precomputed-stats.s3.amazonaws.com/trip-times/v1/sf-muni/'+
             dateStr.replace(/\-/g, '/')+
-            '/trip-times_v1_sf-muni_'+dateStr+'_'+statPath+timePath+'.json.gz?v2';
+            '/trip-times_v1_sf-muni_'+dateStr+'_'+statPath+timePath+'.json.gz';
 
         tripTimes = tripTimesCache[dateStr + timeStr + stat] = await loadJson(s3Url).catch(function(e) {
             sendError("error loading trip times: " + e);
@@ -203,7 +203,7 @@ async function getWaitTimeAtStop(routeId, directionId, stopId, dateStr, timeStr,
 
         let s3Url = 'https://opentransit-precomputed-stats.s3.amazonaws.com/wait-times/v1/sf-muni/'+
             dateStr.replace(/\-/g, '/')+
-            '/wait-times_v1_sf-muni_'+dateStr+'_'+statPath+timePath+'.json.gz?v2';
+            '/wait-times_v1_sf-muni_'+dateStr+'_'+statPath+timePath+'.json.gz';
 
         //console.log(s3Url);
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -36,3 +36,15 @@
 .largeMarginTop {
   margin-top:4rem;
 }
+
+.page-title
+{
+    flex-grow:1;
+}
+
+.flex-screen
+{
+    height:100%;
+    display:flex;
+    flex-direction:column;
+}

--- a/frontend/src/screens/Dashboard.jsx
+++ b/frontend/src/screens/Dashboard.jsx
@@ -19,33 +19,24 @@ import {
   resetIntervalData,
 } from '../actions';
 
-const useStyles = makeStyles({
-  title: {
-    flexGrow: 1,
-  },
-});
-
 function Dashboard(props) {
-  
+
   useEffect(() => {
     if (!props.routes) {
       props.fetchRoutes();
     }
-  }, []);  // like componentDidMount, this runs only on first render     
-  
-  const classes = useStyles();
-  
+  }, []);  // like componentDidMount, this runs only on first render
+
   const { routes } = props;
   return (
-    <Fragment>
+    <div className='flex-screen'>
       <AppBar position="relative">
         <Toolbar>
           <SidebarButton />
-          <div className={classes.title}>Muni</div>
+          <div className='page-title'>Muni</div>
           <DateTimePanel/>
         </Toolbar>
       </AppBar>
-
       <Grid container spacing={0}>
         {' '}
         {/* Using spacing causes horizontal scrolling, see https://material-ui.com/components/grid/#negative-margin */}
@@ -58,7 +49,7 @@ function Dashboard(props) {
           <RouteTable routes={routes} />
         </Grid>
       </Grid>
-    </Fragment>
+    </div>
   );
 }
 

--- a/frontend/src/screens/Isochrone.css
+++ b/frontend/src/screens/Isochrone.css
@@ -5,12 +5,20 @@
 
 .isochrone-controls,
 .isochrone-legend,
+.isochrone-instructions,
 .isochrone-trip-info
 {
     border:1px solid #ccc;
     background-color:#fff;
     border-radius:5px;
     opacity:0.9;
+}
+
+.isochrone-instructions
+{
+    max-width:180px;
+    padding:8px;
+    opacity:1.0;
 }
 
 .isochrone-controls
@@ -22,14 +30,6 @@
 {
     padding:2px 4px;
     white-space:nowrap;
-}
-
-.isochrone-instructions
-{
-    opacity:0.8;
-    padding:5px;
-    border-radius:5px;
-    background-color:#fff;
 }
 
 .isochrone-trip

--- a/frontend/src/screens/Isochrone.css
+++ b/frontend/src/screens/Isochrone.css
@@ -1,3 +1,8 @@
+.isochrone-map
+{
+    flex-grow:1;
+}
+
 .isochrone-controls,
 .isochrone-legend,
 .isochrone-trip-info
@@ -16,6 +21,15 @@
 .isochrone-legend
 {
     padding:2px 4px;
+    white-space:nowrap;
+}
+
+.isochrone-instructions
+{
+    opacity:0.8;
+    padding:5px;
+    border-radius:5px;
+    background-color:#fff;
 }
 
 .isochrone-trip

--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -1,9 +1,13 @@
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
-import { Map, TileLayer, Polyline } from 'react-leaflet';
+import { Map, TileLayer, Polyline, Marker } from 'react-leaflet';
 import L from 'leaflet';
 import Control from 'react-leaflet-control';
 import * as turf from '@turf/turf';
+import SidebarButton from '../components/SidebarButton';
+import DateTimePanel from '../components/DateTimePanel';
+import Toolbar from '@material-ui/core/Toolbar';
+import AppBar from '@material-ui/core/AppBar';
 
 import { fetchRoutes, routesUrl } from '../actions';
 import { ServiceArea, DefaultDisabledRoutes } from '../agencies/sf-muni';
@@ -32,6 +36,24 @@ const tripMinOptions = {
 };
 
 const defaultLayerOptions = {color:'#666'};
+
+const initialInstructions = L.divIcon({
+    className: 'isochrone-instructions',
+    html:'Click anywhere in the city to see the trip times from that point to the rest of the city via Muni and walking.',
+    iconSize: [160, 80]
+});
+
+const computingInstructions = L.divIcon({
+    className: 'isochrone-instructions',
+    html:'Computing...',
+    iconSize: [80, 30]
+});
+
+const tripInstructions = L.divIcon({
+    className: 'isochrone-instructions',
+    html:'Click anywhere in the shaded area to see routes and trip times between the two points, or drag the blue pin to see trip times from a new point.',
+    iconSize: [175, 100]
+});
 
 let redIcon = new L.Icon({
   iconUrl: process.env.PUBLIC_URL + '/marker-icon-2x-red.png',
@@ -64,16 +86,23 @@ class Isochrone extends React.Component {
         }
     }
 
+    componentDidUpdate(prevProps) {
+        if (this.props.date !== prevProps.date ||
+            this.props.start_time !== prevProps.start_time ||
+            this.props.end_time !== prevProps.end_time) {
+            this.recomputeIsochrones();
+        }
+    }
+
     constructor(props) {
-        super(props)
+        super(props);
 
         this.state = {
-            dateStr: '2019-06-06',
-            timeStr: '',
             stat: 'median',
             maxTripMin: 90,
             computedMaxTripMin: null,
             computeId: null,
+            computing: false,
             latLng: null,
             endLatLng: null,
             tripInfo: null,
@@ -103,8 +132,6 @@ class Isochrone extends React.Component {
         }
 
         this.handleMapClick = this.handleMapClick.bind(this);
-        this.handleDateChange = this.handleDateChange.bind(this);
-        this.handleTimeChange = this.handleTimeChange.bind(this);
         this.handleStatChange = this.handleStatChange.bind(this);
         this.handleToggleRoute = this.handleToggleRoute.bind(this);
         this.handleMaxTripMinChange = this.handleMaxTripMinChange.bind(this);
@@ -163,6 +190,16 @@ class Isochrone extends React.Component {
         let tripMin = data.tripMin;
         let reachableCircles = data.circles;
         let geoJson = data.geoJson;
+
+        if (this.state.computeId != data.computeId)
+        {
+            return;
+        }
+
+        if (this.state.computing && tripMin == this.state.maxTripMin)
+        {
+            this.setState({computing: false});
+        }
 
         let layerOptions = tripMinOptions['' + tripMin] || defaultLayerOptions;
 
@@ -352,13 +389,12 @@ class Isochrone extends React.Component {
             return;
         }
 
-        const {maxTripMin, dateStr, timeStr, stat, enabledRoutes} = this.state;
+        const dateStr = this.props.date;
+        const startTimeStr = this.props.start_time;
+        const endTimeStr = this.props.end_time;
+        const timeStr = (startTimeStr && endTimeStr) ? `${startTimeStr}-${endTimeStr}` : "";
 
-        this.setState({
-            latLng: latLng,
-            endLatLng: endLatLng,
-            computedMaxTripMin: maxTripMin
-        });
+        const {maxTripMin, stat, enabledRoutes} = this.state;
 
         let enabledRoutesArr = [];
 
@@ -380,7 +416,12 @@ class Isochrone extends React.Component {
             enabledRoutesArr.join(',')
         ].join(',');
 
-        this.setState({computeId: computeId});
+        this.setState({
+            latLng: latLng,
+            endLatLng: endLatLng,
+            computedMaxTripMin: maxTripMin,
+            computeId: computeId
+        });
 
         let map = this.mapRef.current.leafletElement;
 
@@ -423,6 +464,10 @@ class Isochrone extends React.Component {
             tripMins.push(maxTripMin);
         }
 
+        this.setState({
+            computing: true
+        });
+
         this.isochroneWorker.postMessage({
             action:'computeIsochrones',
             latlng: latLng,
@@ -433,16 +478,6 @@ class Isochrone extends React.Component {
             stat: stat,
             computeId: computeId
         });
-    }
-
-    handleDateChange(event)
-    {
-        this.setState({dateStr: event.target.value}, this.recomputeIsochrones);
-    }
-
-    handleTimeChange(event)
-    {
-        this.setState({timeStr: event.target.value}, this.recomputeIsochrones);
     }
 
     handleStatChange(event)
@@ -605,8 +640,33 @@ class Isochrone extends React.Component {
         }
         tripMins.push(90);
 
-        return <Fragment>
-            <Map center={{lat: 37.772, lng: -122.442}} zoom={13} style={{ height: '100%' }}
+        const center = {lat: 37.772, lng: -122.442};
+        const instructionsPosition = {lat: 37.800, lng: -122.500};
+
+        let instructionsMarker = null;
+        if (!this.state.latLng) {
+            instructionsMarker = <Marker icon={initialInstructions} position={instructionsPosition} />;
+        }
+        else if (this.state.computing)
+        {
+            instructionsMarker = <Marker icon={computingInstructions} position={instructionsPosition} />;
+        }
+        else
+        {
+            instructionsMarker = <Marker icon={tripInstructions} position={instructionsPosition} />;
+        }
+
+        return <div className='flex-screen'>
+            <AppBar position="relative">
+              <Toolbar>
+                <SidebarButton />
+                <div className='page-title'>
+                  Isochrone
+                </div>
+                <DateTimePanel/>
+              </Toolbar>
+            </AppBar>
+            <Map center={center} zoom={13} className='isochrone-map'
                 minZoom={11}
                 maxZoom={18}
                 onClick={this.handleMapClick}
@@ -616,26 +676,9 @@ class Isochrone extends React.Component {
                   attribution='Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
                   url="https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png"
                 /> {/* see http://maps.stamen.com for details */}
+                {instructionsMarker}
                 <Control position="topleft">
                     <div className="isochrone-controls">
-                        <div>
-                            date:
-                            <select value={this.state.dateStr} onChange={this.handleDateChange} className='isochrone-control-select'>
-                                {dateStrs.map(dateStr => (<option key={dateStr} value={dateStr}>{dateStr}</option>))}
-                            </select>
-                        </div>
-                        <div>
-                            time range:
-                            <select value={this.state.timeStr} onChange={this.handleTimeChange} className='isochrone-control-select'>
-                                <option value=''>All day</option>
-                                <option value='07:00-19:00'>Daytime</option>
-                                <option value='03:00-07:00'>Early Morning</option>
-                                <option value='07:00-10:00'>AM Peak</option>
-                                <option value='10:00-16:00'>Midday</option>
-                                <option value='16:00-19:00'>PM Peak</option>
-                                <option value='19:00-03:00+1'>Late Evening</option>
-                            </select>
-                        </div>
                         <div>
                             stat:
                             <select value={this.state.stat} onChange={this.handleStatChange} className='isochrone-control-select'>
@@ -681,12 +724,15 @@ class Isochrone extends React.Component {
                     </div>
                 </Control>
             </Map>
-        </Fragment>;
+        </div>;
     }
 }
 
 const mapStateToProps = state => ({
     routes: state.routes.routes,
+    date: state.routes.graphParams.date,
+    start_time: state.routes.graphParams.start_time,
+    end_time: state.routes.graphParams.end_time
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -37,24 +37,6 @@ const tripMinOptions = {
 
 const defaultLayerOptions = {color:'#666'};
 
-const initialInstructions = L.divIcon({
-    className: 'isochrone-instructions',
-    html:'Click anywhere in the city to see the trip times from that point to the rest of the city via Muni and walking.',
-    iconSize: [160, 80]
-});
-
-const computingInstructions = L.divIcon({
-    className: 'isochrone-instructions',
-    html:'Computing...',
-    iconSize: [80, 30]
-});
-
-const tripInstructions = L.divIcon({
-    className: 'isochrone-instructions',
-    html:'Click anywhere in the shaded area to see routes and trip times between the two points, or drag the blue pin to see trip times from a new point.',
-    iconSize: [175, 100]
-});
-
 let redIcon = new L.Icon({
   iconUrl: process.env.PUBLIC_URL + '/marker-icon-2x-red.png',
   shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/images/marker-shadow.png',
@@ -641,20 +623,6 @@ class Isochrone extends React.Component {
         tripMins.push(90);
 
         const center = {lat: 37.772, lng: -122.442};
-        const instructionsPosition = {lat: 37.800, lng: -122.500};
-
-        let instructionsMarker = null;
-        if (!this.state.latLng) {
-            instructionsMarker = <Marker icon={initialInstructions} position={instructionsPosition} />;
-        }
-        else if (this.state.computing)
-        {
-            instructionsMarker = <Marker icon={computingInstructions} position={instructionsPosition} />;
-        }
-        else
-        {
-            instructionsMarker = <Marker icon={tripInstructions} position={instructionsPosition} />;
-        }
 
         return <div className='flex-screen'>
             <AppBar position="relative">
@@ -676,7 +644,6 @@ class Isochrone extends React.Component {
                   attribution='Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.'
                   url="https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png"
                 /> {/* see http://maps.stamen.com for details */}
-                {instructionsMarker}
                 <Control position="topleft">
                     <div className="isochrone-controls">
                         <div>
@@ -708,9 +675,14 @@ class Isochrone extends React.Component {
                     </div>
                 </Control>
                 <Control position="topright">
-                    <div className="isochrone-trip-info">
-                        {this.state.tripInfo}
-                    </div>
+                    {this.state.tripInfo ?
+                        <div className="isochrone-trip-info">{this.state.tripInfo}</div>
+                        : <div className='isochrone-instructions'>{
+                            !this.state.latLng ? 'Click anywhere in the city to see the trip times from that point to the rest of the city via Muni and walking.' :
+                            this.state.computing ? 'Computing...' :
+                            'Click anywhere in the shaded area to see routes and trip times between the two points, or drag the blue pin to see trip times from a new point.'
+                        }</div>
+                    }
                 </Control>
                 <Control position="bottomright">
                     <div className="isochrone-legend">

--- a/frontend/src/screens/RouteScreen.jsx
+++ b/frontend/src/screens/RouteScreen.jsx
@@ -23,16 +23,8 @@ import {
   resetIntervalData,
 } from '../actions';
 
-const useStyles = makeStyles({
-  title: {
-    flexGrow: 1,
-  },
-});
-
 function RouteScreen(props) {
 
-  const classes = useStyles();
-  
   useEffect(() => {
     if (!props.routes) {
       props.fetchRoutes();
@@ -72,7 +64,7 @@ function RouteScreen(props) {
         <AppBar position="relative">
           <Toolbar>
             <SidebarButton />
-            <div className={classes.title}>
+            <div className='page-title'>
               Muni
               {selectedRoute ? ` > ${selectedRoute.title}` : null}
               {direction ? ` > ${direction.title}` : null}
@@ -80,7 +72,7 @@ function RouteScreen(props) {
               {startStopInfo ? `(from ${startStopInfo.title}` : null}
               {endStopInfo ? ` to ${endStopInfo.title})` : null}
             </div>
-            <DateTimePanel/>              
+            <DateTimePanel/>
           </Toolbar>
         </AppBar>
 


### PR DESCRIPTION
Instructions for the isochrone map are shown in the top right when not showing trip information.

![image](https://user-images.githubusercontent.com/343100/62429297-e3e6ae00-b6c1-11e9-94a7-0077cf02d949.png)

![image](https://user-images.githubusercontent.com/343100/62429312-f9f46e80-b6c1-11e9-933f-e8fe9e200595.png)

![image](https://user-images.githubusercontent.com/343100/62429306-ed701600-b6c1-11e9-99f1-45d9901462e2.png)

![image](https://user-images.githubusercontent.com/343100/62429315-07115d80-b6c2-11e9-81a7-6312f7a41adb.png)
