### PR TITLE
Fix sorting of "--" (Nan) values in RouteTable

### DIFF
--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -26,6 +26,20 @@ import {
 import { handleGraphParams, fetchPrecomputedWaitAndTripData } from '../actions';
 
 function desc(a, b, orderBy) {
+  
+  // Treat NaN as infinity, so that it goes to the bottom of the table in an ascending sort.
+  // NaN needs special handling because NaN < 3 is false as is Nan > 3.
+  
+  if (Number.isNaN(a[orderBy]) && Number.isNaN(b[orderBy])) {
+    return 0;
+  }
+  if (Number.isNaN(a[orderBy])) {
+    return -1;
+  }
+  if (Number.isNaN(b[orderBy])) {
+    return 1;
+  }
+  
   if (b[orderBy] < a[orderBy]) {
     return -1;
   }


### PR DESCRIPTION
<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->

Fixes #231.


<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

The route data contains `NaN`s which require special case handling for sorting.  This is because NaN < 3 evaluates to false, as does NaN > 3, which breaks sorting.

## Screenshot

![Screen Shot 2019-08-30 at 1 01 06 PM](https://user-images.githubusercontent.com/44861283/64048345-4cd90e80-cb26-11e9-8e8f-f3e0d4bad958.png)

