### PR TITLE
Remove Paper around route table and style links.

### DIFF
--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -13,9 +13,10 @@ import Typography from '@material-ui/core/Typography';
 import Paper from '@material-ui/core/Paper';
 import IconButton from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
+import { createMuiTheme } from '@material-ui/core/styles';
 import FilterListIcon from '@material-ui/icons/FilterList';
 import { connect } from 'react-redux';
-import Link from 'redux-first-router-link';
+import Navlink from 'redux-first-router-link';
 import {
   filterRoutes,
   getAllWaits,
@@ -212,10 +213,6 @@ const useStyles = makeStyles(theme => ({
     width: '100%',
     marginTop: theme.spacing(3),
   },
-  paper: {
-    width: '100%',
-    marginBottom: theme.spacing(2),
-  },
   tableWrapper: {
     overflowX: 'auto',
   },
@@ -226,6 +223,7 @@ function RouteTable(props) {
   const [order, setOrder] = React.useState('asc');
   const [orderBy, setOrderBy] = React.useState('title');
   const dense = true;
+  const theme = createMuiTheme();
 
   const { graphParams, myFetchPrecomputedWaitAndTripData } = props;
 
@@ -280,7 +278,6 @@ function RouteTable(props) {
 
   return (
     <div className={classes.root}>
-      <Paper className={classes.paper}>
         <EnhancedTableToolbar numSelected={0} />
         <div className={classes.tableWrapper}>
           <Table aria-labelledby="tableTitle" size={dense ? 'small' : 'medium'}>
@@ -307,7 +304,8 @@ function RouteTable(props) {
                       scope="row"
                       padding="none"
                     >
-                      <Link
+                      <Navlink
+                        style={{color: theme.palette.primary.dark, textDecoration: 'none'}}
                         to={{
                           type: 'ROUTESCREEN',
                           payload: {
@@ -319,7 +317,7 @@ function RouteTable(props) {
                         }}
                       >
                         {row.title}
-                      </Link>
+                      </Navlink>
                     </TableCell>
                     <TableCell
                       align="right"
@@ -354,7 +352,6 @@ function RouteTable(props) {
             </TableBody>
           </Table>
         </div>
-      </Paper>
     </div>
   );
 }


### PR DESCRIPTION
<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->

Fixes #339.

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

Remove `Paper` around route table, as this creates unnecessary borders and shadows around the table.  Style the route links using the theme's primary dark color and no underline.

## Screenshot

![Screen Shot 2019-10-22 at 11 28 23 PM](https://user-images.githubusercontent.com/44861283/67364134-c9370f00-f523-11e9-8f5a-be163369bcbb.png)

## Link to demo, if any

n/a
