### PR TITLE
Attempt at clipping isochrone overlap to service area

### DIFF
--- a/frontend/src/helpers/mapGeometry.js
+++ b/frontend/src/helpers/mapGeometry.js
@@ -98,3 +98,38 @@ export function isInServiceArea(latLng) {
     return turf.booleanWithin(point, feature);
   });
 }
+
+// Clips any geoJson to the service area.
+// For all geoJson Features, check each Feature in the ServiceArea.
+// If the geoJson feature is completely enclosed in the serviceArea, retain the feature
+// If not, clip it.
+export function clipGeoJsonToServiceArea(geoJson) {
+
+  const geoJsonFeatures = turf.flatten(geoJson).features;
+  var outputGeoJson = {
+    "type": "FeatureCollection",
+    "features": []
+  };
+
+  for (var i = geoJsonFeatures.length - 1; i >= 0; i--) {
+    var geo1 = geoJsonFeatures[i];
+    for (var j = ServiceArea.features.length - 1; j >= 0; j--) {
+      var geo2 = ServiceArea.features[j];
+      if (turf.booleanWithin(geo1, geo2)) {
+        outputGeoJson.features.push(geo1);
+      }
+       else {
+        try {
+          var result = turf.intersect(geo1, geo2);
+          if (result) {
+            result.properties = geo1.properties;
+            outputGeoJson.features.push(result);
+          }
+        } catch (TopologyError) {
+          outputGeoJson.features.push(geo1);
+        }
+      }
+    }
+  }
+  return outputGeoJson;
+}

--- a/frontend/src/screens/Isochrone.jsx
+++ b/frontend/src/screens/Isochrone.jsx
@@ -12,7 +12,7 @@ import DateTimePanel from '../components/DateTimePanel';
 import { fetchRoutes } from '../actions';
 import { DefaultDisabledRoutes, routesUrl } from '../locationConstants';
 import { metricsBaseURL } from '../config';
-import { getTripPoints, isInServiceArea } from '../helpers/mapGeometry';
+import { getTripPoints, isInServiceArea, clipGeoJsonToServiceArea } from '../helpers/mapGeometry';
 
 import './Isochrone.css';
 
@@ -173,7 +173,7 @@ class Isochrone extends React.Component {
     const layerOptions = tripMinOptions[`${tripMin}`] || defaultLayerOptions;
 
     const diffLayer = L.geoJson(
-      geoJson,
+      clipGeoJsonToServiceArea(geoJson),
       Object.assign(
         { bubblingMouseEvents: false, fillOpacity: 0.4, stroke: false },
         layerOptions,
@@ -211,6 +211,10 @@ class Isochrone extends React.Component {
   }
 
   showTripInfo(endLatLng, reachableCircles) {
+    if (!isInServiceArea(endLatLng)) {
+      return;
+    }
+
     this.setState({ endLatLng });
 
     const map = this.mapRef.current.leafletElement;


### PR DESCRIPTION
Doesn't fix #338.

We use turf's geoJson processing tools to clip all the geoJson as it is added to the layer. This is slow, and buggy when malformed/self-intersecting polygons are passed (which they are).

This commit also stops you from clicking a second point to set an endLatLng that's outside the service area (i.e. the sea).

<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->
<!--
Fixes #1234. Fixes #2345. Fixes #3456.
-->

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

- Adds an isInServiceArea check to endLatLng at the start of the showTripInfo function in Isochrone.jsx.
- Adds a clipGeoJsonToServiceArea to the end of mapGeometry.js which clips any geoJson given, returning unclipped geoJson if  a TopologyError is thrown (for now) to check why that's happening


Heroku demo to follow

