### PR TITLE
Minor bug fix for MapStops on Safari

### DIFF
--- a/frontend/src/components/MapStops.jsx
+++ b/frontend/src/components/MapStops.jsx
@@ -89,7 +89,7 @@ class MapStops extends Component {
         iconSize: [20, 20],
         iconAnchor: [10, 10], // centers icon over position, with text to the right
         html:
-          `<svg viewBox="-10 -10 10 10" transform="rotate(${rotation} 0 0)">` +
+          `<svg viewBox="-10 -10 10 10"><g transform="rotate(${rotation} -5 -5)">` +
           
           // First we draw a white circle
           
@@ -99,6 +99,7 @@ class MapStops extends Component {
           
           `<polyline points="-5.5,-6 -4,-5 -5.5,-4" stroke-linecap="round" stroke-linejoin="round" stroke="${
             Colors.INDIGO}" stroke-width="0.6" fill="none"/>` +
+          `</g>` +
           `</svg>`, 
       });
 

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -10,7 +10,6 @@ import TableRow from '@material-ui/core/TableRow';
 import TableSortLabel from '@material-ui/core/TableSortLabel';
 import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
-import Paper from '@material-ui/core/Paper';
 import IconButton from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
 import { createMuiTheme } from '@material-ui/core/styles';


### PR DESCRIPTION
<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->
<!--
Fixes #1234. Fixes #2345. Fixes #3456.
-->

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

- MapStops:  implement svg rotation using \<g> for compatibility with macOS/iOS Safari  (Chrome and Firefox implement `transform` for the `svg` tag, which is an SVG 2 feature.  https://stackoverflow.com/questions/48248512/svg-transform-rotate180-does-not-work-in-safari-11
- RouteTable:  remove unused import

## Screenshot

n/a

## Link to demo, if any

n/a
