### PR TITLE
replace %REACT_APP_METRICS_BASE_URL% with empty string in production index.html file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 node_modules
 frontend/node_modules
+backend/data
 data
 venv
 .git

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV PORT 5000
 CMD gunicorn --bind 0.0.0.0:$PORT metrics-api:app
 
 FROM react-dev as react-build
-RUN cd /app/frontend && npm run build
+RUN cd /app/frontend && npm run build && sed -i 's/%REACT_APP_METRICS_BASE_URL%//g' build/index.html
 
 FROM flask AS all-in-one
 ENV METRICS_ALL_IN_ONE 1


### PR DESCRIPTION
Apparently %REACT_APP_METRICS_BASE_URL% is replaced in index.html when running the development server, but is not replaced when running `npm run build`. This caused https://muni.opentransit.city/ to stop working. To fix this, replace %REACT_APP_METRICS_BASE_URL% when building production assets in the Dockerfile.