### PR TITLE
Fixes #235: better speed calculation, also refactor parameters passed to getAllSpeeds, getAllWaits, getAllScores

### DIFF
--- a/frontend/src/components/MapSpider.jsx
+++ b/frontend/src/components/MapSpider.jsx
@@ -10,8 +10,8 @@ import L from 'leaflet';
 import MapShield from './MapShield'
 import Control from 'react-leaflet-control';
 import * as d3 from "d3";
-import { filterRoutes, milesBetween } from '../helpers/routeCalculations';
-import { handleSpiderMapClick, handleGraphParams } from '../actions';
+import { getAllWaits, filterRoutes, milesBetween } from '../helpers/routeCalculations';
+import { handleSpiderMapClick } from '../actions';
 import { getTripPoints } from '../helpers/mapGeometry';
 import { push } from 'redux-first-router'
 
@@ -205,7 +205,7 @@ class MapSpider extends Component {
    */
   DownstreamLines = () => {
 
-    const allWaits = this.getAllWaits();
+    const allWaits = getAllWaits(this.props.waitTimesCache, this.props.graphParams, this.props.routes);
 
     // One polyline for each start marker
 
@@ -406,60 +406,12 @@ class MapSpider extends Component {
     );
   } // end render
 
-  /**
-   * These are static placeholder precomputed average waits per route values.  This will be replaced
-   * eventually by values generated from the precomputed wait times for all stops on a route.
-   *
-   * These are used to draw routes in three widths by frequency: widest is the top third most frequent,
-   * medium width for middle third of frequency, and thinnest for the third least frequent.
-   */
-  getAllWaits() {
-    const allWaits =
-
-  [{"routeID":"38BX","wait":169.84285714285716},{"routeID":"38AX","wait":159.70769230769233},
-    {"routeID":"1BX","wait":130.49655172413796},{"routeID":"41","wait":110.75636363636364},
-    {"routeID":"7X","wait":106.77532467532468},{"routeID":"1AX","wait":102.53235294117647},
-    {"routeID":"31BX","wait":97.9939393939394},{"routeID":"8AX","wait":81.05306122448978},
-    {"routeID":"82X","wait":77.36500000000002},{"routeID":"30X","wait":72.21538461538461},
-    {"routeID":"31AX","wait":48.3780487804878},{"routeID":"14X","wait":45.76607142857143},
-    {"routeID":"S","wait":42.98648648648649},{"routeID":"81X","wait":34.93750000000001},
-    {"routeID":"56","wait":26.305769230769233},{"routeID":"36","wait":23.021428571428572},
-    {"routeID":"23","wait":21.24701492537313},{"routeID":"25","wait":20.81190476190476},
-    {"routeID":"67","wait":19.99772727272727},{"routeID":"39","wait":18.764102564102565},
-    {"routeID":"18","wait":15.71111111111111},{"routeID":"12","wait":15.61954022988506},
-    {"routeID":"52","wait":15.015492957746478},{"routeID":"C","wait":14.902702702702705},
-    {"routeID":"PM","wait":14.210869565217392},{"routeID":"8BX","wait":13.026881720430108},
-    {"routeID":"PH","wait":12.933333333333332},{"routeID":"54","wait":12.680722891566266},
-    {"routeID":"8","wait":12.673636363636362},{"routeID":"35","wait":12.5109375},
-    {"routeID":"31","wait":12.00990990990991},{"routeID":"3","wait":11.955172413793104},
-    {"routeID":"37","wait":11.766315789473683},{"routeID":"88","wait":11.75263157894737},
-    {"routeID":"48","wait":11.725000000000001},{"routeID":"M","wait":11.183636363636365},
-    {"routeID":"57","wait":11.163529411764706},{"routeID":"19","wait":11.15373134328358},
-    {"routeID":"66","wait":10.487499999999999},{"routeID":"9R","wait":10.371264367816094},
-    {"routeID":"10","wait":9.95},{"routeID":"33","wait":9.621839080459772},
-    {"routeID":"5","wait":9.588750000000001},{"routeID":"2","wait":9.172},
-    {"routeID":"38","wait":8.974850299401195},{"routeID":"27","wait":8.712631578947367},
-    {"routeID":"9","wait":8.483185840707964},{"routeID":"KT","wait":8.379761904761907},
-    {"routeID":"6","wait":8.184210526315788},{"routeID":"55","wait":7.946428571428571},
-    {"routeID":"24","wait":7.747899159663866},{"routeID":"J","wait":7.675000000000001},
-    {"routeID":"29","wait":7.4916201117318435},{"routeID":"21","wait":7.115789473684211},
-    {"routeID":"7","wait":7.017757009345793},{"routeID":"28R","wait":7.000000000000001},
-    {"routeID":"43","wait":6.9662857142857115},{"routeID":"30","wait":6.941176470588235},
-    {"routeID":"44","wait":6.82734375},{"routeID":"28","wait":6.578481012658228},
-    {"routeID":"45","wait":6.361016949152543},{"routeID":"L","wait":6.295833333333333},
-    {"routeID":"22","wait":6.107608695652175},{"routeID":"F","wait":6.010000000000001},
-    {"routeID":"NX","wait":5.9375},{"routeID":"N","wait":5.803030303030303},
-    {"routeID":"5R","wait":5.579365079365079},{"routeID":"47","wait":5.460344827586206},
-    {"routeID":"14","wait":5.4173913043478255},{"routeID":"49","wait":5.0628205128205135},
-    {"routeID":"14R","wait":4.806521739130435},{"routeID":"1","wait":3.921875},
-    {"routeID":"38R","wait":3.68125}];
-
-    return allWaits;
-  }
-
 } // end class
 
 const mapStateToProps = state => ({
+  routes: state.routes.routes,
+  graphParams: state.routes.graphParams,
+  waitTimesCache: state.routes.waitTimesCache,  
   spiderLatLng: state.routes.spiderLatLng,
   spiderSelection: state.routes.spiderSelection,
 });

--- a/frontend/src/components/QuadrantChart.jsx
+++ b/frontend/src/components/QuadrantChart.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { getAllWaits, getAllDistances, getAllSpeeds } from '../helpers/routeCalculations';
+import { getAllWaits, getAllSpeeds } from '../helpers/routeCalculations';
 import { connect } from 'react-redux';
 import { XYPlot, HorizontalGridLines, VerticalGridLines, XAxis, YAxis,
   ChartLabel, CustomSVGSeries } from 'react-vis';
@@ -14,9 +14,8 @@ import { XYPlot, HorizontalGridLines, VerticalGridLines, XAxis, YAxis,
  */
 function QuadrantChart(props) {
 
-  const allWaits = getAllWaits(props);
-  const allDistances = getAllDistances(props);
-  const allSpeeds = getAllSpeeds(props, allDistances);
+  const allWaits = getAllWaits(props.waitTimesCache, props.graphParams, props.routes);
+  const allSpeeds = getAllSpeeds(props.tripTimesCache, props.graphParams, props.routes);
   
   const quadrantData = allSpeeds ? allSpeeds.map(speed => {
     const waitObj = allWaits.find(waitObj => waitObj.routeID === speed.routeID);

--- a/frontend/src/components/RouteSummary.jsx
+++ b/frontend/src/components/RouteSummary.jsx
@@ -1,6 +1,6 @@
 import React, { Fragment, useEffect } from 'react';
 
-import { filterRoutes, getAllWaits, getAllDistances, getAllSpeeds, getAllScores,
+import { filterRoutes, getAllWaits, getAllSpeeds, getAllScores,
   computeGrades, quartileBackgroundColor, quartileForegroundColor,
   metersToMiles } from '../helpers/routeCalculations'
 
@@ -50,15 +50,16 @@ function RouteSummary(props) {
 
     routes = props.routes ? filterRoutes(props.routes) : [];
 
-    allWaits = getAllWaits(props);
-
-    const allDistances = getAllDistances(props);
-    allSpeeds = getAllSpeeds(props, allDistances);
+    allWaits = getAllWaits(props.waitTimesCache, graphParams, routes);
+    allSpeeds = getAllSpeeds(props.tripTimesCache, graphParams, routes);
     allScores = getAllScores(routes, allWaits, allSpeeds);
 
     const route_id = graphParams.route_id;
-    const distObj = allDistances ? allDistances.find(distObj => distObj.routeID === route_id) : null;
-    dist = distObj ? distObj.distance : null;
+    const route = routes.find(route => route.id === route_id);
+    if (route) {
+      const sumOfDistances = route.directions.reduce((total, value) => total + value.distance, 0);
+      dist = sumOfDistances / route.directions.length;
+    }
 
     waitObj = allWaits ? allWaits.find(obj => obj.routeID === route_id) : null;
     waitRanking = waitObj ? allWaits.length - allWaits.indexOf(waitObj) : null; // invert wait ranking to for shortest wait time

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -14,7 +14,7 @@ import Paper from '@material-ui/core/Paper';
 import IconButton from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
 import FilterListIcon from '@material-ui/icons/FilterList';
-import { filterRoutes, getAllWaits, getAllDistances, getAllSpeeds, getAllScores } from '../helpers/routeCalculations';
+import { filterRoutes, getAllWaits, getAllSpeeds, getAllScores } from '../helpers/routeCalculations';
 import { connect } from 'react-redux';
 import Link from 'redux-first-router-link';
 
@@ -192,9 +192,8 @@ function RouteTable(props) {
     routes = routes.filter(route => spiderRouteIDs.includes(route.id));
   }
 
-  const allWaits = getAllWaits(props);
-  const allDistances = getAllDistances(props);
-  const allSpeeds = getAllSpeeds(props, allDistances);
+  const allWaits = getAllWaits(props.waitTimesCache, props.graphParams, routes);
+  const allSpeeds = getAllSpeeds(props.tripTimesCache, props.graphParams, routes);
   const allScores = getAllScores(routes, allWaits, allSpeeds);
   
   routes = routes.map(route => {

--- a/frontend/src/components/TravelTimeChart.jsx
+++ b/frontend/src/components/TravelTimeChart.jsx
@@ -51,7 +51,7 @@ function TravelTimeChart(props) {
     direction_id = props.direction_id || graphParams.direction_id; // also take direction_id from props if given
     
     if (direction_id) {
-      tripTimeForDirection = getEndToEndTripTime(props, route_id, direction_id);
+      tripTimeForDirection = getEndToEndTripTime(props.tripCacheTimes, graphParams, props.routes, route_id, direction_id);
     
     /* this is the end-to-end speed in the selected direction, not currently used
     if (dist <= 0 || isNaN(tripTime)) { speed = "?"; } // something wrong with the data here

--- a/frontend/src/helpers/precomputed.js
+++ b/frontend/src/helpers/precomputed.js
@@ -42,6 +42,10 @@ export function getTripTimesForDirection(
 ) {
   const [timeStr, dateStr] = getTimeStrAndDateStr(graphParams);
 
+  if (!tripTimesCache) {
+    return null;
+  }
+
   const tripTimes = tripTimesCache[dateStr + timeStr + stat];
 
   if (!tripTimes) {

--- a/frontend/src/screens/Dashboard.jsx
+++ b/frontend/src/screens/Dashboard.jsx
@@ -40,7 +40,7 @@ function Dashboard(props) {
         {' '}
         {/* Using spacing causes horizontal scrolling, see https://material-ui.com/components/grid/#negative-margin */}
         <Grid item xs={6}>
-          <MapSpider routes={routes} />
+          <MapSpider />
         </Grid>
         <Grid item xs={6} style={{ padding: 12 }}>
           {' '}


### PR DESCRIPTION
- MapSpider: use precomputed wait values to choose thick/med/thin lines based on frequency instead of hardcoded wait values.
- routeCalcuations.getSpeedForRoute: Remove getAllDistances in favor of using the GTFS-based distance per direction
- Refactor code to pass direct objects to getAllSpeeds, getAllWaits, and getAllScores, instead of just props.

<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->

Fixes #235.


<!-- Delete any of these headings if they aren't needed or applicable -->

No real visible changes, except that the spider map lines all become thin while loading new precomputed wait times.

Demo at https://ot-terence.herokuapp.com/
