### PR TITLE
add 10000 second time limit to cron job so it doesn't get stuck

### DIFF
--- a/kubernetes/compute-new-cronjob.yaml
+++ b/kubernetes/compute-new-cronjob.yaml
@@ -26,3 +26,4 @@ spec:
                     name: aws-credentials
                     key: aws_secret_access_key
           restartPolicy: Never
+          activeDeadlineSeconds: 10000


### PR DESCRIPTION
The cron job to compute new arrivals and stats previously hung in the middle of a run (not sure why). Limiting the run time of a cron job should hopefully work around this.