### PR TITLE
update backend to use new tryn-api

### DIFF
--- a/backend/models/eclipses.py
+++ b/backend/models/eclipses.py
@@ -18,7 +18,6 @@ def produce_buses(route_state: dict) -> pd.DataFrame:
             .reindex(['RAW_TIME', 'VID', 'LAT', 'LON', 'DID', 'AGE'], axis='columns')
 
     # adjust each observation time for the number of seconds old the GPS location was when the observation was recorded
-    # and convert time from milliseconds since Unix epoch to seconds since Unix epoch
     buses['TIME'] = (buses['RAW_TIME'] - buses['AGE'].fillna(0)) #.astype(np.int64)
 
     buses = buses.drop(['RAW_TIME','AGE'], axis=1)

--- a/backend/models/eclipses.py
+++ b/backend/models/eclipses.py
@@ -19,7 +19,7 @@ def produce_buses(route_state: dict) -> pd.DataFrame:
 
     # adjust each observation time for the number of seconds old the GPS location was when the observation was recorded
     # and convert time from milliseconds since Unix epoch to seconds since Unix epoch
-    buses['TIME'] = (buses['RAW_TIME'].astype(np.int64) - buses['AGE'].fillna(0)) #.astype(np.int64)
+    buses['TIME'] = (buses['RAW_TIME'] - buses['AGE'].fillna(0)) #.astype(np.int64)
 
     buses = buses.drop(['RAW_TIME','AGE'], axis=1)
     buses = buses.sort_values('TIME', axis=0)

--- a/backend/models/eclipses.py
+++ b/backend/models/eclipses.py
@@ -7,21 +7,21 @@ from . import nextbus, util
 
 def produce_buses(route_state: dict) -> pd.DataFrame:
     buses = pd.io.json.json_normalize(route_state,
-                                      record_path=['routeStates', 'vehicles'],
-                                      meta=[['routeStates', 'vtime']]) \
+                                      record_path=['states', 'vehicles'],
+                                      meta=[['states', 'timestamp']]) \
             .rename(columns={'lat': 'LAT',
                              'lon': 'LON',
                              'vid': 'VID',
                              'did': 'DID',
                              'secsSinceReport': 'AGE',
-                             'routeStates.vtime': 'RAW_TIME_MS'}) \
-            .reindex(['RAW_TIME_MS', 'VID', 'LAT', 'LON', 'DID', 'AGE'], axis='columns')
+                             'states.timestamp': 'RAW_TIME'}) \
+            .reindex(['RAW_TIME', 'VID', 'LAT', 'LON', 'DID', 'AGE'], axis='columns')
 
     # adjust each observation time for the number of seconds old the GPS location was when the observation was recorded
     # and convert time from milliseconds since Unix epoch to seconds since Unix epoch
-    buses['TIME'] = (np.round(buses['RAW_TIME_MS'].astype(np.int64)/1000) - buses['AGE'].fillna(0)) #.astype(np.int64)
+    buses['TIME'] = (buses['RAW_TIME'].astype(np.int64) - buses['AGE'].fillna(0)) #.astype(np.int64)
 
-    buses = buses.drop(['RAW_TIME_MS','AGE'], axis=1)
+    buses = buses.drop(['RAW_TIME','AGE'], axis=1)
     buses = buses.sort_values('TIME', axis=0)
 
     return buses

--- a/backend/models/trynapi.py
+++ b/backend/models/trynapi.py
@@ -125,16 +125,16 @@ def get_cache_path(agency_id: str, d: date, start_time, end_time, route_id) -> s
         raise Exception(f"Invalid route id: {route_id}")
 
     source_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-    return os.path.join(source_dir, 'data', f"state_{agency_id}/{str(d)}/state_{agency_id}_{route_id}_{int(start_time)}_{int(end_time)}.json")
+    return os.path.join(source_dir, 'data', f"state_v2_{agency_id}/{str(d)}/state_{agency_id}_{route_id}_{int(start_time)}_{int(end_time)}.json")
 
 def get_state_raw(agency, start_time, end_time, route_ids):
     tryn_agency = 'muni' if agency == 'sf-muni' else agency
 
-    params = f'state(agency: {json.dumps(tryn_agency)}, startTime: {json.dumps(str(int(start_time)))}, endTime: {json.dumps(str(int(end_time)))}, routes: {json.dumps(route_ids)})'
+    params = f'state(agencyId: {json.dumps(tryn_agency)}, startTime: {json.dumps(int(start_time))}, endTime: {json.dumps(int(end_time))}, routes: {json.dumps(route_ids)})'
 
     query = f"""{{
        {params} {{
-        agency
+        agencyId
         startTime
         routes {{
           routeId

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - ./backend:/app/backend
     environment:
       FLASK_DEBUG: 1
+      TRYNAPI_URL: http://34.67.128.233
   react-dev:
     container_name: metrics-react-dev
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - ./backend:/app/backend
     environment:
       FLASK_DEBUG: 1
-      TRYNAPI_URL: http://34.67.128.233
+      TRYNAPI_URL: http://tryn-api.opentransit.city
   react-dev:
     container_name: metrics-react-dev
     build:


### PR DESCRIPTION
Updates metrics-mvp to support tryn-api changes in https://github.com/trynmaps/tryn-api/pull/46 with timestamps in seconds, exclusive endTime parameter, and some different field names. Will need to also update the default tryn-api URL before merging.