### PR TITLE
add instructions for spider map and route map

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -48,3 +48,13 @@
     display:flex;
     flex-direction:column;
 }
+
+.map-instructions
+{
+    border:1px solid #ccc;
+    background-color:#fff;
+    border-radius:5px;
+    max-width:180px;
+    padding:8px;
+    opacity:1.0;
+}

--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -65,27 +65,9 @@ function ControlPanel(props) {
       stopId.target.value,
     );
 
-    let newSecondStopId = secondStopId;
-
-    // If the "to stop" is not set or is not valid for
-    // the current "from stop", set a default "to stop" that
-    // is some number of stops down.  If there aren't
-    // enough stops, use the end of the line.
-
-    const nStops = 5;
-
-    if (secondStopId == null || !secondStopList.includes(secondStopId)) {
-      newSecondStopId =
-        secondStopList.length >= nStops
-          ? secondStopList[nStops - 1]
-          : secondStopList[secondStopList.length - 1];
-    }
-
-    //console.log(stopId, stopId.target.value, newSecondStopId);
-
     props.onGraphParams({
       start_stop_id: stopId.target.value,
-      end_stop_id: newSecondStopId,
+      end_stop_id: secondStopId,
     });
   };
 

--- a/frontend/src/components/MapSpider.jsx
+++ b/frontend/src/components/MapSpider.jsx
@@ -172,7 +172,7 @@ class MapSpider extends Component {
   /**
    * Rendering of stops nearest to click or current location
    */
-  StartMarkers = () => {
+  getStartMarkers = () => {
 
     let items = null;
 
@@ -195,9 +195,9 @@ class MapSpider extends Component {
             {Math.round(startMarker.miles * 5280)} feet
           </Tooltip>
         </CircleMarker>
-    });
+      });
     }
-    return <Fragment>{items}</Fragment>
+    return items;
   }
 
   /**
@@ -364,6 +364,8 @@ class MapSpider extends Component {
 
     const mapClass = { width: '100%', height: this.state.height };
 
+    let startMarkers = this.getStartMarkers();
+
     return (
       <Map center={position || SF_COORDINATES} zoom={zoom || ZOOM} style={mapClass}
         minZoom={11}
@@ -378,9 +380,16 @@ class MapSpider extends Component {
           opacity={0.3}
         /> {/* see http://maps.stamen.com for details */}
         <this.DownstreamLines/>
-        <this.StartMarkers/>
+        {startMarkers}
         <this.SpiderOriginMarker spiderLatLng={this.props.spiderLatLng}/>
 
+        <Control position="topright">
+          <div className='map-instructions'>{
+            this.props.spiderLatLng && startMarkers && startMarkers.length ?
+              'Click anywhere along a route to see statistics for trips between the two stops.'
+              : 'Click anywhere in the city to see the routes near that point.'
+          }</div>
+        </Control>
         <Control position="bottomleft" >
           <Button variant="contained" color="primary" onClick={ this.handleGeoLocate }>
             <GpsIcon/>&nbsp;

--- a/frontend/src/components/MapStops.jsx
+++ b/frontend/src/components/MapStops.jsx
@@ -62,9 +62,9 @@ class MapStops extends Component {
     for (let i = 0; i < downstreamStops.length - 1; i++) {
 
       const speed = this.getSpeed(routeInfo, direction, downstreamStops, i, direction_id);
-      
-      // draw a wide white polyline as a background for the speed polyline 
-      
+
+      // draw a wide white polyline as a background for the speed polyline
+
       polylines.push(
           <Polyline
             key={'poly-speed-white-' + direction_id + '-' + downstreamStops[i].sid}
@@ -72,12 +72,12 @@ class MapStops extends Component {
             color="white"
             opacity={1}
             weight={10}
-          >      
+          >
           </Polyline>
       );
-      
+
       // then the speed polyline on top of the white polyline
-      
+
       polylines.push(
         <Polyline
           key={'poly-speed-' + direction_id + '-' + downstreamStops[i].sid}
@@ -142,7 +142,7 @@ class MapStops extends Component {
     } else {
       return -1; // speed not available;
     }
-    
+
     const distance = getDistanceInMiles(routeInfo, direction, firstStopID, nextStopID);
 
     return (distance / time) * 60; // miles per minute -> mph
@@ -175,7 +175,7 @@ class MapStops extends Component {
     }
 
     return (
-      <Control position="topright">
+      <Control position="bottomright">
         <div
           style={{
             backgroundColor: 'white',
@@ -313,6 +313,14 @@ class MapStops extends Component {
         />
         {populatedRoutes}
         <this.SpeedLegend />
+        <Control position="topright">
+        {!graphParams.start_stop_id || !graphParams.end_stop_id ?
+          <div className='map-instructions'>
+            {!graphParams.direction_id ? "Select a direction to see stops in that direction." :
+            !graphParams.start_stop_id ? "Click an origin stop." :
+            !graphParams.end_stop_id ? "Click a destination stop." : ""}
+          </div> : null}
+        </Control>
       </Map>
     );
   }

--- a/frontend/src/components/RouteSummary.jsx
+++ b/frontend/src/components/RouteSummary.jsx
@@ -19,15 +19,15 @@ import Box from '@material-ui/core/Box';
 
 /**
  * Renders an "nyc bus stats" style summary of a route and direction.
- * 
+ *
  * @param {any} props
  */
 function RouteSummary(props) {
-  
+
   useEffect(() => {
     props.fetchPrecomputedWaitAndTripData(props.graphParams);
-  }, []);  // like componentDidMount, this runs only on first render    
-  
+  }, []);  // like componentDidMount, this runs only on first render
+
   const { graphParams } = props;
 
   let wait = null;
@@ -47,15 +47,15 @@ function RouteSummary(props) {
   let routes = null;
 
   if (graphParams.route_id) {
-    
+
     routes = props.routes ? filterRoutes(props.routes) : [];
 
     allWaits = getAllWaits(props);
-    
+
     const allDistances = getAllDistances(props);
     allSpeeds = getAllSpeeds(props, allDistances);
     allScores = getAllScores(routes, allWaits, allSpeeds);
-    
+
     const route_id = graphParams.route_id;
     const distObj = allDistances ? allDistances.find(distObj => distObj.routeID === route_id) : null;
     dist = distObj ? distObj.distance : null;
@@ -63,17 +63,17 @@ function RouteSummary(props) {
     waitObj = allWaits ? allWaits.find(obj => obj.routeID === route_id) : null;
     waitRanking = waitObj ? allWaits.length - allWaits.indexOf(waitObj) : null; // invert wait ranking to for shortest wait time
     wait = waitObj ? waitObj.wait : null;
-    
+
     speedObj = allSpeeds ? allSpeeds.find(obj => obj.routeID === route_id) : null;
     speedRanking = speedObj ? allSpeeds.indexOf(speedObj) + 1 : null;
     speed = speedObj ? speedObj.speed : null;
-    
+
     scoreObj = allScores ? allScores.find(obj => obj.routeID === route_id) : null;
     scoreRanking = scoreObj ? allScores.indexOf(scoreObj) + 1 : null;
-    
+
     grades = computeGrades(wait, speed);
   }
-  
+
   const useStyles = makeStyles(theme => ({
     grade: {
       background: wait && speed ? quartileBackgroundColor(grades.totalScore/grades.highestPossibleScore) : "gray",
@@ -85,26 +85,26 @@ function RouteSummary(props) {
       color: wait && grades ? quartileForegroundColor(grades.medianWaitScore/100.0) : "black",
       padding: theme.spacing(2)
     },
-    trip: { 
+    trip: {
       background: speed && grades ? quartileBackgroundColor(grades.speedScore/100.0) : "gray",
       color: speed && grades ? quartileForegroundColor(grades.speedScore/100.0) : "black",
       padding: theme.spacing(2)
     },
   }));
-  
+
   const classes = useStyles();
-  
+
   return <Fragment>
-      
+
       <div style={{ padding: 12 }}>
       <Grid container spacing={3}>
 
-        <Grid item xs>            
+        <Grid item xs>
           <Paper className={classes.grade}>
           <Typography variant="overline">Route score</Typography><br/>
 
           <Typography variant="h3" display="inline">{ wait && speed ? grades.totalScore : '--'}</Typography>
-          <Typography variant="h5" display="inline">/{grades.highestPossibleScore}</Typography>
+          <Typography variant="h5" display="inline">/{grades ? grades.highestPossibleScore : '--'}</Typography>
 
           <Box pt={2}>
             <Typography variant="body1">
@@ -115,7 +115,7 @@ function RouteSummary(props) {
           </Paper>
         </Grid>
 
-        <Grid item xs>            
+        <Grid item xs>
           <Tooltip title={ wait ? 'Subscore: ' + grades.medianWaitScore + '/100' : ''}>
           <Paper className={classes.wait}>
 
@@ -127,18 +127,18 @@ function RouteSummary(props) {
             <Rating
               readOnly
               size="small"
-              value={ Math.round( grades.medianWaitScore / 10.0 ) / 2.0 }
+              value={ grades ? Math.round( grades.medianWaitScore / 10.0 ) / 2.0 : 0 }
               precision={0.5} />
 
             <Box pt={2}>
               { waitRanking ? `#${waitRanking} of ${allWaits.length} for shortest wait` : null }
             </Box>
 
-          </Paper>            
+          </Paper>
           </Tooltip>
-        </Grid>            
-            
-        <Grid item xs>            
+        </Grid>
+
+        <Grid item xs>
 
           <Tooltip title={ speed ? 'Subscore: ' + grades.speedScore + '/100' : ''}>
           <Paper className={classes.trip}>
@@ -147,19 +147,19 @@ function RouteSummary(props) {
             <br/>
             <Typography variant="h3" display="inline">{ speed === null || isNaN(speed) ? "--" : speed.toFixed(1) }</Typography>
             <Typography variant="h5" display="inline">&nbsp;mph</Typography>
-            
+
             <Rating
             readOnly
             size="small"
-            value={ Math.round( grades.speedScore / 10.0 ) / 2.0 }
+            value={ grades ? Math.round( grades.speedScore / 10.0 ) / 2.0 : 0 }
             precision={0.5} />
 
             <Box pt={2}>
               { speedRanking ? `#${speedRanking} of ${allSpeeds.length} for fastest` : null }
             </Box>
-            
+
             Length: { metersToMiles(dist).toFixed(1) } miles
-            
+
           </Paper>
           </Tooltip>
         </Grid>


### PR DESCRIPTION
Initially it shows the message "Click anywhere in the city to see the routes near that point."

When routes are displayed, it shows the message "Click anywhere along a route to see statistics for trips between the two stops."

Also works around a bug that I didn't fully understand where "grades" object could be null on the route screen after clicking the spider map.