### PR TITLE
configure agency IDs for kubernetes cron jobs via ConfigMap

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,6 @@
+## Configuring Kubernetes
+
+To define agency IDs in Kubernetes ConfigMap:
+
+`kubectl create configmap opentransit --from-literal=opentransit_agency_ids=trimet,portland-sc`
+

--- a/kubernetes/compute-new-cronjob.yaml
+++ b/kubernetes/compute-new-cronjob.yaml
@@ -14,7 +14,15 @@ spec:
             image: gcr.io/poetic-genius-233804/metrics-flask:latest
             imagePullPolicy: Always
             command: ["python",  "compute_new.py"]
+            resources:
+              requests:
+                cpu: 0.03
             env:
+              - name: OPENTRANSIT_AGENCY_IDS
+                valueFrom:
+                  configMapKeyRef:
+                    name: opentransit
+                    key: opentransit_agency_ids
               - name: AWS_ACCESS_KEY_ID
                 valueFrom:
                   secretKeyRef:

--- a/kubernetes/save-routes-cronjob.yaml
+++ b/kubernetes/save-routes-cronjob.yaml
@@ -14,7 +14,15 @@ spec:
             image: gcr.io/poetic-genius-233804/metrics-flask:latest
             imagePullPolicy: Always
             command: ["python",  "save_routes.py",  "--s3"]
+            resources:
+              requests:
+                cpu: 0.03
             env:
+              - name: OPENTRANSIT_AGENCY_IDS
+                valueFrom:
+                  configMapKeyRef:
+                    name: opentransit
+                    key: opentransit_agency_ids
               - name: AWS_ACCESS_KEY_ID
                 valueFrom:
                   secretKeyRef:


### PR DESCRIPTION
This allows computing arrivals for other agencies besides `muni` (although the web app still only shows `muni`). 

The actual ConfigMap isn't checked into the repo since different deployments could have different configs. 

To deploy the web UI for other agencies, it would probably be easiest to use Kubernetes namespaces (or a separate Kubernetes cluster).