### PR TITLE
add cron job to update routes JSON once a day

### DIFF
--- a/kubernetes/save-routes-cronjob.yaml
+++ b/kubernetes/save-routes-cronjob.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: save-routes
+spec:
+  schedule: "30 0 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: compute-new
+            image: gcr.io/poetic-genius-233804/metrics-flask:latest
+            imagePullPolicy: Always
+            command: ["python",  "save_routes.py"]
+            env:
+              - name: AWS_ACCESS_KEY_ID
+                valueFrom:
+                  secretKeyRef:
+                    name: aws-credentials
+                    key: aws_access_key_id
+              - name: AWS_SECRET_ACCESS_KEY
+                valueFrom:
+                  secretKeyRef:
+                    name: aws-credentials
+                    key: aws_secret_access_key
+          restartPolicy: Never


### PR DESCRIPTION
Currently it just overwrites https://opentransit-precomputed-stats.s3.amazonaws.com/routes_v2_sf-muni.json.gz (not storing historical data yet). 

The GTFS feed at http://gtfs.sfmta.com/transitdata/google_transit.zip doesn't include 78X or 79X yet.