### PR TITLE
Beautified the Sidebar with Material-UI

### DIFF
--- a/frontend/src/components/SidebarButton.jsx
+++ b/frontend/src/components/SidebarButton.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { NavLink } from 'redux-first-router-link';
+import { connect } from 'react-redux';
+import { components } from '../reducers/page.js';
 import Drawer from '@material-ui/core/Drawer';
 import IconButton from '@material-ui/core/IconButton';
 import List from '@material-ui/core/List';
@@ -14,7 +16,8 @@ import CodeRoundedIcon from '@material-ui/icons/CodeRounded';
 import InfoRoundedIcon from '@material-ui/icons/InfoRounded';
 import Divider from '@material-ui/core/Divider';
 
-function SidebarButton() {
+function SidebarButton(props) {
+  const currentPage = props.currentPage;
   const [drawerOpen, setDrawer] = React.useState(false);
 
   function toggleDrawer() {
@@ -62,6 +65,8 @@ function SidebarButton() {
               activeStyle={activeStyle}
               exact
               style={inactiveStyle}
+              button
+              selected={currentPage==components.DASHBOARD}
             >
               <ListItemIcon>
                 <MapRoundedIcon color="primary"/>
@@ -74,6 +79,8 @@ function SidebarButton() {
               activeStyle={activeStyle}
               exact
               style={inactiveStyle}
+              button
+              selected={currentPage==components.ISOCHRONE}
             >
               <ListItemIcon>
                 <TimelineRoundedIcon color="primary"/>
@@ -86,6 +93,8 @@ function SidebarButton() {
               activeStyle={activeStyle}
               exact
               style={inactiveStyle}
+              button
+              selected={currentPage==components.DATADIAGNOSTIC}
             >
               <ListItemIcon>
                 <CodeRoundedIcon color="primary"/>
@@ -98,6 +107,7 @@ function SidebarButton() {
               href="https://sites.google.com/view/opentransit"
               target="_blank"
               onClick={toggleDrawer}
+              button
             >
               <ListItemIcon>
                 <InfoRoundedIcon color="primary"/>
@@ -111,4 +121,10 @@ function SidebarButton() {
   );
 }
 
-export default SidebarButton;
+const mapStateToProps = state => ({
+  currentPage: state.page,
+});
+
+export default connect(
+  mapStateToProps,
+)(SidebarButton);

--- a/frontend/src/components/SidebarButton.jsx
+++ b/frontend/src/components/SidebarButton.jsx
@@ -8,7 +8,13 @@ import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import MenuIcon from '@material-ui/icons/Menu';
 import { NavLink } from 'redux-first-router-link';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
-import HomeIcon from '@material-ui/icons/Home';
+import TimelineRoundedIcon from '@material-ui/icons/TimelineRounded';
+import MapRoundedIcon from '@material-ui/icons/MapRounded';
+import CodeRoundedIcon from '@material-ui/icons/CodeRounded';
+import InfoRoundedIcon from '@material-ui/icons/InfoRounded';
+import Typography from '@material-ui/core/Typography'
+
+
 
 function SidebarButton() {
   const [drawerOpen, setDrawer] = React.useState(false);
@@ -24,6 +30,13 @@ function SidebarButton() {
     cursor: 'default',
   };
 
+  const inactiveStyle = {
+    fontWeight: 'normal',
+    color: '#3f51b5',
+    textDecoration: 'none',
+    cursor: 'pointer',
+  };
+
   return (
     <div>
       <IconButton
@@ -34,7 +47,7 @@ function SidebarButton() {
       >
         <MenuIcon />
       </IconButton>
-      <Drawer variant="persistent" anchor="left" open={drawerOpen}>
+      <Drawer anchor="left" open={drawerOpen} onClose={toggleDrawer}>
         <div style={{ width: 250 }}>
           <IconButton
             color="inherit"
@@ -42,38 +55,50 @@ function SidebarButton() {
             onClick={toggleDrawer}
             edge="start"
           >
-            <ChevronLeftIcon />
+            <ChevronLeftIcon color="primary"/>
           </IconButton>
           <List>
-            <ListItem>
-              <NavLink
-                to={{ type: 'DASHBOARD' }}
-                activeStyle={activeStyle}
-                exact
-                strict
-              >
-                Dashboard
-              </NavLink>
+            <ListItem
+              button
+              component={NavLink}
+              to={{ type: 'DASHBOARD' }}
+              activeStyle={activeStyle}
+              exact
+              strict
+              style={inactiveStyle}
+            >
+              <ListItemIcon>
+                <TimelineRoundedIcon color="primary"/>
+              </ListItemIcon>
+              Dashboard
             </ListItem>
-            <ListItem>
-              <NavLink
-                to={{ type: 'ISOCHRONE' }}
-                activeStyle={activeStyle}
-                exact
-                strict
-              >
-                Isochrone
-              </NavLink>
+            <ListItem
+              button
+              component={NavLink}
+              to={{ type: 'ISOCHRONE' }}
+              activeStyle={activeStyle}
+              exact
+              strict
+              style={inactiveStyle}
+            >
+              <ListItemIcon>
+                <MapRoundedIcon color="primary"/>
+              </ListItemIcon>
+              Isochrone
             </ListItem>
-            <ListItem>
-              <NavLink
-                to={{ type: 'DATADIAGNOSTIC' }}
-                activeStyle={activeStyle}
-                exact
-                strict
-              >
-                .{/* Semi-hidden data diagnostic link for developers */}
-              </NavLink>
+            <ListItem
+              button
+              component={NavLink}
+              to={{ type: 'DATADIAGNOSTIC' }}
+              activeStyle={activeStyle}
+              exact
+              strict
+              style={inactiveStyle}
+            >
+              <ListItemIcon>
+                <CodeRoundedIcon color="primary"/>
+              </ListItemIcon>
+              Developer Tools
             </ListItem>
           </List>
           {/* Footer content */}
@@ -82,11 +107,17 @@ function SidebarButton() {
             width: "100%",
             bottom: 0,
           }} >
-            <ListItem button component="a" href="https://sites.google.com/view/opentransit" target="_blank">
+            <ListItem
+              button
+              component="a"
+              href="https://sites.google.com/view/opentransit"
+              target="_blank"
+              onClick={toggleDrawer}
+            >
               <ListItemIcon>
-                <HomeIcon />
+                <InfoRoundedIcon color="primary"/>
               </ListItemIcon>
-              <ListItemText primary="About" />
+              <ListItemText primary="About" color="primary"/>
             </ListItem>
           </List>
         </div>

--- a/frontend/src/components/SidebarButton.jsx
+++ b/frontend/src/components/SidebarButton.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { NavLink } from 'redux-first-router-link';
 import Drawer from '@material-ui/core/Drawer';
 import IconButton from '@material-ui/core/IconButton';
 import List from '@material-ui/core/List';
@@ -6,15 +7,12 @@ import ListItem from '@material-ui/core/ListItem';
 import ListItemText from '@material-ui/core/ListItemText';
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft';
 import MenuIcon from '@material-ui/icons/Menu';
-import { NavLink } from 'redux-first-router-link';
 import ListItemIcon from '@material-ui/core/ListItemIcon';
-import TimelineRoundedIcon from '@material-ui/icons/TimelineRounded';
 import MapRoundedIcon from '@material-ui/icons/MapRounded';
+import TimelineRoundedIcon from '@material-ui/icons/TimelineRounded';
 import CodeRoundedIcon from '@material-ui/icons/CodeRounded';
 import InfoRoundedIcon from '@material-ui/icons/InfoRounded';
-import Typography from '@material-ui/core/Typography'
-
-
+import Divider from '@material-ui/core/Divider';
 
 function SidebarButton() {
   const [drawerOpen, setDrawer] = React.useState(false);
@@ -32,7 +30,7 @@ function SidebarButton() {
 
   const inactiveStyle = {
     fontWeight: 'normal',
-    color: '#3f51b5',
+    color: '#000000',
     textDecoration: 'none',
     cursor: 'pointer',
   };
@@ -59,56 +57,43 @@ function SidebarButton() {
           </IconButton>
           <List>
             <ListItem
-              button
               component={NavLink}
               to={{ type: 'DASHBOARD' }}
               activeStyle={activeStyle}
               exact
-              strict
-              style={inactiveStyle}
-            >
-              <ListItemIcon>
-                <TimelineRoundedIcon color="primary"/>
-              </ListItemIcon>
-              Dashboard
-            </ListItem>
-            <ListItem
-              button
-              component={NavLink}
-              to={{ type: 'ISOCHRONE' }}
-              activeStyle={activeStyle}
-              exact
-              strict
               style={inactiveStyle}
             >
               <ListItemIcon>
                 <MapRoundedIcon color="primary"/>
               </ListItemIcon>
-              Isochrone
+              <ListItemText primary="Dashboard"/>
             </ListItem>
             <ListItem
-              button
+              component={NavLink}
+              to={{ type: 'ISOCHRONE' }}
+              activeStyle={activeStyle}
+              exact
+              style={inactiveStyle}
+            >
+              <ListItemIcon>
+                <TimelineRoundedIcon color="primary"/>
+              </ListItemIcon>
+              <ListItemText primary="Isochrone"/>
+            </ListItem>
+            <ListItem
               component={NavLink}
               to={{ type: 'DATADIAGNOSTIC' }}
               activeStyle={activeStyle}
               exact
-              strict
               style={inactiveStyle}
             >
               <ListItemIcon>
                 <CodeRoundedIcon color="primary"/>
               </ListItemIcon>
-              Developer Tools
+              <ListItemText primary="Developer Tools"/>
             </ListItem>
-          </List>
-          {/* Footer content */}
-          <List style={{
-            position: "absolute",
-            width: "100%",
-            bottom: 0,
-          }} >
+            <Divider light />
             <ListItem
-              button
               component="a"
               href="https://sites.google.com/view/opentransit"
               target="_blank"
@@ -117,7 +102,7 @@ function SidebarButton() {
               <ListItemIcon>
                 <InfoRoundedIcon color="primary"/>
               </ListItemIcon>
-              <ListItemText primary="About" color="primary"/>
+              <ListItemText primary="About" style={inactiveStyle}/>
             </ListItem>
           </List>
         </div>

--- a/frontend/src/reducers/page.js
+++ b/frontend/src/reducers/page.js
@@ -1,6 +1,6 @@
 import { NOT_FOUND } from 'redux-first-router';
 
-const components = {
+export const components = {
   ABOUT: 'About',
   ISOCHRONE: 'Isochrone',
   LANDING: 'Landing',


### PR DESCRIPTION
Fixes #402. 
Menu now disappears when clicking anywhere else on the page.

Fixes #390.
Dot is replaced with a meaningful label. Added icons.

Fixes #381.
Brings the rest of the menu in line with the Material-UI of the 'About' link.

Fixes #472.
Hover and active page works now.

<!-- Delete any of these headings if they aren't needed or applicable -->

## Screenshot

![image](https://user-images.githubusercontent.com/12836949/69384783-1963d700-0c72-11ea-8603-6a8c61768d39.png)
