### PR TITLE
Weird line spacing on stats tiles fix

### DIFF
--- a/frontend/src/components/InfoScoreCard.jsx
+++ b/frontend/src/components/InfoScoreCard.jsx
@@ -33,6 +33,7 @@ export default function InfoScoreCard(props) {
     smallValue,
     bottomContent,
     popoverContent,
+    className,
   } = props;
 
   const useStyles = makeStyles(theme => ({
@@ -62,7 +63,6 @@ export default function InfoScoreCard(props) {
       color: myGrades
         ? quartileContrastColor(myGrades[myGradeName] / 100.0)
         : 'black',
-      margin: 4,
     };
   };
 
@@ -72,7 +72,13 @@ export default function InfoScoreCard(props) {
 
   return (
     <Fragment>
-      <Grid item xs component={Paper} style={cardStyle(grades, gradeName)}>
+      <Grid
+        item
+        xs
+        component={Paper}
+        style={cardStyle(grades, gradeName)}
+        className={className}
+      >
         <Box
           display="flex"
           flexDirection="column"

--- a/frontend/src/components/InfoTripSummary.jsx
+++ b/frontend/src/components/InfoTripSummary.jsx
@@ -294,62 +294,76 @@ export default function InfoTripSummary(props) {
             <Grid container spacing={4}>
               {/* spacing doesn't work exactly right here, just pads the Papers */}
               <Grid item xs component={Paper} className={classes.infoScoreCard}>
-                <Typography variant="overline">Typical journey</Typography>
-                <br />
-
-                <Typography variant="h3" display="inline">
-                  {typicalWait + typicalTravel}
-                </Typography>
-                <Typography variant="h5" display="inline">
-                  &nbsp;min
-                </Typography>
-
                 <Box
                   display="flex"
-                  justifyContent="space-between"
-                  alignItems="flex-end"
-                  pt={2}
+                  flexDirection="column"
+                  justifyContent="flex-start"
+                  height="100%"
                 >
-                  <Typography variant="body1">
-                    <WatchLaterOutlinedIcon fontSize="small" style={{verticalAlign: 'sub'}} />&nbsp;
-                    {typicalWait} min
-                    <br/>
-                    <StartStopIcon fontSize="small" style={{verticalAlign: 'sub'}} />&nbsp;
-                    {typicalTravel} min
+                  <Typography variant="overline">Typical journey</Typography>
+                  <br />
+
+                  <Typography variant="h3" display="inline">
+                    {typicalWait + typicalTravel}
                   </Typography>
-                  <IconButton size="small" onClick={handleTypicalClick}>
-                    <InfoIcon fontSize="small" />
-                  </IconButton>
+                  <Typography variant="h5" display="inline">
+                    &nbsp;min
+                  </Typography>
+
+                  <Box
+                    display="flex"
+                    justifyContent="space-between"
+                    alignItems="flex-end"
+                    pt={2}
+                  >
+                    <Typography variant="body1">
+                      <WatchLaterOutlinedIcon fontSize="small" style={{verticalAlign: 'sub'}} />&nbsp;
+                      {typicalWait} min
+                      <br/>
+                      <StartStopIcon fontSize="small" style={{verticalAlign: 'sub'}} />&nbsp;
+                      {typicalTravel} min
+                    </Typography>
+                    <IconButton size="small" onClick={handleTypicalClick}>
+                      <InfoIcon fontSize="small" />
+                    </IconButton>
+                  </Box>
                  </Box>
               </Grid>
               
               <Grid item xs component={Paper} className={classes.infoScoreCard}>
-                <Typography variant="overline">Journey planning</Typography>
-                <br />
-
-                <Typography variant="h3" display="inline">
-                  {planningWait + planningTravel}
-                </Typography>
-                <Typography variant="h5" display="inline">
-                  &nbsp;min
-                </Typography>
-
                 <Box
                   display="flex"
-                  justifyContent="space-between"
-                  alignItems="flex-end"
-                  pt={2}
+                  flexDirection="column"
+                  justifyContent="flex-start"
+                  height="100%"
                 >
-                  <Typography variant="body1">
-                    <WatchLaterOutlinedIcon fontSize="small" style={{verticalAlign: 'sub'}} />&nbsp;
-                    {planningWait} min
-                    <br/> 
-                    <StartStopIcon fontSize="small" style={{verticalAlign: 'sub'}} />&nbsp;
-                    {planningTravel} min
+                  <Typography variant="overline">Journey planning</Typography>
+                  <br />
+
+                  <Typography variant="h3" display="inline">
+                    {planningWait + planningTravel}
                   </Typography>
-                  <IconButton size="small" onClick={handlePlanningClick}>
-                    <InfoIcon fontSize="small" />
-                  </IconButton>
+                  <Typography variant="h5" display="inline">
+                    &nbsp;min
+                  </Typography>
+
+                  <Box
+                    display="flex"
+                    justifyContent="space-between"
+                    alignItems="flex-end"
+                    pt={2}
+                  >
+                    <Typography variant="body1">
+                      <WatchLaterOutlinedIcon fontSize="small" style={{verticalAlign: 'sub'}} />&nbsp;
+                      {planningWait} min
+                      <br/> 
+                      <StartStopIcon fontSize="small" style={{verticalAlign: 'sub'}} />&nbsp;
+                      {planningTravel} min
+                    </Typography>
+                    <IconButton size="small" onClick={handlePlanningClick}>
+                      <InfoIcon fontSize="small" />
+                    </IconButton>
+                  </Box>
                 </Box>
               </Grid>
               <InfoScoreCard

--- a/frontend/src/components/InfoTripSummary.jsx
+++ b/frontend/src/components/InfoTripSummary.jsx
@@ -147,12 +147,20 @@ export default function InfoTripSummary(props) {
   }
 
   const useStyles = makeStyles(theme => ({
-    uncolored: {
-      margin: theme.spacing(1),
-    },
     popover: {
       padding: theme.spacing(2),
       maxWidth: 500,
+    },
+    lineHeightOverride: {
+      '& .MuiTypography-overline': {
+        'line-height': 1,
+      }
+    },
+    padding: {
+      padding: '8px',
+    },
+    infoScoreCard: {
+      margin: '4px',
     },
   }));
 
@@ -280,12 +288,12 @@ export default function InfoTripSummary(props) {
 
   return (
     <Fragment>
-      <div style={{ padding: 8 }}>
+      <div className={`${classes.lineHeightOverride} ${classes.padding}`}>
         {grades ? (
           <Fragment>
             <Grid container spacing={4}>
               {/* spacing doesn't work exactly right here, just pads the Papers */}
-              <Grid item xs component={Paper} className={classes.uncolored}>
+              <Grid item xs component={Paper} className={classes.infoScoreCard}>
                 <Typography variant="overline">Typical journey</Typography>
                 <br />
 
@@ -315,7 +323,7 @@ export default function InfoTripSummary(props) {
                  </Box>
               </Grid>
               
-              <Grid item xs component={Paper} className={classes.uncolored}>
+              <Grid item xs component={Paper} className={classes.infoScoreCard}>
                 <Typography variant="overline">Journey planning</Typography>
                 <br />
 
@@ -353,6 +361,7 @@ export default function InfoTripSummary(props) {
                 smallValue={`/${grades ? grades.highestPossibleScore : '--'}`}
                 bottomContent="&nbsp;"
                 popoverContent={popoverContentTotalScore}
+                className={classes.infoScoreCard}
               />
               <InfoScoreCard
                 grades={grades}
@@ -362,6 +371,7 @@ export default function InfoTripSummary(props) {
                 smallValue="&nbsp;min"
                 bottomContent="&nbsp;"
                 popoverContent={popoverContentWait}
+                className={classes.infoScoreCard}
               />
               <InfoScoreCard
                 grades={grades}
@@ -375,6 +385,7 @@ export default function InfoTripSummary(props) {
                     : ''
                 }
                 popoverContent={popoverContentLongWait}
+                className={classes.infoScoreCard}
               />
               <InfoScoreCard
                 grades={grades}
@@ -384,6 +395,7 @@ export default function InfoTripSummary(props) {
                 smallValue="&nbsp;mph"
                 bottomContent={`${distance.toFixed(1)} miles`}
                 popoverContent={popoverContentSpeed}
+                className={classes.infoScoreCard}
               />
               <InfoScoreCard
                 grades={grades}
@@ -393,6 +405,7 @@ export default function InfoTripSummary(props) {
                 smallValue="&nbsp;min"
                 bottomContent="&nbsp;"
                 popoverContent={popoverContentTravelVariability}
+                className={classes.infoScoreCard}
               />
             </Grid>
 


### PR DESCRIPTION
<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->
Fixes #436

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes
Fix the line spacing styling so that there isn't a blank link when title wraps. 
While I was changing up things, I moved styles from in-line to css-in-js declared at the top for best practices (more consistent, group all styling rules together, avoid in-line styling) and passed in a common style into `InfoTripSummary`
...

## Screenshot
![image](https://user-images.githubusercontent.com/10445556/69897969-c4762f80-1307-11ea-948f-584959422434.png)
![image](https://user-images.githubusercontent.com/10445556/69897986-f7202800-1307-11ea-87a6-873fc83662ab.png)

...

## Testing
I just manually tested for desktop and smaller screens. I'm not aware of any tests. It would probably be good to have an imagediff/snapshot test at some point when things are stable
...
Seems like there could be a component created for the two cards that is _not_ `InfoScoreCard` but shares some core look and feel, but I considered that out of scope for this bug. 