### PR TITLE
Dashboard: Fix sorting of routes by name (title).

### DIFF
--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -27,6 +27,12 @@ import {
 
 import { handleGraphParams, fetchPrecomputedWaitAndTripData } from '../actions';
 
+/**
+ * 
+ * @param {any} a
+ * @param {any} b
+ * @param {any} orderBy
+ */
 function desc(a, b, orderBy) {
   // Treat NaN as infinity, so that it goes to the bottom of the table in an ascending sort.
   // NaN needs special handling because NaN < 3 is false as is Nan > 3.
@@ -50,7 +56,31 @@ function desc(a, b, orderBy) {
   return 0;
 }
 
-function stableSort(array, cmp) {
+/**
+ * Sorts the given array using a comparator.  Equal values are ordered by array index.
+ * 
+ * Sorting by title is a special case because the original order of the routes array is
+ * better than sorting route title alphabetically.  For example, 1 should be followed by
+ * 1AX rather than 10 and 12.
+ *  
+ * @param {Array} array      Array to sort
+ * @param {Function} cmp     Comparator to use
+ * @param {String} sortOrder Either 'desc' or 'asc'
+ * @param {String} orderBy   Column to sort by
+ */
+function stableSort(array, cmp, sortOrder, orderBy) {
+  
+  // special case for title sorting that short circuits the use of the comparator
+  
+  if (orderBy === 'title') {
+    if (sortOrder === 'desc') {
+      const newArray = [...array].reverse();
+      return newArray;
+    } else {
+      return array;
+    }
+  }
+  
   const stabilizedThis = array.map((el, index) => [el, index]);
   stabilizedThis.sort((a, b) => {
     const order = cmp(a[0], b[0]);
@@ -258,7 +288,7 @@ function RouteTable(props) {
               rowCount={routes.length}
             />
             <TableBody>
-              {stableSort(routes, getSorting(order, orderBy)).map(
+              {stableSort(routes, getSorting(order, orderBy), order, orderBy).map(
                 (row, index) => {
                   const labelId = `enhanced-table-checkbox-${index}`;
 

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -61,6 +61,7 @@ function desc(a, b, orderBy) {
  * @param {Function} cmp     Comparator to use
  * @param {String} sortOrder Either 'desc' or 'asc'
  * @param {String} orderBy   Column to sort by
+ * @returns {Array}          The sorted array
  */
 function stableSort(array, cmp, sortOrder, orderBy) {
   

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -27,12 +27,6 @@ import {
 
 import { handleGraphParams, fetchPrecomputedWaitAndTripData } from '../actions';
 
-/**
- * 
- * @param {any} a
- * @param {any} b
- * @param {any} orderBy
- */
 function desc(a, b, orderBy) {
   // Treat NaN as infinity, so that it goes to the bottom of the table in an ascending sort.
   // NaN needs special handling because NaN < 3 is false as is Nan > 3.


### PR DESCRIPTION


<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->

Fixes #164.

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

When sorting by route name (internally `title`), use the natural order of the routes array, which comes from Nextbus. It is the simplest way to get a "good" ordering for the routes without having to implement a hybrid numeric/lexical sort.

## Screenshot

![Screen Shot 2019-10-01 at 9 30 28 PM](https://user-images.githubusercontent.com/44861283/66018253-2d216700-e493-11e9-8fbf-9ea4a0835b6b.png)


## Link to demo, if any

n/a
