### PR TITLE
fix bug when a route has 0 arrivals

### DIFF
--- a/models/eclipses.py
+++ b/models/eclipses.py
@@ -328,7 +328,7 @@ def find_arrivals(route_state: dict, route_config: nextbus.RouteConfig, d: date,
     possible_arrivals = concat_possible_arrivals()
 
     if possible_arrivals.empty:
-        arrivals = possible_arrivals
+        arrivals, num_trips = possible_arrivals, 0
     else:
         print(f'{route_id}: {round(time.time() - t0, 1)} cleaning arrivals')
 


### PR DESCRIPTION
The print statement raised an error because num_trips was undefined when there were no possible arrivals.