### PR TITLE
handle loops correctly when displaying list of stops in the UI issue 426

### DIFF
--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -63,11 +63,12 @@ function ControlPanel(props) {
       mySelectedRoute,
       directionId,
     );
-    const secondStopListIndex = stopId
-      ? secondStopInfo.stops.indexOf(stopId)
-      : 0;
-
+    
     const stopsList = secondStopInfo.stops;
+    const secondStopListIndex = stopId
+      ? stopsList.indexOf(stopId)
+      : 0;
+    
     // loop routes start and stop at same stop
     const isLoopRoute = stopsList[0] === stopsList[stopsList.length - 1];
     const oneWaySecondStopsList = stopsList.slice(secondStopListIndex + 1);
@@ -75,7 +76,7 @@ function ControlPanel(props) {
     if (!isLoopRoute) {
       return oneWaySecondStopsList;
     }
-    // loop routes display all subsequent routes up to origin stop
+    // loop routes display all subsequent stops up to origin stop
     return oneWaySecondStopsList.concat(stopsList.slice(1, secondStopListIndex));
   }
 

--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -70,9 +70,10 @@ function ControlPanel(props) {
 
     const unidirectionalSecondStopsList = secondStopInfo.stops.slice(secondStopListIndex + 1);
 
-    const circularSecondStopsList = unidirectionalSecondStopsList.concat(secondStopInfo.stops.slice(0, secondStopListIndex));
-
-    return isLoopRoute ? circularSecondStopsList : unidirectionalSecondStopsList;
+    if (!isLoopRoute) {
+      return unidirectionalSecondStopsList;
+    }
+    return unidirectionalSecondStopsList.concat(secondStopInfo.stops.slice(1, secondStopListIndex));
   }
 
   function onSelectFirstStop(event) {

--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -66,14 +66,17 @@ function ControlPanel(props) {
     const secondStopListIndex = stopId
       ? secondStopInfo.stops.indexOf(stopId)
       : 0;
-    const isLoopRoute = secondStopInfo.stops[0] === secondStopInfo.stops[secondStopInfo.stops.length - 1];
 
-    const unidirectionalSecondStopsList = secondStopInfo.stops.slice(secondStopListIndex + 1);
+    const stopsList = secondStopInfo.stops;
+    // loop routes start and stop at same stop
+    const isLoopRoute = stopsList[0] === stopsList[stopsList.length - 1];
+    const oneWaySecondStopsList = stopsList.slice(secondStopListIndex + 1);
 
     if (!isLoopRoute) {
-      return unidirectionalSecondStopsList;
+      return oneWaySecondStopsList;
     }
-    return unidirectionalSecondStopsList.concat(secondStopInfo.stops.slice(1, secondStopListIndex));
+    // loop routes display all subsequent routes up to origin stop
+    return oneWaySecondStopsList.concat(stopsList.slice(1, secondStopListIndex));
   }
 
   function onSelectFirstStop(event) {

--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -66,7 +66,13 @@ function ControlPanel(props) {
     const secondStopListIndex = stopId
       ? secondStopInfo.stops.indexOf(stopId)
       : 0;
-    return secondStopInfo.stops.slice(secondStopListIndex + 1);
+    const isLoopRoute = secondStopInfo.stops[0] === secondStopInfo.stops[secondStopInfo.stops.length - 1];
+
+    const unidirectionalSecondStopsList = secondStopInfo.stops.slice(secondStopListIndex + 1);
+
+    const circularSecondStopsList = unidirectionalSecondStopsList.concat(secondStopInfo.stops.slice(0, secondStopListIndex));
+
+    return isLoopRoute ? circularSecondStopsList : unidirectionalSecondStopsList;
   }
 
   function onSelectFirstStop(event) {


### PR DESCRIPTION
Fixes #426 

* Please provide any feedback as this is my first pull request on an open source project.  

## Screenshot 1: Shows second stops extending past 9th & Lovejoy (this used to be the last stop shown)

<img width="733" alt="Screen Shot 2019-11-25 at 8 59 29 PM" src="https://user-images.githubusercontent.com/48000707/69600717-8656d400-0fc6-11ea-8fd3-945be0f4cc59.png">

## Screenshot 2: Shows functionality preserved for unidirectional routes

<img width="655" alt="Screen Shot 2019-11-25 at 8 57 04 PM" src="https://user-images.githubusercontent.com/48000707/69600647-468fec80-0fc6-11ea-9d99-fa7f35abc02b.png">
