### PR TITLE
RouteTable:  use filled Chips with light background colors and add units

### DIFF
--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -25,6 +25,7 @@ import {
   getAllSpeeds,
   getAllScores,
   quartileBackgroundColor,
+  quartileContrastColor,
 } from '../helpers/routeCalculations';
 
 import { handleGraphParams, fetchPrecomputedWaitAndTripData } from '../actions';
@@ -386,6 +387,9 @@ function RouteTable(props) {
                     >
                     <Chip
                       style={{
+                        color: quartileContrastColor(
+                          row.totalScore / 100,
+                        ),
                         backgroundColor: quartileBackgroundColor(
                           row.totalScore / 100,
                         ),
@@ -401,6 +405,9 @@ function RouteTable(props) {
                     >
                     <Chip
                       style={{
+                        color: quartileContrastColor(
+                          row.medianWaitScore / 100
+                        ),
                         backgroundColor: quartileBackgroundColor(
                           row.medianWaitScore / 100
                         ),
@@ -417,6 +424,9 @@ function RouteTable(props) {
                     >
                     <Chip
                       style={{
+                        color: quartileContrastColor(
+                          row.longWaitScore / 100,
+                        ),
                         backgroundColor: quartileBackgroundColor(
                           row.longWaitScore / 100,
                         ),
@@ -439,6 +449,9 @@ function RouteTable(props) {
                     >
                     <Chip
                       style={{
+                        color: quartileContrastColor(
+                          row.speedScore / 100,
+                        ),
                         backgroundColor: quartileBackgroundColor(
                           row.speedScore / 100,
                         ),
@@ -455,6 +468,9 @@ function RouteTable(props) {
                     >
                     <Chip
                       style={{
+                        color: quartileContrastColor(
+                          row.travelVarianceScore / 100,
+                        ),
                         backgroundColor: quartileBackgroundColor(
                           row.travelVarianceScore / 100,
                         ),

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -94,19 +94,19 @@ function getSorting(order, orderBy) {
 const headRows = [
   { id: 'title', numeric: false, disablePadding: false, label: 'Name' },
   { id: 'totalScore', numeric: true, disablePadding: true, label: 'Score' },
-  { id: 'wait', numeric: true, disablePadding: true, label: 'Median Wait (min)' },
+  { id: 'wait', numeric: true, disablePadding: true, label: 'Median Wait' },
   {
     id: 'longWait',
     numeric: true,
     disablePadding: true,
     label: 'Long Wait %',
   },
-  { id: 'speed', numeric: true, disablePadding: true, label: 'Average Speed (mph)' },
+  { id: 'speed', numeric: true, disablePadding: true, label: 'Average Speed' },
   { 
     id: 'variability',
     numeric: true,
     disablePadding: true,
-    label: 'Travel Time Variability (min)',
+    label: 'Travel Time Variability',
   },
 ];
 

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -25,7 +25,6 @@ import {
   getAllScores,
   quartileBackgroundColor,
   quartileContrastColor,
-  quartileTextColor,
 } from '../helpers/routeCalculations';
 
 import { handleGraphParams, fetchPrecomputedWaitAndTripData } from '../actions';
@@ -391,47 +390,59 @@ function RouteTable(props) {
                     </TableCell>
                     <TableCell
                       align="right"
-                      padding="none"
                       style={{
-                        color: quartileTextColor(row.medianWaitScore / 100),
+                        //color: quartileTextColor(row.medianWaitScore / 100),
+                        color: quartileContrastColor(row.medianWaitScore / 100),
+                        backgroundColor: quartileBackgroundColor(
+                          row.medianWaitScore / 100
+                        ),
                       }}
                     >
-                      {Number.isNaN(row.wait) ? '--' : row.wait.toFixed(0)}
+                      {Number.isNaN(row.wait) ? '--' : row.wait.toFixed(0) + ' min'}
                     </TableCell>
                     <TableCell
                       align="right"
-                      padding="none"
                       style={{
-                        color: quartileTextColor(row.longWaitScore / 100),
+                        //color: quartileTextColor(row.longWaitScore / 100),
+                        color: quartileContrastColor(row.longWaitScore / 100),
+                        backgroundColor: quartileBackgroundColor(
+                          row.longWaitScore / 100,
+                        ),
                       }}
                     >
                       {Number.isNaN(row.longWait)
                         ? '--'
                         : <Fragment>
-                            {(row.longWait * 100).toFixed(0)}<font style={{color:"#8a8a8a"}}>%</font>
+                            {(row.longWait * 100).toFixed(0)}{'%'}
                           </Fragment>
                       }
                     </TableCell>
                     <TableCell
                       align="right"
-                      padding="none"
                       style={{
-                        color: quartileTextColor(row.speedScore / 100),
+                        //color: quartileTextColor(row.speedScore / 100),
+                        color: quartileContrastColor(row.speedScore / 100),
+                        backgroundColor: quartileBackgroundColor(
+                          row.speedScore / 100,
+                        ),
                       }}
                     >
-                      {Number.isNaN(row.speed) ? '--' : row.speed.toFixed(0)}
+                      {Number.isNaN(row.speed) ? '--' : row.speed.toFixed(0) + ' mph'}
                     </TableCell>
                     <TableCell
                       align="right"
-                      padding="none"
                       style={{
-                        color: quartileTextColor(row.travelVarianceScore / 100),
+                        //color: quartileTextColor(row.travelVarianceScore / 100),
+                        color: quartileContrastColor(row.travelVarianceScore / 100),
+                        backgroundColor: quartileBackgroundColor(
+                          row.travelVarianceScore / 100,
+                        ),
                       }}
                     >
                       {Number.isNaN(row.variability)
                         ? '--'
                         : <Fragment>
-                            <font style={{color:"#8a8a8a"}}>{'\u00b1'} </font>{row.variability.toFixed(0)}
+                            {'\u00b1'} {row.variability.toFixed(0)}
                           </Fragment>
                       }
                     </TableCell>

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, Fragment } from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import { lighten, makeStyles } from '@material-ui/core/styles';
+import Chip from '@material-ui/core/Chip';
 import Popover from '@material-ui/core/Popover';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
@@ -24,7 +25,6 @@ import {
   getAllSpeeds,
   getAllScores,
   quartileBackgroundColor,
-  quartileContrastColor,
 } from '../helpers/routeCalculations';
 
 import { handleGraphParams, fetchPrecomputedWaitAndTripData } from '../actions';
@@ -93,7 +93,7 @@ function getSorting(order, orderBy) {
 
 const headRows = [
   { id: 'title', numeric: false, disablePadding: false, label: 'Name' },
-  { id: 'totalScore', numeric: true, disablePadding: false, label: 'Score' },
+  { id: 'totalScore', numeric: true, disablePadding: true, label: 'Score' },
   { id: 'wait', numeric: true, disablePadding: true, label: 'Median Wait (min)' },
   {
     id: 'longWait',
@@ -102,7 +102,7 @@ const headRows = [
     label: 'Long Wait %',
   },
   { id: 'speed', numeric: true, disablePadding: true, label: 'Average Speed (mph)' },
-  {
+  { 
     id: 'variability',
     numeric: true,
     disablePadding: true,
@@ -360,6 +360,7 @@ function RouteTable(props) {
                       id={labelId}
                       scope="row"
                       padding="none"
+                      style={{border:'none', paddingTop:6, paddingBottom:6}}
                     >
                       <Navlink
                         style={{color: theme.palette.primary.dark, textDecoration: 'none'}}
@@ -379,72 +380,94 @@ function RouteTable(props) {
                     </TableCell>
                     <TableCell
                       align="right"
+                      padding="none"
+                      style={{border:'none', paddingTop:6, paddingBottom:6}}
+                    >
+                    <Chip
                       style={{
-                        color: quartileContrastColor(row.totalScore / 100),
                         backgroundColor: quartileBackgroundColor(
                           row.totalScore / 100,
                         ),
                       }}
-                    >
-                      {Number.isNaN(row.totalScore) ? '--' : row.totalScore}
+                      label=
+                        {Number.isNaN(row.totalScore) ? '--' : row.totalScore}
+                    />
                     </TableCell>
                     <TableCell
                       align="right"
+                      padding="none"
+                      style={{border:'none', paddingTop:6, paddingBottom:6}}
+                    >
+                    <Chip
                       style={{
-                        //color: quartileTextColor(row.medianWaitScore / 100),
-                        color: quartileContrastColor(row.medianWaitScore / 100),
                         backgroundColor: quartileBackgroundColor(
                           row.medianWaitScore / 100
                         ),
                       }}
-                    >
-                      {Number.isNaN(row.wait) ? '--' : row.wait.toFixed(0) + ' min'}
+                      label=
+                        {Number.isNaN(row.wait) ? '--' : row.wait.toFixed(0) + ' min'}
+                    />                    
+
                     </TableCell>
                     <TableCell
                       align="right"
+                      style={{border:'none'}}
+                      padding="none"
+                    >
+                    <Chip
                       style={{
-                        //color: quartileTextColor(row.longWaitScore / 100),
-                        color: quartileContrastColor(row.longWaitScore / 100),
                         backgroundColor: quartileBackgroundColor(
                           row.longWaitScore / 100,
                         ),
                       }}
-                    >
-                      {Number.isNaN(row.longWait)
+                      label=
+                        {Number.isNaN(row.longWait)
                         ? '--'
                         : <Fragment>
                             {(row.longWait * 100).toFixed(0)}{'%'}
                           </Fragment>
                       }
+
+                    />                    
+                    
                     </TableCell>
                     <TableCell
                       align="right"
+                      padding="none"
+                      style={{border:'none', paddingTop:6, paddingBottom:6}}
+                    >
+                    <Chip
                       style={{
-                        //color: quartileTextColor(row.speedScore / 100),
-                        color: quartileContrastColor(row.speedScore / 100),
                         backgroundColor: quartileBackgroundColor(
                           row.speedScore / 100,
                         ),
                       }}
-                    >
-                      {Number.isNaN(row.speed) ? '--' : row.speed.toFixed(0) + ' mph'}
+                      label= 
+                        {Number.isNaN(row.speed) ? '--' : row.speed.toFixed(0) + ' mph'}
+
+                    />                    
                     </TableCell>
                     <TableCell
                       align="right"
+                      padding="none"
+                      style={{border:'none', paddingTop:6, paddingBottom:6}}
+                    >
+                    <Chip
                       style={{
-                        //color: quartileTextColor(row.travelVarianceScore / 100),
-                        color: quartileContrastColor(row.travelVarianceScore / 100),
                         backgroundColor: quartileBackgroundColor(
                           row.travelVarianceScore / 100,
                         ),
                       }}
-                    >
-                      {Number.isNaN(row.variability)
-                        ? '--'
-                        : <Fragment>
-                            {'\u00b1'} {row.variability.toFixed(0)}
-                          </Fragment>
-                      }
+                      label= 
+                        {Number.isNaN(row.variability)
+                          ? '--'
+                          : <Fragment>
+                              {'\u00b1'} {row.variability.toFixed(0)} min
+                            </Fragment>
+                        }
+
+                    />                    
+                    
                     </TableCell>
                   </TableRow>
                 );

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -92,7 +92,7 @@ function getSorting(order, orderBy) {
 }
 
 const headRows = [
-  { id: 'title', numeric: false, disablePadding: false, label: 'Name' },
+  { id: 'title', numeric: false, disablePadding: true, label: 'Name' },
   { id: 'totalScore', numeric: true, disablePadding: true, label: 'Score' },
   { id: 'wait', numeric: true, disablePadding: true, label: 'Median Wait' },
   {
@@ -124,6 +124,7 @@ function EnhancedTableHead(props) {
             key={row.id}
             align={row.numeric ? 'right' : 'left'}
             padding={row.disablePadding ? 'none' : 'default'}
+            style={{ paddingRight: 12 }}
             sortDirection={orderBy === row.id ? order : false}
           >
             <TableSortLabel

--- a/frontend/src/helpers/routeCalculations.js
+++ b/frontend/src/helpers/routeCalculations.js
@@ -7,8 +7,8 @@
 
 import * as d3 from 'd3';
 import red from '@material-ui/core/colors/red';
-import yellow from '@material-ui/core/colors/yellow';
-import lightGreen from '@material-ui/core/colors/lightGreen';
+import amber from '@material-ui/core/colors/amber';
+import lime from '@material-ui/core/colors/lime';
 import green from '@material-ui/core/colors/green';
 import {
   getTripTimeStat,
@@ -543,18 +543,12 @@ export function getAllScores(routes, waits, speeds) {
 export const quartileBackgroundColor = d3
   .scaleThreshold()
   .domain([0.25, 0.5, 0.75])
-  .range([red[300], yellow[300], lightGreen[800], green[900]]);
+  .range([red[50], amber[50], lime[100], green[100]]);
 
 export const quartileContrastColor = d3
   .scaleThreshold()
   .domain([0.25, 0.5, 0.75])
-  .range(['black', 'black', 'white', 'white']);
-
-// for coloring the route table's white columns, to emphasize low scoring cells
-export const quartileTextColor = d3
-  .scaleThreshold()
-  .domain([0.25, 0.5, 0.75])
-  .range(['black', 'black', '#8a8a8a', '#8a8a8a']);
+  .range(['rgba(0,0,0,0.87)', 'rgba(0,0,0,0.87)', 'rgba(0,0,0,0.87)', 'rgba(0,0,0,0.87)']);
 
 /**
  * Haversine formula for calcuating distance between two coordinates in lat lon

--- a/frontend/src/helpers/routeCalculations.js
+++ b/frontend/src/helpers/routeCalculations.js
@@ -7,9 +7,9 @@
 
 import * as d3 from 'd3';
 import red from '@material-ui/core/colors/red';
-import amber from '@material-ui/core/colors/amber';
-import lime from '@material-ui/core/colors/lime';
 import green from '@material-ui/core/colors/green';
+import yellow from '@material-ui/core/colors/yellow';
+import lightGreen from '@material-ui/core/colors/lightGreen';
 import {
   getTripTimeStat,
   getTripTimesForDirection,
@@ -543,12 +543,12 @@ export function getAllScores(routes, waits, speeds) {
 export const quartileBackgroundColor = d3
   .scaleThreshold()
   .domain([0.25, 0.5, 0.75])
-  .range([red[50], amber[50], lime[100], green[100]]);
+  .range([red[300], yellow[300], lightGreen[700], green[900]]);
 
 export const quartileContrastColor = d3
   .scaleThreshold()
   .domain([0.25, 0.5, 0.75])
-  .range(['rgba(0,0,0,0.87)', 'rgba(0,0,0,0.87)', 'rgba(0,0,0,0.87)', 'rgba(0,0,0,0.87)']);
+  .range(['rgba(0,0,0,0.87)', 'rgba(0,0,0,0.87)', 'white', 'white']);
 
 /**
  * Haversine formula for calcuating distance between two coordinates in lat lon


### PR DESCRIPTION
<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->

Related to #429.


<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

Color table cells with metric values (wait, speed, etc.) by quartile.  Add units (min, mph) to each cell's value.

## Screenshot

![Screen Shot 2019-11-20 at 3 46 24 PM](https://user-images.githubusercontent.com/44861283/69303954-b459a400-0bd3-11ea-91b0-d8733cba96e1.png)

## Link to demo, if any

http://wpg-opentransit.herokuapp.com

