### PR TITLE
Delete pre.sh

### DIFF
--- a/pre.sh
+++ b/pre.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-if [[ -d frontend/node_modules ]]; then
-  npm lint:all
-fi


### PR DESCRIPTION
I do not believe we are using this anymore due to husky and prettier and according to this: https://github.com/trynmaps/metrics-mvp/commit/10d2245ac7c6633182147439d910b347d73701a7

It would be great if @youngj could confirm