### PR TITLE
Updated Prettier Rules

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -11,6 +11,14 @@
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "jsx-a11y/label-has-for": "off",
     "prettier/prettier": "error",
-    "max-len": ["error", 80]
+    "max-len": ["warn", 80],
+    "prefer-destructuring": ["warn", {
+      "array": true,
+      "object": true
+    }, {
+      "enforceForRenamedProperties": false
+    }],
+    "no-underscore-dangle": "warn",
+    "react/prop-types": "warn"
   }
 }


### PR DESCRIPTION
I'm going to break up the clean up / beautification of the codebase into smaller parts since the codebase changes so match it's basically asking for conflicts

- Makes going over the max length a warning instead of an _error_
- destructuring isn't mandatory
- makes using `_foo` or `foo_` or any dangling underscore a warning
- makes props a warning