### PR TITLE
UI proposal: hide numeric scores and star ratings; vary text color on route table

### DIFF
--- a/frontend/src/components/InfoScoreCard.jsx
+++ b/frontend/src/components/InfoScoreCard.jsx
@@ -79,7 +79,7 @@ export default function InfoScoreCard(props) {
           justifyContent="flex-start"
           height="100%"
         >
-          <Typography variant="overline">{title}</Typography>
+          <Typography style={{whiteSpace:'nowrap'}} variant="overline">{title}</Typography>
 
           <Box flexGrow={1}>
             {' '}
@@ -90,9 +90,9 @@ export default function InfoScoreCard(props) {
             <Typography variant="h5" display="inline">
               {smallValue}
             </Typography>
-            {hideRating ? null : (
+            {/*hideRating ? null : (
               <Rating readOnly size="small" value={rating} precision={0.5} />
-            )}
+            )*/}
           </Box>
           <Box
             display="flex"

--- a/frontend/src/components/InfoTripSummary.jsx
+++ b/frontend/src/components/InfoTripSummary.jsx
@@ -37,7 +37,7 @@ import WatchLaterOutlinedIcon from '@material-ui/icons/WatchLaterOutlined';
  * @param {any} props
  */
 export default function InfoTripSummary(props) {
-  
+
   const [typicalAnchorEl, setTypicalAnchorEl] = useState(null);
   const [planningAnchorEl, setPlanningAnchorEl] = useState(null);
 
@@ -56,7 +56,7 @@ export default function InfoTripSummary(props) {
   function handlePlanningClose() {
     setPlanningAnchorEl(null);
   }
-  
+
   const { graphData, graphParams, routes } = props;
   const waitTimes = graphData ? graphData.waitTimes : null;
   const tripTimes = graphData ? graphData.tripTimes : null;
@@ -165,7 +165,7 @@ export default function InfoTripSummary(props) {
     getPercentileValue(tripTimes, PLANNING_PERCENTILE),
   );
   const travelVariability = Math.round(
-    (getPercentileValue(tripTimes, PLANNING_PERCENTILE) -      
+    (getPercentileValue(tripTimes, PLANNING_PERCENTILE) -
      getPercentileValue(tripTimes, TENTH_PERCENTILE)) / 2.0,
   );
 
@@ -222,7 +222,7 @@ export default function InfoTripSummary(props) {
   const popoverContentLongWait = grades ? (
     <Fragment>
       Long wait probability is the chance a rider has of a wait of twenty minutes or
-      longer after arriving randomly at the "from" stop. 
+      longer after arriving randomly at the "from" stop.
       Probability of{' '}
       {(longWaitProbability * 100).toFixed(1) /* be more precise than card */}%
       gets a score of {grades.longWaitScore}.
@@ -286,7 +286,7 @@ export default function InfoTripSummary(props) {
             <Grid container spacing={4}>
               {/* spacing doesn't work exactly right here, just pads the Papers */}
               <Grid item xs component={Paper} className={classes.uncolored}>
-                <Typography variant="overline">Typical journey</Typography>
+                <Typography variant="overline" style={{whiteSpace:'nowrap'}}>Typical journey</Typography>
                 <br />
 
                 <Typography variant="h3" display="inline">
@@ -314,9 +314,9 @@ export default function InfoTripSummary(props) {
                   </IconButton>
                  </Box>
               </Grid>
-              
+
               <Grid item xs component={Paper} className={classes.uncolored}>
-                <Typography variant="overline">Journey planning</Typography>
+                <Typography variant="overline" style={{whiteSpace:'nowrap'}}>Journey planning</Typography>
                 <br />
 
                 <Typography variant="h3" display="inline">
@@ -335,7 +335,7 @@ export default function InfoTripSummary(props) {
                   <Typography variant="body1">
                     <WatchLaterOutlinedIcon fontSize="small" style={{verticalAlign: 'sub'}} />&nbsp;
                     {planningWait} min
-                    <br/> 
+                    <br/>
                     <StartStopIcon fontSize="small" style={{verticalAlign: 'sub'}} />&nbsp;
                     {planningTravel} min
                   </Typography>
@@ -344,7 +344,7 @@ export default function InfoTripSummary(props) {
                   </IconButton>
                 </Box>
               </Grid>
-              <InfoScoreCard
+              {/*<InfoScoreCard
                 grades={grades}
                 gradeName="totalScore"
                 hideRating
@@ -353,7 +353,7 @@ export default function InfoTripSummary(props) {
                 smallValue={`/${grades ? grades.highestPossibleScore : '--'}`}
                 bottomContent="&nbsp;"
                 popoverContent={popoverContentTotalScore}
-              />
+              />*/}
               <InfoScoreCard
                 grades={grades}
                 gradeName="medianWaitScore"

--- a/frontend/src/components/RouteSummary.jsx
+++ b/frontend/src/components/RouteSummary.jsx
@@ -199,7 +199,7 @@ function RouteSummary(props) {
     <Fragment>
       <div style={{ padding: 24 }}>
         <Grid container spacing={4}>
-          <InfoScoreCard
+            {/* <InfoScoreCard
             grades={wait && speed && grades ? grades : null}
             gradeName="totalScore"
             hideRating
@@ -212,7 +212,7 @@ function RouteSummary(props) {
                 : 'No data'
             }
             popoverContent={popoverContentTotalScore}
-          />
+            />*/}
 
           <InfoScoreCard
             grades={wait && grades ? grades : null}

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -94,20 +94,20 @@ function getSorting(order, orderBy) {
 
 const headRows = [
   { id: 'title', numeric: false, disablePadding: false, label: 'Name' },
-  { id: 'totalScore', numeric: true, disablePadding: false, label: 'Score' },
-  { id: 'wait', numeric: true, disablePadding: true, label: 'Median Wait (min)' },
+  //{ id: 'totalScore', numeric: true, disablePadding: false, label: 'Score' },
+  { id: 'wait', numeric: true, disablePadding: true, label: 'Median Wait' },
   {
     id: 'longWait',
     numeric: true,
     disablePadding: true,
     label: 'Long Wait %',
   },
-  { id: 'speed', numeric: true, disablePadding: true, label: 'Average Speed (mph)' },
+  { id: 'speed', numeric: true, disablePadding: true, label: 'Average Speed' },
   {
     id: 'variability',
     numeric: true,
     disablePadding: true,
-    label: 'Travel Time Variability (min)',
+    label: 'Travel Time Variability',
   },
 ];
 
@@ -180,7 +180,7 @@ const useToolbarStyles = makeStyles(theme => ({
 const EnhancedTableToolbar = props => {
   const classes = useToolbarStyles();
   const { numSelected } = props;
-  
+
   const [anchorEl, setAnchorEl] = useState(null);
 
   function handleClick(event) {
@@ -189,7 +189,7 @@ const EnhancedTableToolbar = props => {
 
   function handleClose() {
     setAnchorEl(null);
-  }  
+  }
 
   return (
     <Toolbar
@@ -241,14 +241,14 @@ const EnhancedTableToolbar = props => {
           randomly at a stop while the route is running.
           <p/>
           <b>Long wait probability</b> is the chance a rider has of a wait of twenty minutes
-          or longer after arriving randomly at a stop. 
+          or longer after arriving randomly at a stop.
           <p/>
           <b>Average speed</b> is the speed of the 50th percentile (typical) end to end trip, averaged
           for all directions.
           <p/>
           <b>Travel time variability</b> is the 90th percentile end to end travel time minus the 10th percentile
           travel time.  This measures how much extra travel time is needed for some trips.
-          
+
         </div>
       </Popover>
 
@@ -360,7 +360,6 @@ function RouteTable(props) {
                       component="th"
                       id={labelId}
                       scope="row"
-                      padding="none"
                     >
                       <Navlink
                         style={{color: theme.palette.primary.dark, textDecoration: 'none'}}
@@ -378,7 +377,7 @@ function RouteTable(props) {
                         {row.title}
                       </Navlink>
                     </TableCell>
-                    <TableCell
+                    {/* <TableCell
                       align="right"
                       style={{
                         color: quartileContrastColor(row.totalScore / 100),
@@ -388,27 +387,38 @@ function RouteTable(props) {
                       }}
                     >
                       {Number.isNaN(row.totalScore) ? '--' : row.totalScore}
-                    </TableCell>
+                    </TableCell> */}
                     <TableCell
                       align="right"
                       padding="none"
                       style={{
+                        //fontWeight: 'bold',
+                        whiteSpace:'nowrap',
                         color: quartileTextColor(row.medianWaitScore / 100),
+                        /* color: quartileContrastColor(row.medianWaitScore / 100),
+                        backgroundColor: quartileBackgroundColor(
+                          row.medianWaitScore / 100
+                        ), */
                       }}
                     >
-                      {Number.isNaN(row.wait) ? '--' : row.wait.toFixed(0)}
+                      {Number.isNaN(row.wait) ? '--' : (row.wait.toFixed(0) + ' min')}
                     </TableCell>
                     <TableCell
                       align="right"
                       padding="none"
                       style={{
+                        whiteSpace:'nowrap',
                         color: quartileTextColor(row.longWaitScore / 100),
+                        /* color: quartileContrastColor(row.longWaitScore / 100),
+                        backgroundColor: quartileBackgroundColor(
+                          row.longWaitScore / 100,
+                        ), */
                       }}
                     >
                       {Number.isNaN(row.longWait)
                         ? '--'
                         : <Fragment>
-                            {(row.longWait * 100).toFixed(0)}<font style={{color:"#8a8a8a"}}>%</font>
+                            {(row.longWait * 100).toFixed(0)}%
                           </Fragment>
                       }
                     </TableCell>
@@ -416,22 +426,33 @@ function RouteTable(props) {
                       align="right"
                       padding="none"
                       style={{
+                        whiteSpace:'nowrap',
                         color: quartileTextColor(row.speedScore / 100),
+                        /* color: quartileContrastColor(row.speedScore / 100),
+                        backgroundColor: quartileBackgroundColor(
+                          row.speedScore / 100,
+                        ), */
                       }}
                     >
-                      {Number.isNaN(row.speed) ? '--' : row.speed.toFixed(0)}
+                      {Number.isNaN(row.speed) ? '--' : (row.speed.toFixed(0) + ' mph')}
                     </TableCell>
                     <TableCell
                       align="right"
                       padding="none"
                       style={{
                         color: quartileTextColor(row.travelVarianceScore / 100),
+                        whiteSpace:'nowrap',
+                        color: quartileTextColor(row.travelVarianceScore / 100),
+                        /* color: quartileContrastColor(row.travelVarianceScore / 100),
+                        backgroundColor: quartileBackgroundColor(
+                          row.travelVarianceScore / 100,
+                        ), */
                       }}
                     >
                       {Number.isNaN(row.variability)
                         ? '--'
                         : <Fragment>
-                            <font style={{color:"#8a8a8a"}}>{'\u00b1'} </font>{row.variability.toFixed(0)}
+                            {'\u00b1'} {row.variability.toFixed(0)} min
                           </Fragment>
                       }
                     </TableCell>

--- a/frontend/src/helpers/routeCalculations.js
+++ b/frontend/src/helpers/routeCalculations.js
@@ -10,6 +10,7 @@ import red from '@material-ui/core/colors/red';
 import yellow from '@material-ui/core/colors/yellow';
 import lightGreen from '@material-ui/core/colors/lightGreen';
 import green from '@material-ui/core/colors/green';
+import orange from '@material-ui/core/colors/orange';
 import {
   getTripTimeStat,
   getTripTimesForDirection,
@@ -554,7 +555,8 @@ export const quartileContrastColor = d3
 export const quartileTextColor = d3
   .scaleThreshold()
   .domain([0.25, 0.5, 0.75])
-  .range(['black', 'black', '#8a8a8a', '#8a8a8a']);
+  .range([red[900], orange[800], lightGreen[700], green[900]]);
+  //.range(['black', 'black', '#8a8a8a', '#8a8a8a']);
 
 /**
  * Haversine formula for calcuating distance between two coordinates in lat lon


### PR DESCRIPTION
See http://opentransit-youngj.herokuapp.com/

![image](https://user-images.githubusercontent.com/343100/69394705-a23e3b00-0c91-11ea-8334-944364dc0576.png)

![image](https://user-images.githubusercontent.com/343100/69394725-b4b87480-0c91-11ea-80ac-5f4c8eec1d0c.png)

![image](https://user-images.githubusercontent.com/343100/69394749-cac63500-0c91-11ea-86bf-442b1d4040d9.png)

I think that showing numeric scores on an absolute scale gives too much emphasis to the preferences  of whoever defines the scoring algorithm. Each user may have different opinions on what metrics are important to them about the quality of a route, such as median wait time, speed, variability, etc.  Different riders may have different opinions about whether a route that is scheduled with long headways and is always on schedule is better or worse than a route that arrives inconsistently with shorter headways. Also, different routes and transit modes have different rider expectations.

If I was showing OpenTransit to someone who works at a transit agency, I wouldn't be able to justify the current methodology for scoring routes and trips. Instead of claiming expertise at knowing what is "good" and what is "bad", I think it would be better to stick to presenting basic metrics that users can intuitively understand without a long explanation. Then users can focus on the metrics that matter to them, and avoid being distracted by trying to understand whether our scoring algorithm matches what they actually care about.

Similar to the numeric scores, I think that the star ratings place too much confidence in our ability to tell what is good and what is bad.

Using varying colors to highlight possible good/bad metrics seems helpful, even if the colors are defined on an absolute scale (although we would probably need to customize scales for different agencies with different ranges of wait times, speeds, etc.). For example it seems less controversial to show a metric in yellow than to show something like 1.5 / 5 stars.

I think relative rankings of metrics across routes are helpful to put metrics in context, without needing to make our own judgement of how good or bad a metric is.

I like varying text colors for metrics in the route table to allow the user to easily scan the table for possible good or bad numbers without needing to parse each number, while being less visually overwhelming than changing the cell background color.

Adding units to all metrics in the route table seems to make it easier to scan the table without needing to remember the associated header of that column.

Hiding scores also reduces the number of numbers on the route table and route/trip summary, making the app somewhat less overwhelming.