### PR TITLE
MapStops improvements

### DIFF
--- a/frontend/src/UIConstants.js
+++ b/frontend/src/UIConstants.js
@@ -2,6 +2,8 @@
  * Constants for the UI that allow for reconfiguration.
  */
 
+import indigo from '@material-ui/core/colors/indigo';
+
 // Colors definition:
 // This section its should be use to declare an object color
 // that contain the colors used in the application
@@ -10,7 +12,8 @@ export const Colors = {
   PURPLE: '#aa82c5',
   BLUE: 'blue',
   RED: 'red',
-  GREEN: 'green'
+  GREEN: 'green',
+  INDIGO: indigo[400],
 }
 
 // placeholder colors: gray and purple from nyc busstats

--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 // import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
+import Box from '@material-ui/core/Box';
 import Input from '@material-ui/core/Input';
 import InputLabel from '@material-ui/core/InputLabel';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -11,6 +12,8 @@ import Select from '@material-ui/core/Select';
 import Grid from '@material-ui/core/Grid';
 import { handleGraphParams } from '../actions';
 import { ROUTE, DIRECTION, FROM_STOP, TO_STOP, Path } from '../routeUtil';
+import LocationOn from '@material-ui/icons/LocationOn';
+import TripOrigin from '@material-ui/icons/TripOrigin';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -172,48 +175,54 @@ function ControlPanel(props) {
         {selectedDirection ? (
           <Grid container>
             <Grid item xs>
-              <FormControl className={classes.formControl}>
-                <InputLabel htmlFor="fromstop">From Stop</InputLabel>
-                <Select
+              <Box ml={1}>
+                <TripOrigin fontSize="small" htmlColor="black"/>
+                <FormControl className={classes.formControl}>
+                  <InputLabel htmlFor="fromstop">From Stop</InputLabel>
+                  <Select
                   value={graphParams.startStopId || 1}
                   onChange={onSelectFirstStop}
                   input={<Input name="stop" id="fromstop" />}
-                >
-                  {(selectedDirection.stops || []).map(firstStopId => (
-                    <MenuItem key={firstStopId} value={firstStopId}>
-                      {
-                        (
-                          selectedRoute.stops[firstStopId] || {
-                            title: firstStopId,
-                          }
-                        ).title
-                      }
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
+                  >
+                    {(selectedDirection.stops || []).map(firstStopId => (
+                      <MenuItem key={firstStopId} value={firstStopId}>
+                        {
+                          (
+                            selectedRoute.stops[firstStopId] || {
+                              title: firstStopId,
+                            }
+                          ).title
+                        }
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Box> 
             </Grid>
             <Grid item xs>
-              <FormControl className={classes.formControl}>
-                <InputLabel htmlFor="tostop">To Stop</InputLabel>
-                <Select
+              <Box ml={1}>
+                <LocationOn fontSize="small" htmlColor="black"/>
+                <FormControl className={classes.formControl}>
+                  <InputLabel htmlFor="tostop">To Stop</InputLabel>
+                  <Select
                   value={graphParams.endStopId || 1}
                   onChange={onSelectSecondStop}
                   input={<Input name="stop" id="tostop" />}
-                >
-                  {(secondStopList || []).map(secondStopId => (
-                    <MenuItem key={secondStopId} value={secondStopId}>
-                      {
-                        (
-                          selectedRoute.stops[secondStopId] || {
-                            title: secondStopId,
-                          }
-                        ).title
-                      }
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
+                  >
+                    {(secondStopList || []).map(secondStopId => (
+                      <MenuItem key={secondStopId} value={secondStopId}>
+                        {
+                          (
+                            selectedRoute.stops[secondStopId] || {
+                              title: secondStopId,
+                            }
+                          ).title
+                        }
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Box>
             </Grid>
           </Grid>
         ) : null}

--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -12,8 +12,9 @@ import Select from '@material-ui/core/Select';
 import Grid from '@material-ui/core/Grid';
 import { handleGraphParams } from '../actions';
 import { ROUTE, DIRECTION, FROM_STOP, TO_STOP, Path } from '../routeUtil';
-import StartStopIcon from '@material-ui/icons/LocationOn';
+import StartStopIcon from '@material-ui/icons/DirectionsTransit';
 import EndStopIcon from '@material-ui/icons/Flag';
+import { Colors } from '../UIConstants';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -189,7 +190,7 @@ function ControlPanel(props) {
           <Grid container>
             <Grid item xs>
               <Box ml={1}>
-                <StartStopIcon fontSize="small" htmlColor="black"/>
+                <StartStopIcon fontSize="small" htmlColor={Colors.INDIGO}/>
                 <FormControl className={classes.formControl}>
                   <InputLabel htmlFor="fromstop">From Stop</InputLabel>
                   <Select
@@ -214,7 +215,7 @@ function ControlPanel(props) {
             </Grid>
             <Grid item xs>
               <Box ml={1}>
-                <EndStopIcon fontSize="small" htmlColor="black"/>
+                <EndStopIcon fontSize="small" htmlColor={Colors.INDIGO}/>
                 <FormControl className={classes.formControl}>
                   <InputLabel htmlFor="tostop">To Stop</InputLabel>
                   <Select

--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -12,8 +12,8 @@ import Select from '@material-ui/core/Select';
 import Grid from '@material-ui/core/Grid';
 import { handleGraphParams } from '../actions';
 import { ROUTE, DIRECTION, FROM_STOP, TO_STOP, Path } from '../routeUtil';
-import LocationOn from '@material-ui/icons/LocationOn';
-import TripOrigin from '@material-ui/icons/TripOrigin';
+import StartStopIcon from '@material-ui/icons/LocationOn';
+import EndStopIcon from '@material-ui/icons/Flag';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -176,7 +176,7 @@ function ControlPanel(props) {
           <Grid container>
             <Grid item xs>
               <Box ml={1}>
-                <TripOrigin fontSize="small" htmlColor="black"/>
+                <StartStopIcon fontSize="small" htmlColor="black"/>
                 <FormControl className={classes.formControl}>
                   <InputLabel htmlFor="fromstop">From Stop</InputLabel>
                   <Select
@@ -201,7 +201,7 @@ function ControlPanel(props) {
             </Grid>
             <Grid item xs>
               <Box ml={1}>
-                <LocationOn fontSize="small" htmlColor="black"/>
+                <EndStopIcon fontSize="small" htmlColor="black"/>
                 <FormControl className={classes.formControl}>
                   <InputLabel htmlFor="tostop">To Stop</InputLabel>
                   <Select

--- a/frontend/src/components/MapStops.jsx
+++ b/frontend/src/components/MapStops.jsx
@@ -10,7 +10,7 @@ import { getTripTimesFromStop } from '../helpers/precomputed';
 import { getTripPoints, getDistanceInMiles } from '../helpers/mapGeometry';
 import { STARTING_COORDINATES } from '../locationConstants';
 import { Colors } from '../UIConstants';
-import StartStopIcon from '@material-ui/icons/LocationOn';
+import StartStopIcon from '@material-ui/icons/DirectionsTransit';
 import EndStopIcon from '@material-ui/icons/Flag';
 import ReactDOMServer from 'react-dom/server';
 
@@ -54,11 +54,11 @@ class MapStops extends Component {
       
       icon = L.divIcon({
         className: 'custom-icon', // this is needed to turn off the default icon styling (blank square)
-        iconSize: [240, 22],
-        iconAnchor: [11, 11], // centers icon over position, with text to the right
+        iconSize: [240, 24],
+        iconAnchor: [12, 12], // centers icon over position, with text to the right
         html:
           
-          `<svg width="22" height="22" viewBox="-10 -10 10 10">` +
+          `<svg width="24" height="24" viewBox="-10 -10 10 10">` +
           
           // this is a larger white circle
           
@@ -66,13 +66,13 @@ class MapStops extends Component {
           
           // this is the passed in icon, which we ask React to render as html (becomes an svg object)
           
-          `</svg><div style="position:relative; top: -25px; left:1px">` +
-          ReactDOMServer.renderToString(<IconType style={{color:'black'}} fontSize={'small'}/>) +
+          `</svg><div style="position:relative; top: -26px; left:2px">` +
+          ReactDOMServer.renderToString(<IconType style={{color:Colors.INDIGO}} fontSize={'small'}/>) +
          `</div>` +
          
          // this is the stop title with a text shadow to outline it in white
          
-         `<div style="position:relative; top:-50px; left:25px; font-weight:bold; ` +
+         `<div style="position:relative; top:-50px; left:25px; font-weight:bold; color:` + Colors.INDIGO + `; ` +
          `text-shadow: -1px 1px 0 #fff,` +
          `1px 1px 0 #fff,` +
          `1px -1px 0 #fff,` +


### PR DESCRIPTION


<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->
<!--
Fixes #295. Fixes #294. Fixes #291.  Fixes #168.
-->

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

Changes the map of stops so that a larger map legend isn't needed:
- Make all stops the same indigo color
- Add "from stop" and "to stop" icons in black.  The model for this is the Google Maps UI, where these icons appear next to the corresponding form inputs as well on the map.

File level changes:
- `ControlPanel`: add "from stop" and "to stop" icons next to the pulldown menus
- `MapStops`:
  - add "to stop" and "from stop" icons to the map
  - make all other stops the same color (indigo)
  - rename `populateRouteDirection` to `populateStops`
  - move the call to `populateSpeed` out of `populateStops` so that the speed lines stay under all the stop markers of all directions
- `UIConstants`: new indigo color from the Material UI palette for stop markers.

## Screenshot

![Screen Shot 2019-10-08 at 2 32 56 PM](https://user-images.githubusercontent.com/44861283/66434973-98f65900-e9d8-11e9-80f7-0445b0ede001.png)

## Link to demo, if any

https://ot-terence.herokuapp.com
