### PR TITLE
Auto-label PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,28 @@
+# Add 'frontend' to any changes within 'frontend'
+"Frontend": ./frontend/**/*
+
+# Similar for others
+"Backend": ./backend/*  
+"Data Science": ./backend/models/**/*
+
+
+### EXAMPLES
+# # Add 'label1' to any changes within 'example' folder or any subfolders
+# label1:
+#   - example/**/*
+# 
+# # Add 'label2' to any file changes within 'example2' folder
+# label2: example2/*
+# 
+# # Add 'repo' label to any root file changes
+# repo:
+#   - ./*
+# 
+# # Add '@domain/core' label to any change within the 'core' package
+# @domain/core:
+#   - package/core/*
+#   - package/core/**/*
+# 
+# # Add 'test' label to any change to *.spec.js files within the source dir
+# test:
+#   - src/**/*.spec.js

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,19 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler/blob/master/README.md
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION

## Proposed changes

This creates a GitHub action that auto-labels PRs based on the files they change. If you touch the backend directory, for instance, your PR will get a Backend label. This should help us sort through the ever-increasing number of PRs more efficiently.
