### PR TITLE
Codeowners to auto suggest reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Global / Backend reviewer suggestions
+*               @hathix @youngj @exxonvaldez
+
+# Frontend reviewer suggestions (overrides global)
+/frontend/      @exxonvaldez @akgupta89
+
+# Kubernetes reviewer suggestions
+/kubernetes/    @youngj


### PR DESCRIPTION
This will help with auto suggesting reviewers

It'd be better if we moved the python stuff into a `/backend/` folder so we can maintain this cleaner as a mono repo and make the file structure of this repo suggest code owners properly. Ideally better than maintaining a document that suggests code owners to tag