### PR TITLE
Hover over stops - faster

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,3 +1,7 @@
+:root {
+  --stop-name: "";
+}
+
 .App {
   text-align: center;
 }
@@ -57,4 +61,21 @@
     max-width:180px;
     padding:8px;
     opacity:1.0;
+}
+
+.on-hover > svg {
+  transform: scale(1.6);
+}
+
+.on-hover::after {
+  z-index: 1000;
+  content: var(--stop-name);
+  position: absolute;
+  width: 240px;
+  top: 1px;
+  left: 23px;
+  font-weight: bold;
+  color: #5c6bc0;
+  text-shadow: -1px 1px 0 #fff, 1px 1px 0 #fff, 1px -1px 0 #fff,
+    -1px -1px 0 #fff;
 }

--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -132,19 +132,25 @@ function ControlPanel(props) {
       endStopId: null,
     });
   }
-
-  function handleMouseOver(node, title) {
+  /**
+   * Handle mouseover event on Select TO & From dropdown list item.
+   */
+  function handleItemMouseOver(node, title) {
     if (node && allowHover) {
       node.classList.add('on-hover');
       node.style.setProperty('--stop-name', `"${title}"`);
     }
   }
-
-  function handleMouseOut(node) {
+  /**
+   * Handle mouseout event on Select TO & From dropdown list item.
+   */
+  function handleItemMouseOut(node) {
     node && node.classList.remove('on-hover');
   }
-
-  function handleOnClose() {
+  /**
+   * Handle Select component close
+   */
+  function handleSelectClose() {
     setAllowHover(false);
     const nodeList = document.querySelectorAll('.on-hover');
     nodeList.forEach(node => node.classList.remove('on-hover'));
@@ -216,7 +222,7 @@ function ControlPanel(props) {
                     onChange={onSelectFirstStop}
                     input={<Input name="stop" id="fromstop" />}
                     onOpen={() => setAllowHover(true)}
-                    onClose={handleOnClose}
+                    onClose={handleSelectClose}
                   >
                     {(selectedDirection.stops || []).map(firstStopId => {
                       const icon = document.querySelector(`.id${firstStopId}`);
@@ -229,10 +235,10 @@ function ControlPanel(props) {
                         <MenuItem
                           key={firstStopId}
                           value={firstStopId}
-                          onMouseOver={() => handleMouseOver(icon, title)}
-                          onFocus={() => handleMouseOver(icon, title)}
-                          onMouseOut={() => handleMouseOut(icon)}
-                          onBlur={() => handleMouseOut(icon)}
+                          onMouseOver={() => handleItemMouseOver(icon, title)}
+                          onFocus={() => handleItemMouseOver(icon, title)}
+                          onMouseOut={() => handleItemMouseOut(icon)}
+                          onBlur={() => handleItemMouseOut(icon)}
                         >
                           {title}
                         </MenuItem>
@@ -252,7 +258,7 @@ function ControlPanel(props) {
                     onChange={onSelectSecondStop}
                     input={<Input name="stop" id="tostop" />}
                     onOpen={() => setAllowHover(true)}
-                    onClose={handleOnClose}
+                    onClose={handleSelectClose}
                   >
                     {(secondStopList || []).map(secondStopId => {
                       const icon = document.querySelector(`.id${secondStopId}`);
@@ -265,10 +271,10 @@ function ControlPanel(props) {
                         <MenuItem
                           key={secondStopId}
                           value={secondStopId}
-                          onMouseOver={() => handleMouseOver(icon, title)}
-                          onFocus={() => handleMouseOver(icon, title)}
-                          onMouseOut={() => handleMouseOut(icon)}
-                          onBlur={() => handleMouseOut(icon)}
+                          onMouseOver={() => handleItemMouseOver(icon, title)}
+                          onFocus={() => handleItemMouseOver(icon, title)}
+                          onMouseOut={() => handleItemMouseOut(icon)}
+                          onBlur={() => handleItemMouseOut(icon)}
                         >
                           {title}
                         </MenuItem>

--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/prop-types */
-import React from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
 // import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
@@ -10,10 +10,10 @@ import MenuItem from '@material-ui/core/MenuItem';
 import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
 import Grid from '@material-ui/core/Grid';
-import { handleGraphParams } from '../actions';
-import { ROUTE, DIRECTION, FROM_STOP, TO_STOP, Path } from '../routeUtil';
 import StartStopIcon from '@material-ui/icons/DirectionsTransit';
 import EndStopIcon from '@material-ui/icons/Flag';
+import { handleGraphParams } from '../actions';
+import { ROUTE, DIRECTION, FROM_STOP, TO_STOP, Path } from '../routeUtil';
 import { Colors } from '../UIConstants';
 
 const useStyles = makeStyles(theme => ({
@@ -30,6 +30,7 @@ const useStyles = makeStyles(theme => ({
 function ControlPanel(props) {
   const { routes, graphParams } = props;
   let secondStopList = [];
+  const [allowHover, setAllowHover] = useState(false);
 
   /**
    * Sets the direction
@@ -132,6 +133,23 @@ function ControlPanel(props) {
     });
   }
 
+  function handleMouseOver(node, title) {
+    if (node && allowHover) {
+      node.classList.add('on-hover');
+      node.style.setProperty('--stop-name', `"${title}"`);
+    }
+  }
+
+  function handleMouseOut(node) {
+    node && node.classList.remove('on-hover');
+  }
+
+  function handleOnClose() {
+    setAllowHover(false);
+    const nodeList = document.querySelectorAll('.on-hover');
+    nodeList.forEach(node => node.classList.remove('on-hover'));
+  }
+
   let selectedDirection = null;
   if (selectedRoute && selectedRoute.directions && graphParams.directionId) {
     selectedDirection = selectedRoute.directions.find(
@@ -190,50 +208,72 @@ function ControlPanel(props) {
           <Grid container>
             <Grid item xs>
               <Box ml={1}>
-                <StartStopIcon fontSize="small" htmlColor={Colors.INDIGO}/>
+                <StartStopIcon fontSize="small" htmlColor={Colors.INDIGO} />
                 <FormControl className={classes.formControl}>
                   <InputLabel htmlFor="fromstop">From Stop</InputLabel>
                   <Select
-                  value={graphParams.startStopId || 1}
-                  onChange={onSelectFirstStop}
-                  input={<Input name="stop" id="fromstop" />}
+                    value={graphParams.startStopId || 1}
+                    onChange={onSelectFirstStop}
+                    input={<Input name="stop" id="fromstop" />}
+                    onOpen={() => setAllowHover(true)}
+                    onClose={handleOnClose}
                   >
-                    {(selectedDirection.stops || []).map(firstStopId => (
-                      <MenuItem key={firstStopId} value={firstStopId}>
-                        {
-                          (
-                            selectedRoute.stops[firstStopId] || {
-                              title: firstStopId,
-                            }
-                          ).title
+                    {(selectedDirection.stops || []).map(firstStopId => {
+                      const icon = document.querySelector(`.id${firstStopId}`);
+                      const title = (
+                        selectedRoute.stops[firstStopId] || {
+                          title: firstStopId,
                         }
-                      </MenuItem>
-                    ))}
+                      ).title;
+                      return (
+                        <MenuItem
+                          key={firstStopId}
+                          value={firstStopId}
+                          onMouseOver={() => handleMouseOver(icon, title)}
+                          onFocus={() => handleMouseOver(icon, title)}
+                          onMouseOut={() => handleMouseOut(icon)}
+                          onBlur={() => handleMouseOut(icon)}
+                        >
+                          {title}
+                        </MenuItem>
+                      );
+                    })}
                   </Select>
                 </FormControl>
-              </Box> 
+              </Box>
             </Grid>
             <Grid item xs>
               <Box ml={1}>
-                <EndStopIcon fontSize="small" htmlColor={Colors.INDIGO}/>
+                <EndStopIcon fontSize="small" htmlColor={Colors.INDIGO} />
                 <FormControl className={classes.formControl}>
                   <InputLabel htmlFor="tostop">To Stop</InputLabel>
                   <Select
-                  value={graphParams.endStopId || 1}
-                  onChange={onSelectSecondStop}
-                  input={<Input name="stop" id="tostop" />}
+                    value={graphParams.endStopId || 1}
+                    onChange={onSelectSecondStop}
+                    input={<Input name="stop" id="tostop" />}
+                    onOpen={() => setAllowHover(true)}
+                    onClose={handleOnClose}
                   >
-                    {(secondStopList || []).map(secondStopId => (
-                      <MenuItem key={secondStopId} value={secondStopId}>
-                        {
-                          (
-                            selectedRoute.stops[secondStopId] || {
-                              title: secondStopId,
-                            }
-                          ).title
+                    {(secondStopList || []).map(secondStopId => {
+                      const icon = document.querySelector(`.id${secondStopId}`);
+                      const title = (
+                        selectedRoute.stops[secondStopId] || {
+                          title: secondStopId,
                         }
-                      </MenuItem>
-                    ))}
+                      ).title;
+                      return (
+                        <MenuItem
+                          key={secondStopId}
+                          value={secondStopId}
+                          onMouseOver={() => handleMouseOver(icon, title)}
+                          onFocus={() => handleMouseOver(icon, title)}
+                          onMouseOut={() => handleMouseOut(icon)}
+                          onBlur={() => handleMouseOut(icon)}
+                        >
+                          {title}
+                        </MenuItem>
+                      );
+                    })}
                   </Select>
                 </FormControl>
               </Box>

--- a/frontend/src/components/MapStops.jsx
+++ b/frontend/src/components/MapStops.jsx
@@ -85,7 +85,7 @@ class MapStops extends Component {
       // svg "v" shape rotated by the given rotation value.
 
       icon = L.divIcon({
-        className: 'custom-icon', // this is needed to turn off the default icon styling (blank square)
+        className: `custom-icon ${stop.sid}`, // this is needed to turn off the default icon styling (blank square)
         iconSize: [20, 20],
         iconAnchor: [10, 10], // centers icon over position, with text to the right
         html:

--- a/frontend/src/components/MapStops.jsx
+++ b/frontend/src/components/MapStops.jsx
@@ -85,7 +85,7 @@ class MapStops extends Component {
       // svg "v" shape rotated by the given rotation value.
 
       icon = L.divIcon({
-        className: `custom-icon id${stop.sid}`, // this is needed to turn off the default icon styling (blank square)
+        className: `id${stop.sid}`, // this is needed to turn off the default icon styling (blank square)
         iconSize: [20, 20],
         iconAnchor: [10, 10], // centers icon over position, with text to the right
         html:

--- a/frontend/src/components/MapStops.jsx
+++ b/frontend/src/components/MapStops.jsx
@@ -85,7 +85,7 @@ class MapStops extends Component {
       // svg "v" shape rotated by the given rotation value.
 
       icon = L.divIcon({
-        className: `custom-icon ${stop.sid}`, // this is needed to turn off the default icon styling (blank square)
+        className: `custom-icon id${stop.sid}`, // this is needed to turn off the default icon styling (blank square)
         iconSize: [20, 20],
         iconAnchor: [10, 10], // centers icon over position, with text to the right
         html:


### PR DESCRIPTION
Fixes #272. Improves PR #362.

Use a different approach to create "hover over stops" effect.  Instead of letting React rerender the whole routes (see PR #362 for detailed performance issue), it adds an "on-hover" className to the stop that being hovered. The "on-hover" class uses a pseudo class **.on-hover::before** to add stop title.

Proposed changes
When you hover over entries in the To & From Dropdowns, the stop/route on the map will update correspondingly. So you know exactly where the stop you're hovering is on the map.

Link to demo, if any
https://open-transit.herokuapp.com/route/M/direction/M____O_D00/fromStop/6996/toStop/7125