### PR TITLE
Refactor static  colors codes to variables tha can be use in an easie…

### DIFF
--- a/frontend/src/UIConstants.js
+++ b/frontend/src/UIConstants.js
@@ -2,8 +2,17 @@
  * Constants for the UI that allow for reconfiguration.
  */
 
+// Colors definition:
+// This section its should be use to declare the colors
+// used in the application
+export const GRAY = '#a4a6a9';
+export const PURPLE = '#aa82c5';
+export const BLUE = 'blue';
+export const RED = 'RED';
+export const GREEN = 'green';
+
 // placeholder colors: gray and purple from nyc busstats
-export const CHART_COLORS = ['#a4a6a9', '#aa82c5'];
+export const CHART_COLORS = [GRAY, PURPLE];
 
 // use this percentile (e.g. 90th) for waits/travel times
 // for planning purposes the idea here is to filter out

--- a/frontend/src/UIConstants.js
+++ b/frontend/src/UIConstants.js
@@ -3,16 +3,18 @@
  */
 
 // Colors definition:
-// This section its should be use to declare the colors
-// used in the application
-export const GRAY = '#a4a6a9';
-export const PURPLE = '#aa82c5';
-export const BLUE = 'blue';
-export const RED = 'RED';
-export const GREEN = 'green';
+// This section its should be use to declare an object color
+// that contain the colors used in the application
+export const Colors = {
+  GRAY: '#a4a6a9',
+  PURPLE: '#aa82c5',
+  BLUE: 'blue',
+  RED: 'RED',
+  GREEN: 'green'
+}
 
 // placeholder colors: gray and purple from nyc busstats
-export const CHART_COLORS = [GRAY, PURPLE];
+export const CHART_COLORS = [Colors.GRAY, Colors.PURPLE];
 
 // use this percentile (e.g. 90th) for waits/travel times
 // for planning purposes the idea here is to filter out

--- a/frontend/src/UIConstants.js
+++ b/frontend/src/UIConstants.js
@@ -9,7 +9,7 @@ export const Colors = {
   GRAY: '#a4a6a9',
   PURPLE: '#aa82c5',
   BLUE: 'blue',
-  RED: 'RED',
+  RED: 'red',
   GREEN: 'green'
 }
 

--- a/frontend/src/components/MapStops.jsx
+++ b/frontend/src/components/MapStops.jsx
@@ -8,10 +8,10 @@ import { handleGraphParams } from '../actions';
 import { getTripTimesFromStop } from '../helpers/precomputed';
 import { getTripPoints, getDistanceInMiles } from '../helpers/mapGeometry';
 import { STARTING_COORDINATES } from '../locationConstants';
-import { BLUE, RED, GREEN, PURPLE } from '../UIConstants';
+import { Colors } from '../UIConstants';
 
 const RADIUS = 6;
-const STOP_COLORS = [BLUE, RED, GREEN, PURPLE];
+const STOP_COLORS = [Colors.BLUE, Colors.RED, Colors.GREEN, Colors.PURPLE];
 const ZOOM = 13;
 
 class MapStops extends Component {

--- a/frontend/src/components/MapStops.jsx
+++ b/frontend/src/components/MapStops.jsx
@@ -8,9 +8,10 @@ import { handleGraphParams } from '../actions';
 import { getTripTimesFromStop } from '../helpers/precomputed';
 import { getTripPoints, getDistanceInMiles } from '../helpers/mapGeometry';
 import { STARTING_COORDINATES } from '../locationConstants';
+import { BLUE, RED, GREEN, PURPLE } from '../UIConstants';
 
 const RADIUS = 6;
-const STOP_COLORS = ['blue', 'red', 'green', 'purple'];
+const STOP_COLORS = [BLUE, RED, GREEN, PURPLE];
 const ZOOM = 13;
 
 class MapStops extends Component {


### PR DESCRIPTION
Refactor colors static codes to variables that can be used in an easier way thrown the application


Fixes #209



## Proposed changes
Set colors code as variable to make easier reuse it or change it
```
export const Colors = {
  GRAY: '#a4a6a9',
  PURPLE: '#aa82c5',
  BLUE: 'blue',
  RED: 'red',
  GREEN: 'green'
}
```