### PR TITLE
Speed calculation fixes

### DIFF
--- a/backend/agencies/muni.yaml
+++ b/backend/agencies/muni.yaml
@@ -248,6 +248,22 @@ js_properties:
   #   - The 9 has multiple terminals so use the last common stop.
   #   - The 5 was reconfigured and Nextbus stop configs are out of sync with historic data.  Use last good stop.
   routeHeuristics: {
+      E: {
+        '0': {
+          ignoreFirstStop: '13095', # use Beach and Stockton as outbound start terminal until ~Oct 2020.
+        },
+        '1': {
+          ignoreLastStop: '14530', # use Embarcadero and Stockton as inbound end terminal until ~Oct 2020.
+        }
+      },
+      F: {
+        '0': {
+          ignoreFirstStop: '13095', # use Beach and Stockton as outbound start terminal until ~Oct 2020.
+        },
+        '1': {
+          ignoreLastStop: '14530', # use Embarcadero and Stockton as inbound end terminal until ~Oct 2020.
+        }
+      },
       N: {
         '0': {
           ignoreFirstStop: true, # 4th and King to 2nd and King trip times are skewed by a few hyperlong trips
@@ -256,18 +272,18 @@ js_properties:
       S: {
         ignoreRoute: true,
       },
-      '5': {
-        '1': {
-          ignoreFirstStop: '4218', # no data for 3927, and first few stop ids are now different.  Problem is even worse on outbound side, no good fix there.
-        },
-      },
       '9': {
         '1': {
-          ignoreFirstStop: '7297', # use Bayshore as actual first stop (daytime)
+          ignoreFirstStop: '17227', # use Bayshore and Visitacion as actual first stop (daytime)
         },
         '0': {
-          ignoreLastStop: '7297', # use Bayshore as actual terminal (daytime)
+          ignoreLastStop: '13783', # use Bayshore and Leland as actual terminal (daytime)
         },
+      },
+      '29': {
+        '1': {
+          ignoreFirstStop: '14783', # use Gilman and 3rd St as first inbound stop, almost doubling back
+        }
       },
       '90': {
         ignoreRoute: true,

--- a/backend/agencies/muni.yaml
+++ b/backend/agencies/muni.yaml
@@ -246,7 +246,6 @@ js_properties:
   #     should be used instead for end-to-end calculations.  Cable car lines are like this.
   # - Possibly special handling for routes with back end issues (currently 5, 9, 9R) as a temporary workaround.
   #   - The 9 has multiple terminals so use the last common stop.
-  #   - The 5 was reconfigured and Nextbus stop configs are out of sync with historic data.  Use last good stop.
   routeHeuristics: {
       E: {
         '0': {

--- a/frontend/src/components/MapStops.jsx
+++ b/frontend/src/components/MapStops.jsx
@@ -431,7 +431,8 @@ class MapStops extends Component {
   computeHeight() {
     return (
       (window.innerWidth >= 640 ? window.innerHeight : window.innerHeight / 2) -
-      64 /* blue app bar */
+      64 - /* blue app bar */
+      50 /* breadcrumb paper */
     );
   }
 

--- a/frontend/src/components/TravelTimeChart.jsx
+++ b/frontend/src/components/TravelTimeChart.jsx
@@ -66,7 +66,7 @@ function TravelTimeChart(props) {
         props.routes,
         routeId,
         directionId,
-      );
+      ).tripTime;
 
       /* this is the end-to-end speed in the selected direction, not currently used
     if (dist <= 0 || Number.isNaN(tripTime)) { speed = "?"; } // something wrong with the data here

--- a/frontend/src/helpers/routeCalculations.js
+++ b/frontend/src/helpers/routeCalculations.js
@@ -77,7 +77,7 @@ function getTripTimesUsingHeuristics(
   if (!tripTimesForDir || !routes) {
     //console.log("No trip times found at all for " + directionId + " (gtfs out of sync or route not running)");
     // not sure if we should remap to normal terminal
-    return { tripTimesForFirstStop: null, directionInfo: null, distanceAlongRoute: null };
+    return { tripTimesForFirstStop: null, directionInfo: null, firstStopDistance: null };
   }
 
   //console.log('trip times for dir: ' + Object.keys(tripTimesForDir).length + ' keys' );

--- a/frontend/src/helpers/routeCalculations.js
+++ b/frontend/src/helpers/routeCalculations.js
@@ -186,7 +186,6 @@ export function getEndToEndTripTime(
   }
 
   // if there is no trip time to the last stop, then use the highest trip time actually observed
-  // (generally this shouldn't happen)
 
   if (!tripTime) {
     const obj = getTripTimeStat(tripTimesForFirstStop, statIndex);

--- a/frontend/src/helpers/routeCalculations.js
+++ b/frontend/src/helpers/routeCalculations.js
@@ -188,14 +188,14 @@ export function getEndToEndTripTime(
   // if there is no trip time to the last stop, then use the highest trip time actually observed
 
   if (!tripTime) {
-    const obj = getTripTimeStat(tripTimesForFirstStop, statIndex);
-    const keys = Object.keys(obj);
+    const tripTimes = getTripTimeStat(tripTimesForFirstStop, statIndex);
+    const stopIds = Object.keys(tripTimes);
     tripTime = 0;
 
-    for (let i = 0; i < keys.length; i++) {
-      if (obj[keys[i]] > tripTime) {
-        tripTime = obj[keys[i]];
-        tripDistance = directionInfo.stop_geometry[keys[i]].distance - firstStopDistance;
+    for (let i = 0; i < stopIds.length; i++) {
+      if (tripTimes[stopIds[i]] > tripTime) {
+        tripTime = tripTimes[stopIds[i]];
+        tripDistance = directionInfo.stop_geometry[stopIds[i]].distance - firstStopDistance;
       }
     }
 


### PR DESCRIPTION
<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->

Fixes #439 and supersonic 29-Sunset.  Fixes #407.  

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

- muni.yaml: Updated muni.yaml for GTFS stop ids and E/F temporary turnaround at pier 39.  Fix for supersonic 29 sunset speed by ignoring starting inbound stops that are too close (tight "U"). (#439)
- MapStops: Minor layout fix for map height to compensate for new breadcrumb area (from #415)
- TravelTimeChart and routeCalculations:  compute route speed with more accurate distance based on starting and ending stops as outlined in #407.

## Screenshot

Improved speed for E and F on the left:

![Screen Shot 2019-11-26 at 6 16 11 PM](https://user-images.githubusercontent.com/44861283/69688012-b0b59980-1079-11ea-8438-8e270e738182.png)

Improved speed for 29 and also routes that double back, like 36 and 39, on the left:

![Screen Shot 2019-11-26 at 6 18 08 PM](https://user-images.githubusercontent.com/44861283/69688010-af846c80-1079-11ea-8cdd-dc6b070062a1.png)

Route summary layout fix on left, map not cut off vs cut off map and scroll on right:

![Screen Shot 2019-11-26 at 6 24 45 PM](https://user-images.githubusercontent.com/44861283/69688161-1a35a800-107a-11ea-8dfe-21f15b0c3217.png)

## Link to demo, if any

https://ot-terence.herokuapp.com/
