### PR TITLE
Redirect HTTP to HTTPS 

### DIFF
--- a/nginx/conf.d/web.conf
+++ b/nginx/conf.d/web.conf
@@ -26,6 +26,10 @@ server {
 
     # all URLs that don't start with /frontend or /api handled by react routes
     location / {
+        if ($http_x_forwarded_proto = "http") {
+            return 301 https://$host$request_uri;
+        }
+
         rewrite ^.*$ /frontend/build/index.html last;
     }
 }


### PR DESCRIPTION
Fixes #162 

## Proposed changes
Adds a rule to nginx config to to redirect to HTTPS if the "X-Forwarded-Proto" header is "http"

## Testing

Unfortunately, the heroku deployment does not use nginx. However, you can verify this locally.

First, start the application using the prod configuration:
```
docker-compose -f docker-compose.prod.yml
```

In a separate terminal, run:
```
curl -v -H 'x-forwarded-proto: https' http://localhost:8080
```

Expected output:

```
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET / HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.64.1
> Accept: */*
> x-forwarded-proto: http
>
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.16.0
< Date: Thu, 24 Oct 2019 03:22:47 GMT
< Content-Type: text/html
< Content-Length: 169
< Connection: keep-alive
< Location: https://localhost:8080/
<
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx/1.16.0</center>
</body>
</html>
* Connection #0 to host localhost left intact
* Closing connection 0
~ $ curl -v -H 'x-forwarded-proto: http' http://localhost:8080
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET / HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.64.1
> Accept: */*
> x-forwarded-proto: http
>
< HTTP/1.1 301 Moved Permanently
< Server: nginx/1.16.0
< Date: Thu, 24 Oct 2019 03:23:44 GMT
< Content-Type: text/html
< Content-Length: 169
< Connection: keep-alive
< Location: https://localhost/
<
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx/1.16.0</center>
</body>
</html>
```

GCP does pass `X-Forwarded-Proto`.
