### PR TITLE
For small windows (640px), make dashboard map and route screen map full width

### DIFF
--- a/frontend/src/components/MapSpider.jsx
+++ b/frontend/src/components/MapSpider.jsx
@@ -29,10 +29,16 @@ class MapSpider extends Component {
     this.mapRef = createRef(); // used for geolocating
   }
 
-  // TODO: Needs optimizing. This sets height to that of the window, not remaining space, which
-  // has to be adjusted for by hand.
+  // Make the map full height unless the window is smaller than the sm breakpoint (640px), in which
+  // case make the map half height.
+  //
+  // TODO: Need to convert this component to a functional component.  Then we can use the useTheme
+  // hook to programatically access the breakpoint widths.
+  //
+  // Note: This code has to be adjusted to be kept in sync with the UI layout.
+  //
   updateDimensions() {
-    const height = (window.innerWidth >= 992 ? window.innerHeight : 500) - 64 /* blue app bar */;
+    const height = (window.innerWidth >= 640 ? window.innerHeight : window.innerHeight/2) - 64 /* blue app bar */;
     this.setState({ height: height })
   }
 

--- a/frontend/src/screens/Dashboard.jsx
+++ b/frontend/src/screens/Dashboard.jsx
@@ -39,10 +39,11 @@ function Dashboard(props) {
       <Grid container spacing={0}>
         {' '}
         {/* Using spacing causes horizontal scrolling, see https://material-ui.com/components/grid/#negative-margin */}
-        <Grid item xs={6}>
+        
+        <Grid item xs={12} sm={6}> {/* map and table are both full width for 640px windows or smaller, else half width */}
           <MapSpider />
         </Grid>
-        <Grid item xs={6} style={{ padding: 12 }}>
+        <Grid item xs={12} sm={6} style={{ padding: 12 }}>
           {' '}
           {/* Doing the spacing between Grid items ourselves.  See previous comment. */}
           <RouteTable routes={routes} />

--- a/frontend/src/screens/RouteScreen.jsx
+++ b/frontend/src/screens/RouteScreen.jsx
@@ -76,7 +76,7 @@ function RouteScreen(props) {
         </AppBar>
 
         <Grid container spacing={0}>
-          <Grid item xs={6}>
+          <Grid item xs={12} sm={6}> {/* control panel and map are full width for 640px windows or smaller, else half width */}
             <ControlPanel
               routes={routes}
               resetGraphData={props.resetGraphData}
@@ -87,7 +87,7 @@ function RouteScreen(props) {
             />
             <MapStops routes={routes} />
           </Grid>
-          <Grid item xs={6}>
+          <Grid item xs={12} sm={6}>
             {graphData /* if we have graph data, then show the info component */ ? (
               <Info
                 graphData={graphData}


### PR DESCRIPTION


<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->

Fixes #268.

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

- Use the "sm" breakpoint (640px window width) to be breakpoint where map becomes half of the screen width (`MapSpider` and `MapStops`), and full width below that.
- `MapSpider` was always full height but now is half height if window width is less than 640px.

Note: `MapStops` is currently fixed height, 500px.  We could make it more like MapSpider if we wanted.

Note:  The Material UI `Table`s don't do well in narrow windows.  They have a lot of padding in the columns.  Need to address this is another issue/PR.

## Screenshot

<img width="424" alt="Screen Shot 2019-08-29 at 12 07 48 AM" src="https://user-images.githubusercontent.com/44861283/63918612-dcc96c00-c9f1-11e9-9df2-373bcd71077f.png">


<img width="387" alt="Screen Shot 2019-08-29 at 12 08 41 AM" src="https://user-images.githubusercontent.com/44861283/63918607-da671200-c9f1-11e9-80dc-31b9e5dcdf70.png">

## Link to demo, if any

Not available.  No visible changes for larger screens.
