### PR TITLE
Fix some React console warnings (no visible changes).

### DIFF
--- a/frontend/src/screens/Dashboard.jsx
+++ b/frontend/src/screens/Dashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, Fragment } from 'react';
+import React, { useEffect } from 'react';
 import Grid from '@material-ui/core/Grid';
 import Toolbar from '@material-ui/core/Toolbar';
 import AppBar from '@material-ui/core/AppBar';
@@ -8,7 +8,6 @@ import MapSpider from '../components/MapSpider';
 import RouteTable from '../components/RouteTable';
 import SidebarButton from '../components/SidebarButton';
 import DateTimePanel from '../components/DateTimePanel';
-import { makeStyles } from '@material-ui/core/styles';
 
 import {
   fetchData,

--- a/frontend/src/screens/Isochrone.css
+++ b/frontend/src/screens/Isochrone.css
@@ -37,10 +37,12 @@
     padding:4px 4px;
 }
 
-.isochrone-select-all a
+.isochrone-select-all span
 {
+    color:#0078A8;
     padding-right:2px;
     text-decoration:none;
+    cursor:pointer;
 }
 
 .isochrone-legend-colors

--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -1,6 +1,6 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
-import { Map, TileLayer, Polyline, Marker } from 'react-leaflet';
+import { Map, TileLayer } from 'react-leaflet';
 import L from 'leaflet';
 import Control from 'react-leaflet-control';
 import * as turf from '@turf/turf';
@@ -173,12 +173,12 @@ class Isochrone extends React.Component {
         let reachableCircles = data.circles;
         let geoJson = data.geoJson;
 
-        if (this.state.computeId != data.computeId)
+        if (this.state.computeId !== data.computeId)
         {
             return;
         }
 
-        if (this.state.computing && tripMin == this.state.maxTripMin)
+        if (this.state.computing && tripMin === this.state.maxTripMin)
         {
             this.setState({computing: false});
         }
@@ -613,8 +613,6 @@ class Isochrone extends React.Component {
 
         colors.push(<div key='default' style={{backgroundColor: defaultLayerOptions.color}}></div>);
 
-        const dateStrs = ['2019-06-06', '2019-06-07', '2019-06-08', '2019-06-09'];
-
         let tripMins = [];
         for (let tripMin = 15; tripMin <= maxColoredTripMin; tripMin += 15)
         {
@@ -663,9 +661,9 @@ class Isochrone extends React.Component {
                         <div>
                             routes:
                             <div className='isochrone-select-all'>
-                                <a href='javascript:void(0)' onClick={this.selectAllRoutesClicked}>all</a>
+                                <span onClick={this.selectAllRoutesClicked}>all</span>
                                 {" / "}
-                                <a href='javascript:void(0)' onClick={this.selectNoRoutesClicked}>none</a>
+                                <span onClick={this.selectNoRoutesClicked}>none</span>
                             </div>
                             <div className='isochrone-routes'>
                                 {(routes || []).map(route => this.makeRouteToggle(route))}

--- a/frontend/src/screens/RouteScreen.jsx
+++ b/frontend/src/screens/RouteScreen.jsx
@@ -2,7 +2,6 @@ import React, { useEffect, Fragment } from 'react';
 import Grid from '@material-ui/core/Grid';
 import Toolbar from '@material-ui/core/Toolbar';
 import AppBar from '@material-ui/core/AppBar';
-import { makeStyles } from '@material-ui/core/styles';
 
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';


### PR DESCRIPTION
(Note: when there are too many files with warnings, React stops logging additional warnings to console.  This makes it harder to catch additional issues.)

- Fix warnings around unused imports and constant 
- Fix warnings around use of != and ==.
- Change \<a href="javascript:void(0)"> to \<span> per accessibility warning advice at https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md, update css to make span resemble link.  In the future, we could use Material UI components, such as small buttons, although they won't be as compact as the text link.