### PR TITLE
script to compute new arrival times, wait time stats, and trip time stats

### DIFF
--- a/compute_arrivals.py
+++ b/compute_arrivals.py
@@ -10,9 +10,9 @@ import gzip
 
 OWL_LINES = ['90', '91', 'K_OWL', 'L_OWL', 'M_OWL', 'N_OWL', 'T_OWL']
 
-def compute_arrivals_for_date(d: date, start_hour: int, tz: pytz.timezone,
+def compute_arrivals_for_date_and_start_hour(d: date, start_hour: int, tz: pytz.timezone,
                 agency: str, route_ids: list,
-                s3=False):
+                save_to_s3=True):
 
     start_dt = tz.localize(datetime(d.year, d.month, d.day, hour=start_hour))
     end_dt = start_dt + timedelta(days=1)
@@ -45,10 +45,28 @@ def compute_arrivals_for_date(d: date, start_hour: int, tz: pytz.timezone,
 
         print(f'{route_id}: {round(time.time()-t1,1)} saving arrival history')
 
-        arrival_history.save_for_date(history, d, s3)
+        arrival_history.save_for_date(history, d, save_to_s3)
 
         print(f'{route_id}: {round(time.time()-t1,2)} done')
 
+def compute_arrivals(d: date, tz: pytz.timezone, agency: str, route_ids: list, save_to_s3=True):
+    # for standard routes start each "day" at 3 AM local time so midnight-3am buses are associated with previous day
+    owl_routes = [x for x in route_ids if x in set(OWL_LINES)]
+
+    compute_arrivals_for_date_and_start_hour(
+        d, start_hour=3, tz=tz,
+        agency=agency,
+        route_ids=[r for r in route_ids if r not in owl_routes],
+        save_to_s3=save_to_s3
+    )
+
+    # owl routes run from 1AM to 5AM so they are associated with the same day
+    compute_arrivals_for_date_and_start_hour(
+        d, start_hour=0, tz=tz,
+        agency=agency,
+        route_ids=owl_routes,
+        save_to_s3=save_to_s3
+    )
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Compute and cache arrival history')
@@ -66,8 +84,6 @@ if __name__ == '__main__':
     if route_ids is None:
         route_ids = [route.id for route in nextbus.get_route_list(agency)]
 
-    owl_routes = [x for x in route_ids if x in set(OWL_LINES)]
-
     date_str = args.date
 
     if args.date:
@@ -80,17 +96,4 @@ if __name__ == '__main__':
     tz = pytz.timezone('America/Los_Angeles')
 
     for d in dates:
-        # for standard routes start each "day" at 3 AM local time so midnight-3am buses are associated with previous day
-        compute_arrivals_for_date(
-            d, start_hour=3, tz=tz,
-            agency=agency,
-            route_ids=[r for r in route_ids if r not in owl_routes],
-            s3=args.s3
-        )
-        # owl routes run from 1AM to 5AM so they are associated with the same day
-        compute_arrivals_for_date(
-            d, start_hour=0, tz=tz,
-            agency=agency,
-            route_ids=owl_routes,
-            s3=args.s3
-        )
+        compute_arrivals(d, tz, agency, route_ids, args.s3)

--- a/compute_new.py
+++ b/compute_new.py
@@ -1,0 +1,88 @@
+import argparse
+import json
+import requests
+from datetime import datetime, timedelta, time
+import pytz
+import boto3
+
+from models import nextbus, util, wait_times
+
+from compute_arrivals import compute_arrivals
+from compute_trip_times import compute_trip_times
+from compute_wait_times import compute_wait_times
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description = '')
+    parser.add_argument('--start-date', help='Start date (yyyy-mm-dd)')
+
+    args = parser.parse_args()
+
+    agency_id = 'sf-muni'
+
+    s3_bucket = wait_times.get_s3_bucket()
+    s3_path = f"state_{agency_id}_v1.json"
+
+    def save_state(state):
+        state_str = json.dumps(state)
+        s3 = boto3.resource('s3')
+        print(f'saving state to s3://{s3_bucket}/{s3_path}')
+        object = s3.Object(s3_bucket, s3_path)
+        object.put(
+            Body=bytes(state_str, 'utf-8'),
+            ContentType='application/json',
+            ACL='public-read'
+        )
+
+    s3_url = f"http://{s3_bucket}.s3.amazonaws.com/{s3_path}"
+    r = requests.get(s3_url)
+
+    if r.status_code == 404 or r.status_code == 403:
+        state = {}
+    elif r.status_code != 200:
+        raise Exception(f"Error fetching {s3_url}: HTTP {r.status_code}: {r.text}")
+    else:
+        state = json.loads(r.text)
+
+    print(state)
+
+    if args.start_date is not None:
+        d = util.parse_date(args.start_date)
+    elif 'last_complete_date' in state:
+        d = util.parse_date(state['last_complete_date']) + timedelta(days=1)
+    else:
+        raise Exception("No compute state, use --start-date parameter the first time")
+
+    routes = nextbus.get_route_list(agency_id)
+    route_ids = [route.id for route in routes]
+
+    tz = pytz.timezone('America/Los_Angeles')
+
+    now = datetime.now(tz)
+    today = now.date()
+
+    if now.time().hour < 3:
+        today -= timedelta(days=1)
+
+    while d <= today:
+
+        compute_start_time = datetime.now(tz)
+
+        print(f'computing arrivals for {d}')
+        compute_arrivals(d, tz, agency_id, route_ids)
+
+        print(f'computing trip times for {d}')
+        compute_trip_times(d, tz, agency_id, routes)
+
+        print(f'computing wait times for {d}')
+        compute_wait_times(d, tz, agency_id, routes)
+
+        date_str = str(d)
+
+        if d < today and ('last_complete_date' not in state or date_str > state['last_complete_date']):
+            state['last_complete_date'] = date_str
+            save_state(state)
+        elif d == today:
+            state['last_partial_date_time'] = str(compute_start_time)
+            save_state(state)
+
+        d += timedelta(days=1)

--- a/compute_new.py
+++ b/compute_new.py
@@ -43,8 +43,6 @@ if __name__ == '__main__':
     else:
         state = json.loads(r.text)
 
-    print(state)
-
     if args.start_date is not None:
         d = util.parse_date(args.start_date)
     elif 'last_complete_date' in state:
@@ -64,7 +62,6 @@ if __name__ == '__main__':
         today -= timedelta(days=1)
 
     while d <= today:
-
         compute_start_time = datetime.now(tz)
 
         print(f'computing arrivals for {d}')

--- a/compute_trip_times.py
+++ b/compute_trip_times.py
@@ -158,7 +158,10 @@ def add_trip_time_stats_for_stop_pair(
             stat_value = get_stat_value(stat_id, all_stat_values)
             interval_trip_time_stats[stat_id][route_id][dir_id][s1][s2] = stat_value
 
-def compute_trip_times(agency_id, d: date, routes, tz, stat_ids, save_to_s3 = False):
+def compute_trip_times(d: date, tz, agency_id, routes, save_to_s3=True, stat_ids=None):
+    if stat_ids is None:
+        stat_ids = stat_groups.keys()
+
     print(d)
     time_str_intervals = constants.DEFAULT_TIME_STR_INTERVALS.copy()
     time_str_intervals.append(('07:00','19:00'))
@@ -263,8 +266,6 @@ if __name__ == '__main__':
         raise Exception('missing date, start-date, or end-date')
 
     stat_ids = args.stat
-    if stat_ids is None:
-        stat_ids = stat_groups.keys()
 
     for d in dates:
-        compute_trip_times(agency_id, d, routes, tz, stat_ids, save_to_s3=args.s3)
+        compute_trip_times(d, tz, agency_id, routes, save_to_s3=args.s3, stat_ids=stat_ids)

--- a/compute_wait_times.py
+++ b/compute_wait_times.py
@@ -79,7 +79,10 @@ def add_median_wait_time_stats_for_direction(
 
         dir_wait_time_stats["median"] = median
 
-def compute_wait_times(agency_id, d: date, routes, tz, stat_ids, save_to_s3 = False):
+def compute_wait_times(d: date, tz, agency_id, routes, save_to_s3=True, stat_ids=None):
+    if stat_ids is None:
+        stat_ids = stat_groups.keys()
+
     print(d)
     all_wait_time_stats = {}
 
@@ -216,8 +219,6 @@ if __name__ == '__main__':
         raise Exception('missing date, start-date, or end-date')
 
     stat_ids = args.stat
-    if stat_ids is None:
-        stat_ids = stat_groups.keys()
 
     for d in dates:
-        compute_wait_times(agency_id, d, routes, tz, stat_ids, save_to_s3=args.s3)
+        compute_wait_times(d, tz, agency_id, routes, save_to_s3=args.s3, stat_ids=stat_ids)


### PR DESCRIPTION
compute_new.py checks S3 to see the last date that has been fully computed, and starts computing arrival times, wait time stats, and trip time stats on the next day and advances until it reaches the current day. It could be run in Kubernetes as a cron job (not in this PR) to automatically compute the necessary stats. It could also be run more than once a day in order to provide near-real-time stats for the current day.