### PR TITLE
Improve documentation on port 5000

### DIFF
--- a/backend/metrics-api.py
+++ b/backend/metrics-api.py
@@ -249,7 +249,7 @@ if os.environ.get('METRICS_ALL_IN_ONE') == '1':
 else:
     @app.route('/')
     def root():
-        return """<h2>Hello!</h2><p>This is the API server.</p>"""
+        return """<h2>Hello!</h2><p>This is the API server Go to port 3000 to see the real app.</p>"""
 
 if __name__ == '__main__':
     # Bind to PORT if defined, otherwise default to 5000.


### PR DESCRIPTION

## Proposed changes

Running `docker-compose up` tells the user to visit port 5000, but that just gives them the "this is the api server" message, with no direction to the app. This has confused many new OpenTransit'ers.

This commit adds a note that the user should visit port 3000 to see the real app.
