### PR TITLE
Update CodeOwners

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -7,7 +7,7 @@
 /frontend/      @exxonvaldez @akgupta89 @ckrajewski
 
 # Backend
-/backend/ 	 @youngj @jtanquil @vicky11z
+/backend/ 	 @youngj @jtanquil
 
 # Kubernetes reviewer suggestions
 /kubernetes/    @youngj


### PR DESCRIPTION
## Proposed changes

Removes Vicky from the CODEOWNERS. She hasn't participated in 2-3 months without any notice and at this point we are unnecessarily spamming her if she has decided to drop the project.
