### PR TITLE
count arrivals as belonging to separate trips if there is a gap of 3+ stops, or 30+ minutes of missing GPS observations

### DIFF
--- a/backend/models/arrival_history.py
+++ b/backend/models/arrival_history.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import gzip
 import numpy as np
 
-DefaultVersion = 'v4'
+DefaultVersion = 'v4a'
 
 class ArrivalHistory:
     def __init__(self, agency, route_id, stops_data, start_time = None, end_time = None, version = DefaultVersion):

--- a/backend/models/eclipses.py
+++ b/backend/models/eclipses.py
@@ -470,6 +470,8 @@ def clean_arrivals(possible_arrivals: pd.DataFrame, buses: pd.DataFrame, route_c
 
     start_trip = 0
 
+    arrival_time_diffs = []
+
     def set_trip(dir_arrivals):
         nonlocal start_trip
 
@@ -482,6 +484,8 @@ def clean_arrivals(possible_arrivals: pd.DataFrame, buses: pd.DataFrame, route_c
         arrival_time_values = dir_arrivals['TIME'].values
 
         arrival_time_diff = np.diff(arrival_time_values, prepend=arrival_time_values[0])
+
+        arrival_time_diffs.append(arrival_time_diff)
 
         new_trip = (stop_index_diff <= 0) | (arrival_time_diff > 3600)
 
@@ -516,6 +520,11 @@ def clean_arrivals(possible_arrivals: pd.DataFrame, buses: pd.DataFrame, route_c
         get_arrivals_for_vehicle_direction(dir_arrivals, vehicle_id, direction_id, buses_map[vehicle_id], route_config)
             for (vehicle_id, direction_id), dir_arrivals in possible_arrivals.groupby(['VID', 'DID'])
     ])
+
+    arrival_time_diffs = np.concatenate(arrival_time_diffs)
+    diff_quantiles = np.quantile(arrival_time_diffs, [0.5, 0.9, 1])
+
+    print(f' median={diff_quantiles[0]} 90%={diff_quantiles[1]} max={diff_quantiles[2]}')
 
     return arrivals.sort_values('TIME'), start_trip
 

--- a/backend/models/eclipses.py
+++ b/backend/models/eclipses.py
@@ -479,7 +479,11 @@ def clean_arrivals(possible_arrivals: pd.DataFrame, buses: pd.DataFrame, route_c
 
         stop_index_diff = np.diff(stop_index_values, prepend=-999999)
 
-        new_trip = stop_index_diff <= 0
+        arrival_time_values = dir_arrivals['TIME'].values
+
+        arrival_time_diff = np.diff(arrival_time_values, prepend=arrival_time_values[0])
+
+        new_trip = (stop_index_diff <= 0) | (arrival_time_diff > 3600)
 
         # The trip ID is an arbitrary integer that is the same for a group
         # of arrivals for the same vehicle and direction that have an ascending stop index.

--- a/backend/models/eclipses.py
+++ b/backend/models/eclipses.py
@@ -80,6 +80,10 @@ def resample_bus(bus: pd.DataFrame) -> pd.DataFrame:
         vid = bus['VID'].values[0]
         did_values = bus['DID'].values
 
+        # obs_group is a counter associated with each resampled GPS observation
+        # that lets us group consecutive GPS observations for a particular vehicle.
+        # If a vehicle is missing GPS observations for a certain amount of time,
+        # we increment the obs_group counter.
         obs_group = 1
 
         for i in range(0, len(time_values)):

--- a/backend/models/trip_times.py
+++ b/backend/models/trip_times.py
@@ -66,7 +66,7 @@ def sort_parallel(arr, arr2):
     sort_order = np.argsort(arr)
     return arr[sort_order], arr2[sort_order]
 
-DefaultVersion = 'v1'
+DefaultVersion = 'v1a'
 
 class CachedTripTimes:
     def __init__(self, trip_times_data):

--- a/backend/models/wait_times.py
+++ b/backend/models/wait_times.py
@@ -355,7 +355,7 @@ class WaitTimeStats:
 
         return waits[np.logical_not(np.isnan(waits))] / 60
 
-DefaultVersion = 'v1'
+DefaultVersion = 'v1a'
 
 class CachedWaitTimes:
     def __init__(self, wait_times_data):

--- a/frontend/public/isochrone-worker.js
+++ b/frontend/public/isochrone-worker.js
@@ -19,6 +19,9 @@ const EarthRadius = 6371000;
 const MaxWalkRadius = 1800;
 const FirstStopMinWaitMinutes = 1.0;
 
+const TripTimesVersion = 'v1a';
+const WaitTimesVersion = 'v1a';
+
 let curComputeId = null;
 let tripTimesCache = {};
 let waitTimesCache = {};
@@ -127,9 +130,9 @@ async function getTripTimesFromStop(routeId, directionId, startStopId, dateStr, 
         let timePath = getTimePath(timeStr);
         let statPath = getStatPath(stat);
 
-        let s3Url = 'https://opentransit-precomputed-stats.s3.amazonaws.com/trip-times/v1/sf-muni/'+
+        let s3Url = 'https://opentransit-precomputed-stats.s3.amazonaws.com/trip-times/'+TripTimesVersion+'/sf-muni/'+
             dateStr.replace(/\-/g, '/')+
-            '/trip-times_v1_sf-muni_'+dateStr+'_'+statPath+timePath+'.json.gz';
+            '/trip-times_'+TripTimesVersion+'_sf-muni_'+dateStr+'_'+statPath+timePath+'.json.gz';
 
         tripTimes = tripTimesCache[dateStr + timeStr + stat] = await loadJson(s3Url).catch(function(e) {
             sendError("error loading trip times: " + e);
@@ -201,9 +204,9 @@ async function getWaitTimeAtStop(routeId, directionId, stopId, dateStr, timeStr,
         var timePath = getTimePath(timeStr);
         let statPath = getStatPath(stat);
 
-        let s3Url = 'https://opentransit-precomputed-stats.s3.amazonaws.com/wait-times/v1/sf-muni/'+
+        let s3Url = 'https://opentransit-precomputed-stats.s3.amazonaws.com/wait-times/'+WaitTimesVersion+'/sf-muni/'+
             dateStr.replace(/\-/g, '/')+
-            '/wait-times_v1_sf-muni_'+dateStr+'_'+statPath+timePath+'.json.gz';
+            '/wait-times_'+WaitTimesVersion+'_sf-muni_'+dateStr+'_'+statPath+timePath+'.json.gz';
 
         //console.log(s3Url);
 

--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -144,10 +144,12 @@ export function fetchArrivals(params) {
   return function(dispatch) {
     const dateStr = params.date;
 
-    const s3Url = `https://opentransit-stop-arrivals.s3.amazonaws.com/v4/sf-muni/${dateStr.replace(
+    const arrivalsVersion = 'v4a';
+
+    const s3Url = `https://opentransit-stop-arrivals.s3.amazonaws.com/${arrivalsVersion}/sf-muni/${dateStr.replace(
       /-/g,
       '/',
-    )}/arrivals_v4_sf-muni_${dateStr}_${params.routeId}.json.gz`;
+    )}/arrivals_${arrivalsVersion}_sf-muni_${dateStr}_${params.routeId}.json.gz`;
 
     axios
       .get(s3Url)

--- a/frontend/src/locationConstants.js
+++ b/frontend/src/locationConstants.js
@@ -138,6 +138,8 @@ export const ServiceArea = {
 export const routesUrl =
   'https://opentransit-precomputed-stats.s3.amazonaws.com/routes_v2_sf-muni.json.gz';
 
+const tripTimesVersion = 'v1a';
+
 /**
  * Generate S3 url for trips
  * @param dateStr - date
@@ -146,11 +148,13 @@ export const routesUrl =
  * @returns {string} S3 url
  */
 export function generateTripURL(dateStr, statPath, timePath) {
-  return `https://opentransit-precomputed-stats.s3.amazonaws.com/trip-times/v1/sf-muni/${dateStr.replace(
+  return `https://opentransit-precomputed-stats.s3.amazonaws.com/trip-times/${tripTimesVersion}/sf-muni/${dateStr.replace(
     /-/g,
     '/',
-  )}/trip-times_v1_sf-muni_${dateStr}_${statPath}${timePath}.json.gz`;
+  )}/trip-times_${tripTimesVersion}_sf-muni_${dateStr}_${statPath}${timePath}.json.gz`;
 }
+
+const waitTimesVersion = 'v1a';
 
 /**
  * Generate S3 url for wait times
@@ -160,10 +164,10 @@ export function generateTripURL(dateStr, statPath, timePath) {
  * @returns {string} S3 url
  */
 export function generateWaitTimeURL(dateStr, statPath, timePath) {
-  return `https://opentransit-precomputed-stats.s3.amazonaws.com/wait-times/v1/sf-muni/${dateStr.replace(
+  return `https://opentransit-precomputed-stats.s3.amazonaws.com/wait-times/${waitTimesVersion}/sf-muni/${dateStr.replace(
     /-/g,
     '/',
-  )}/wait-times_v1_sf-muni_${dateStr}_${statPath}${timePath}.json.gz`;
+  )}/wait-times_${waitTimesVersion}_sf-muni_${dateStr}_${statPath}${timePath}.json.gz`;
 }
 
 /**


### PR DESCRIPTION
The Marey chart highlighted some issues with the arrival time calculation, especially on Muni Metro routes, where there were many long gaps in arrival times for one vehicle that were being counted as part of a single trip (when most likely that vehicle was out of service during the gap):

Example (KT on 9/27):
![image](https://user-images.githubusercontent.com/343100/65843245-792ea900-e2e5-11e9-9138-9b32521c9fbd.png)

To fix this issue, the arrival time algorithm now counts arrivals as belonging to separate trips if there is a gap of 3 or more stops, or if there is a gap of 30 or more minutes without any GPS observations from that vehicle (indicating that the vehicle was likely not in continuous service during that time).

The algorithm does not have any limit on the travel time between stops (e.g. 1 hour). It is possible that a bus may actually be in service between those two stops but waiting a long time in traffic. With some transit systems it may also be normal for a vehicle to take a long time between stops. This makes it hard to come up with a heuristic for splitting trips based on the travel time between stops.

With this change, the Marey chart looks much more reasonable, although there are still occasional cases with a large travel time between 2 stops (usually between the 1st and 2nd stop or 2nd-to-last and last stop for a vehicle in a particular direction, due to the vehicle waiting in between those two stops before starting the next run).

Example (KT on 9/27):
![image](https://user-images.githubusercontent.com/343100/65843462-a62f8b80-e2e6-11e9-8d79-71272062bf4c.png)

In order to avoid loading old arrival times and statistics from the cache, the version codes for the arrival times and precomputed wait time/trip time stats have been changed, and the historical stats will need to be regenerated.

Mostly fixes #285 