### PR TITLE
Wording fixes.

### DIFF
--- a/frontend/src/UIConstants.js
+++ b/frontend/src/UIConstants.js
@@ -25,6 +25,7 @@ export const CHART_COLORS = [Colors.GRAY, Colors.PURPLE];
 // long the trip will "usually" take.  So for 90th percentile
 // this would be the historic performance 9 times out of 10.
 export const PLANNING_PERCENTILE = 90;
+export const TENTH_PERCENTILE = 10;
 
 // a commonly used style option for react-vis
 // Crosshairs (hovers) where we don't want a crosshair line

--- a/frontend/src/components/InfoScoreCard.jsx
+++ b/frontend/src/components/InfoScoreCard.jsx
@@ -15,7 +15,7 @@ import Rating from '@material-ui/lab/Rating';
 import Box from '@material-ui/core/Box';
 import {
   quartileBackgroundColor,
-  quartileForegroundColor,
+  quartileContrastColor,
 } from '../helpers/routeCalculations';
 
 /**
@@ -60,7 +60,7 @@ export default function InfoScoreCard(props) {
         ? quartileBackgroundColor(myGrades[myGradeName] / 100.0)
         : 'gray',
       color: myGrades
-        ? quartileForegroundColor(myGrades[myGradeName] / 100.0)
+        ? quartileContrastColor(myGrades[myGradeName] / 100.0)
         : 'black',
       margin: 4,
     };

--- a/frontend/src/components/InfoScoreCard.jsx
+++ b/frontend/src/components/InfoScoreCard.jsx
@@ -38,6 +38,7 @@ export default function InfoScoreCard(props) {
   const useStyles = makeStyles(theme => ({
     popover: {
       padding: theme.spacing(2),
+      maxWidth: 500,
     },
   }));
 

--- a/frontend/src/components/InfoScoreLegend.jsx
+++ b/frontend/src/components/InfoScoreLegend.jsx
@@ -8,7 +8,7 @@ import { Table, TableBody, TableCell, TableRow } from '@material-ui/core';
 
 import {
   quartileBackgroundColor,
-  quartileForegroundColor,
+  quartileContrastColor,
 } from '../helpers/routeCalculations';
 
 export default function InfoScoreLegend(props) {
@@ -24,7 +24,7 @@ export default function InfoScoreLegend(props) {
               <TableCell
                 align="right"
                 style={{
-                  color: quartileForegroundColor(row.value / 100),
+                  color: quartileContrastColor(row.value / 100),
                   backgroundColor: quartileBackgroundColor(row.value / 100),
                 }}
               >

--- a/frontend/src/components/InfoTripSummary.jsx
+++ b/frontend/src/components/InfoTripSummary.jsx
@@ -284,7 +284,7 @@ export default function InfoTripSummary(props) {
             <Grid container spacing={4}>
               {/* spacing doesn't work exactly right here, just pads the Papers */}
               <Grid item xs component={Paper} className={classes.uncolored}>
-                <Typography variant="overline">typical journey</Typography>
+                <Typography variant="overline">Typical journey</Typography>
                 <br />
 
                 <Typography variant="h3" display="inline">
@@ -318,7 +318,7 @@ export default function InfoTripSummary(props) {
                 <br />
 
                 <Typography variant="h3" display="inline">
-                  &lt;{planningWait + planningTravel}
+                  {planningWait + planningTravel}
                 </Typography>
                 <Typography variant="h5" display="inline">
                   &nbsp;min

--- a/frontend/src/components/RouteSummary.jsx
+++ b/frontend/src/components/RouteSummary.jsx
@@ -18,7 +18,6 @@ import {
   computeGrades,
   metersToMiles,
 } from '../helpers/routeCalculations';
-import { PLANNING_PERCENTILE } from '../UIConstants';
 
 /**
  * Renders an "nyc bus stats" style summary of a route and direction.
@@ -99,15 +98,15 @@ function RouteSummary(props) {
               <TableCell align="right">{grades.medianWaitScore}</TableCell>
             </TableRow>
             <TableRow>
-              <TableCell>20 min wait</TableCell>
+              <TableCell>Long wait probability</TableCell>
               <TableCell align="right">{grades.longWaitScore}</TableCell>
             </TableRow>
             <TableRow>
-              <TableCell>Median speed</TableCell>
+              <TableCell>Average speed</TableCell>
               <TableCell align="right"> {grades.speedScore}</TableCell>
             </TableRow>
             <TableRow>
-              <TableCell>Travel variance</TableCell>
+              <TableCell>Travel time variability</TableCell>
               <TableCell align="right"> {grades.travelVarianceScore}</TableCell>
             </TableRow>
           </TableBody>
@@ -136,7 +135,9 @@ function RouteSummary(props) {
 
   const popoverContentLongWait = grades ? (
     <Fragment>
-      20 min wait probability of{' '}
+      Long wait probability is the chance a rider has of a wait of twenty minutes or
+      longer after arriving randomly at a stop.
+      Probability of{' '}
       {(longWait * 100).toFixed(1) /* be more precise than card */}% gets a
       score of {grades.longWaitScore}.
       <Box pt={2}>
@@ -155,7 +156,8 @@ function RouteSummary(props) {
 
   const popoverContentSpeed = grades ? (
     <Fragment>
-      Median speed of{' '}
+      This is the average of the speeds for median end to end trips, in all directions.
+      Average speed of{' '}
       {speed === null || Number.isNaN(speed) ? '--' : speed.toFixed(1)} mph gets
       a score of {grades.speedScore}.
       <Box pt={2}>
@@ -172,12 +174,12 @@ function RouteSummary(props) {
     </Fragment>
   ) : null;
 
-  const popoverContentTravelVariance = grades ? (
+  const popoverContentTravelVariability = grades ? (
     <Fragment>
-      Variance is the travel time above the median time, for 90% of trips.
-      In other words, most trips will take up to this much additional travel time.
-      Variance of{' '}
-      {variability === null ? '--' : variability.toFixed(1)} min gets a score of{' '}
+      Travel time variability is the 90th percentile end to end travel time minus the 10th percentile
+      travel time.  This measures how much extra travel time is needed for some trips.
+      Variability of{' '}
+      {variability === null ? '--' : '\u00b1' + variability.toFixed(1)} min gets a score of{' '}
       {grades.travelVarianceScore}.
       <Box pt={2}>
         <InfoScoreLegend
@@ -231,7 +233,7 @@ function RouteSummary(props) {
           <InfoScoreCard
             grades={wait && grades ? grades : null}
             gradeName="longWaitScore"
-            title="20 Min Wait"
+            title="Long Wait %"
             largeValue={(longWait * 100).toFixed(0)}
             smallValue="%"
             bottomContent={
@@ -247,7 +249,7 @@ function RouteSummary(props) {
           <InfoScoreCard
             grades={speed && grades ? grades : null}
             gradeName="speedScore"
-            title="Median Speed"
+            title="Average Speed"
             largeValue={
               speed === null || Number.isNaN(speed) ? '--' : speed.toFixed(0)
             }
@@ -258,7 +260,7 @@ function RouteSummary(props) {
                   ? `#${speedRanking} of ${allSpeeds.length} for fastest`
                   : null}
                 <br />
-                Length: {metersToMiles(dist).toFixed(1)} miles
+                {metersToMiles(dist).toFixed(1)} miles
               </Fragment>
             }
             popoverContent={popoverContentSpeed}
@@ -267,11 +269,11 @@ function RouteSummary(props) {
           <InfoScoreCard
             grades={speed && grades ? grades : null}
             gradeName="travelVarianceScore"
-            title="Travel Variance"
-            largeValue={variability === null ? '--' : variability.toFixed(0)}
+            title="Travel Time Variability"
+            largeValue={variability === null ? '--' : '\u00b1' + variability.toFixed(0)}
             smallValue="&nbsp;min"
-            bottomContent={`In ${PLANNING_PERCENTILE}% of trips`}
-            popoverContent={popoverContentTravelVariance}
+            bottomContent="&nbsp;"
+            popoverContent={popoverContentTravelVariability}
           />
 
           <TravelTimeChart />

--- a/frontend/src/components/RouteSummary.jsx
+++ b/frontend/src/components/RouteSummary.jsx
@@ -89,13 +89,13 @@ function RouteSummary(props) {
 
   const popoverContentTotalScore = grades ? (
     <Fragment>
-      Trip score of {grades.totalScore} is the average of the following
+      Route score of {grades.totalScore} is the average of the following
       subscores:
       <Box pt={2}>
         <Table>
           <TableBody>
             <TableRow>
-              <TableCell>Median Wait</TableCell>
+              <TableCell>Median wait</TableCell>
               <TableCell align="right">{grades.medianWaitScore}</TableCell>
             </TableRow>
             <TableRow>
@@ -107,7 +107,7 @@ function RouteSummary(props) {
               <TableCell align="right"> {grades.speedScore}</TableCell>
             </TableRow>
             <TableRow>
-              <TableCell>Extra travel</TableCell>
+              <TableCell>Travel variance</TableCell>
               <TableCell align="right"> {grades.travelVarianceScore}</TableCell>
             </TableRow>
           </TableBody>
@@ -174,7 +174,9 @@ function RouteSummary(props) {
 
   const popoverContentTravelVariance = grades ? (
     <Fragment>
-      Extra travel time of{' '}
+      Variance is the travel time above the median time, for 90% of trips.
+      In other words, most trips will take up to this much additional travel time.
+      Variance of{' '}
       {variability === null ? '--' : variability.toFixed(1)} min gets a score of{' '}
       {grades.travelVarianceScore}.
       <Box pt={2}>
@@ -265,7 +267,7 @@ function RouteSummary(props) {
           <InfoScoreCard
             grades={speed && grades ? grades : null}
             gradeName="travelVarianceScore"
-            title="Extra Travel"
+            title="Travel Variance"
             largeValue={variability === null ? '--' : variability.toFixed(0)}
             smallValue="&nbsp;min"
             bottomContent={`In ${PLANNING_PERCENTILE}% of trips`}

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -1,7 +1,8 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { lighten, makeStyles } from '@material-ui/core/styles';
+import Popover from '@material-ui/core/Popover';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
 import TableCell from '@material-ui/core/TableCell';
@@ -14,6 +15,7 @@ import IconButton from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
 import { createMuiTheme } from '@material-ui/core/styles';
 import FilterListIcon from '@material-ui/icons/FilterList';
+import InfoIcon from '@material-ui/icons/InfoOutlined';
 import { connect } from 'react-redux';
 import Navlink from 'redux-first-router-link';
 import {
@@ -104,7 +106,7 @@ const headRows = [
     id: 'variability',
     numeric: true,
     disablePadding: false,
-    label: 'Extra Travel (min)',
+    label: 'Travel Variance (min)',
   },
 ];
 
@@ -168,11 +170,25 @@ const useToolbarStyles = makeStyles(theme => ({
   title: {
     flex: '0 0 auto',
   },
+  popover: {
+    padding: theme.spacing(2),
+    maxWidth: 500,
+  },
 }));
 
 const EnhancedTableToolbar = props => {
   const classes = useToolbarStyles();
   const { numSelected } = props;
+  
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  function handleClick(event) {
+    setAnchorEl(event.currentTarget);
+  }
+
+  function handleClose() {
+    setAnchorEl(null);
+  }  
 
   return (
     <Toolbar
@@ -188,6 +204,9 @@ const EnhancedTableToolbar = props => {
         ) : (
           <Typography variant="h6" id="tableTitle">
             Routes
+                  <IconButton size="small" onClick={handleClick}>
+                    <InfoIcon fontSize="small" />
+                  </IconButton>
           </Typography>
         )}
       </div>
@@ -199,6 +218,36 @@ const EnhancedTableToolbar = props => {
           </IconButton>
         </Tooltip>
       </div>
+
+      <Popover
+        open={Boolean(anchorEl)}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+      >
+        <div className={classes.popover}><b>Score</b> is the average of subscores (0-100) for median wait,
+          20 minute wait probability, median speed, and travel variance.  Click on a route to see its metrics
+          and explanations of how the subscores are calculated.
+          <p/>
+          <b>Wait</b> is the 50th percentile (typical) wait time between vehicles.
+          <p/>
+          The <b>20 minute wait %</b> (probability) is the chance of having a long wait after getting to a stop.
+          <p/>
+          <b>Speed</b> is the 50th percentile speed of vehicles end to end on the route, averaged
+          for all directions.
+          <p/>
+          <b>Travel variance</b> is the end to end travel time above the median travel time, for 90% of trips.
+          In other words, most trips will take up to this much additional travel time.
+        </div>
+      </Popover>
+
     </Toolbar>
   );
 };


### PR DESCRIPTION


<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->
<!--
Fixes #382. Fixes #392.
-->

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

On the stop to stop page:
- Rename "90% of trips" to "most trips (less than)"
- Add an info icon for "most trips" to explain that "most" is 90% of trips.
- Add an expanded definition of travel variance to the popover.

On the route summary:
- Add an expanded definition of travel variance to the popover.

On the route table:
- add a popover explaining the column titles.

Also on these three pages:
- Rename "extra travel" to "travel variance"
- Limit popover widths to 500px max.

## Screenshot

Stop to stop with "most trips (less than)" and "travel variance":

![Screen Shot 2019-11-18 at 7 34 39 PM](https://user-images.githubusercontent.com/44861283/69114517-7d9c5600-0a3a-11ea-96bc-cc6de06fdda1.png)



Stop to stop with travel variance popover:

![Screen Shot 2019-11-18 at 7 35 19 PM](https://user-images.githubusercontent.com/44861283/69114557-9a388e00-0a3a-11ea-883f-0e5a1a6acb88.png)



Route summary with travel variance popover:

![Screen Shot 2019-11-18 at 7 36 03 PM](https://user-images.githubusercontent.com/44861283/69114585-ae7c8b00-0a3a-11ea-8bf3-173ba94eaa89.png)



Route table, new column headings and info icon:

![Screen Shot 2019-11-18 at 7 36 50 PM](https://user-images.githubusercontent.com/44861283/69114609-c8b66900-0a3a-11ea-99fc-36200c382fdd.png)



Route table with popover:

![Screen Shot 2019-11-18 at 7 37 07 PM](https://user-images.githubusercontent.com/44861283/69114637-d370fe00-0a3a-11ea-8aaa-cb573466ce55.png)


## Link to demo, if any

n/a
