### PR TITLE
Draft: Emoji to represent GTFS route type

### DIFF
--- a/frontend/src/UIConstants.js
+++ b/frontend/src/UIConstants.js
@@ -85,3 +85,26 @@ export const WEEKENDS = [
 
 // Marey chart:  how long of a dwell at a stop results in a second data point for exit.
 export const DWELL_THRESHOLD_SECS = 120;
+
+/*
+ * Route type emojis.
+ *
+ * 0 - Tram, Streetcar, Light rail. Any light rail or street level system within a metropolitan area.
+ * 1 - Subway, Metro. Any underground rail system within a metropolitan area.
+ * 2 - Rail. Used for intercity or long-distance travel.
+ * 3 - Bus. Used for short- and long-distance bus routes.
+ * 4 - Ferry. Used for short- and long-distance boat service.
+ * 5 - Cable car. Used for street-level cable cars where the cable runs beneath the car.
+ * 6 - Gondola, Suspended cable car. Typically used for aerial cable cars where the car is suspended from the cable.
+ * 7 - Funicular. Any rail system designed for steep inclines.
+ */
+export const ROUTE_TYPE_EMOJIS = {
+  '0': { symbol: '🚈', label: 'Light Rail'}, /* light rail, or railway car: 🚃, or tram: 🚊, tram car: 🚋  */
+  '1': { symbol: '🚇', label: 'Subway'}, /* metro */
+  '2': { symbol: '🚆', label: 'Rail'}, /* train, or bullet train: 🚅, high-speed train: 🚄, locomotive: 🚂 */
+  '3': { symbol: '🚌', label: 'Bus'}, /* bus, or oncoming bus: 🚍, trolley bus: 🚎 */
+  '4': { symbol: '⛴', label: 'Ferry'}, /* ferry, or ship: ️🚢 */
+  '5': { symbol: '🚋', label: 'Cable Car'}, /* tram car (nothing better available) */
+  '6': { symbol: '🚠', label: 'Gondola'}, /* mountain cableway, or aerial tramway: 🚡 */
+  '7': { symbol: '🚞', label: 'Funicular'}, /* mountain railway */
+}

--- a/frontend/src/UIConstants.js
+++ b/frontend/src/UIConstants.js
@@ -2,7 +2,16 @@
  * Constants for the UI that allow for reconfiguration.
  */
 
+import React from 'react';
 import indigo from '@material-ui/core/colors/indigo';
+import DirectionsBusIcon from '@material-ui/icons/DirectionsBusOutlined';
+import DirectionsBoatIcon from '@material-ui/icons/DirectionsBoat';
+import DirectionsTransitIcon from '@material-ui/icons/DirectionsTransit';
+import SubwayIcon from '@material-ui/icons/Subway';
+import TrainIcon from '@material-ui/icons/Train';
+import TramIcon from '@material-ui/icons/TramOutlined';
+
+
 
 // Colors definition:
 // This section its should be use to declare an object color
@@ -99,12 +108,24 @@ export const DWELL_THRESHOLD_SECS = 120;
  * 7 - Funicular. Any rail system designed for steep inclines.
  */
 export const ROUTE_TYPE_EMOJIS = {
-  '0': { symbol: '🚈', label: 'Light Rail'}, /* light rail, or railway car: 🚃, or tram: 🚊, tram car: 🚋  */
-  '1': { symbol: '🚇', label: 'Subway'}, /* metro */
-  '2': { symbol: '🚆', label: 'Rail'}, /* train, or bullet train: 🚅, high-speed train: 🚄, locomotive: 🚂 */
-  '3': { symbol: '🚌', label: 'Bus'}, /* bus, or oncoming bus: 🚍, trolley bus: 🚎 */
-  '4': { symbol: '⛴', label: 'Ferry'}, /* ferry, or ship: ️🚢 */
-  '5': { symbol: '🚋', label: 'Cable Car'}, /* tram car (nothing better available) */
-  '6': { symbol: '🚠', label: 'Gondola'}, /* mountain cableway, or aerial tramway: 🚡 */
-  '7': { symbol: '🚞', label: 'Funicular'}, /* mountain railway */
+  '0': { symbol: '🚈', label: 'Light Rail', muiIcon: TramIcon }, /* light rail, or railway car: 🚃, or tram: 🚊, tram car: 🚋  */
+  '1': { symbol: '🚇', label: 'Subway', muiIcon: SubwayIcon }, /* metro */
+  '2': { symbol: '🚆', label: 'Rail', muiIcon: TrainIcon }, /* train, or bullet train: 🚅, high-speed train: 🚄, locomotive: 🚂 */
+  '3': { symbol: '🚌', label: 'Bus', muiIcon: DirectionsBusIcon}, /* bus, or oncoming bus: 🚍, trolley bus: 🚎 */
+  '4': { symbol: '⛴', label: 'Ferry', muiIcon: DirectionsBoatIcon}, /* ferry, or ship: ️🚢 */
+  '5': { symbol: '🚋', label: 'Cable Car', muiIcon: TramIcon}, /* tram car (nothing better available) */
+  '6': { symbol: '🚠', label: 'Gondola', muiIcon: DirectionsTransitIcon}, /* mountain cableway, or aerial tramway: 🚡 */
+  '7': { symbol: '🚞', label: 'Funicular', muiIcon: TramIcon}, /* mountain railway */
+}
+
+export function RouteIcon(props) {
+  const emojiProps = ROUTE_TYPE_EMOJIS[props.routeType];
+
+  // JSX type can be a capitalized variable.
+  if (emojiProps) {
+    const IconType = emojiProps.muiIcon;
+    return <IconType {...props} />;
+  } else {
+    return null;
+  }
 }

--- a/frontend/src/components/Emoji.jsx
+++ b/frontend/src/components/Emoji.jsx
@@ -1,0 +1,38 @@
+/**
+ * Emoji wrapper component adapted from https://github.com/SeanMcP/a11y-react-emoji/blob/master/src/Emoji.tsx
+ *
+ * See also https://www.npmjs.com/package/a11y-react-emoji
+ */
+
+import React from 'react';
+import { ROUTE_TYPE_EMOJIS } from '../UIConstants';
+
+function Emoji(props) {
+  const { label, symbol, ...rest } = props;
+  return (
+    <span
+      aria-hidden={label ? undefined : true}
+      aria-label={label ? label : undefined}
+      role="img"
+      {...rest}
+    >
+      {symbol}
+    </span>
+    );
+};
+
+/**
+ * Returns an accessible emoji corresponding to the given route type.
+ *
+ * @param type {Number} GTFS route type
+ */
+export function EmojiForRouteType(type) {
+  const emojiProps = ROUTE_TYPE_EMOJIS[type];
+  if (emojiProps) {
+    return Emoji(emojiProps);
+  } else {
+    return '';
+  }
+}
+
+export default Emoji;

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -29,6 +29,7 @@ import {
 } from '../helpers/routeCalculations';
 
 import { handleGraphParams, fetchPrecomputedWaitAndTripData } from '../actions';
+import { EmojiForRouteType } from './Emoji';
 
 function desc(a, b, orderBy) {
   // Treat NaN as infinity, so that it goes to the bottom of the table in an ascending sort.
@@ -375,7 +376,7 @@ function RouteTable(props) {
                           },
                         }}
                       >
-                        {row.title}
+                        {EmojiForRouteType(row.type)} {row.title}
                       </Navlink>
                     </TableCell>
                     <TableCell

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -362,6 +362,7 @@ function RouteTable(props) {
                       id={labelId}
                       scope="row"
                       padding="none"
+                      style={{border:'none', paddingTop:6, paddingBottom:6}}                      
                     >
                       <Navlink
                         style={{color: theme.palette.primary.dark, textDecoration: 'none'}}

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -30,6 +30,7 @@ import {
 
 import { handleGraphParams, fetchPrecomputedWaitAndTripData } from '../actions';
 import { EmojiForRouteType } from './Emoji';
+import { RouteIcon } from '../UIConstants';
 
 function desc(a, b, orderBy) {
   // Treat NaN as infinity, so that it goes to the bottom of the table in an ascending sort.
@@ -377,7 +378,9 @@ function RouteTable(props) {
                           },
                         }}
                       >
-                        {EmojiForRouteType(row.type)} {row.title}
+                        {/*EmojiForRouteType(row.type)*/}
+                        {RouteIcon({routeType: row.type, style:{verticalAlign:'sub'}})}
+                        {row.title}
                       </Navlink>
                     </TableCell>
                     <TableCell

--- a/frontend/src/screens/RouteScreen.jsx
+++ b/frontend/src/screens/RouteScreen.jsx
@@ -14,6 +14,7 @@ import DateTimePanel from '../components/DateTimePanel';
 import { getAgency } from '../config';
 import ControlPanel from '../components/ControlPanel';
 import RouteSummary from '../components/RouteSummary';
+import { EmojiForRouteType } from '../components/Emoji';
 
 import { fetchRoutes } from '../actions';
 
@@ -73,7 +74,7 @@ function RouteScreen(props) {
       
       <Paper>
         <Box p={2} className="page-title">            
-          {selectedRoute ? ` ${selectedRoute.title}` : null}
+          {selectedRoute ? <Fragment>{EmojiForRouteType(selectedRoute.type)} {selectedRoute.title}</Fragment> : null}
           {direction ? ` > ${direction.title}` : null}
           &nbsp;
           {startStopInfo ? `(from ${startStopInfo.title}` : null}

--- a/frontend/src/screens/RouteScreen.jsx
+++ b/frontend/src/screens/RouteScreen.jsx
@@ -15,6 +15,7 @@ import { getAgency } from '../config';
 import ControlPanel from '../components/ControlPanel';
 import RouteSummary from '../components/RouteSummary';
 import { EmojiForRouteType } from '../components/Emoji';
+import { RouteIcon } from '../UIConstants';
 
 import { fetchRoutes } from '../actions';
 
@@ -74,7 +75,11 @@ function RouteScreen(props) {
       
       <Paper>
         <Box p={2} className="page-title">            
-          {selectedRoute ? <Fragment>{EmojiForRouteType(selectedRoute.type)} {selectedRoute.title}</Fragment> : null}
+          {selectedRoute ? <Fragment>
+            {/*EmojiForRouteType(selectedRoute.type)*/}
+            {RouteIcon({routeType: selectedRoute.type, style:{verticalAlign:'sub'}})}
+            {selectedRoute.title}
+          </Fragment> : null}
           {direction ? ` > ${direction.title}` : null}
           &nbsp;
           {startStopInfo ? `(from ${startStopInfo.title}` : null}


### PR DESCRIPTION
<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->

This a partial prototype for #457, show route type in UI, to get early feedback and to hand over if anybody else is interested in taking over.


<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

Using native (UTF-8) emojis, wrapped in a span for accessibility.  Created constants to represent emoji symbol and label by GTFS route type.

Added emoji to route names in the route table, and in the bread crumb, just to see how it looks.  Alternate emojis are noted in the source code.

## Screenshot

Route table:

![Screen Shot 2019-12-02 at 11 15 31 PM](https://user-images.githubusercontent.com/44861283/70028514-b1f33480-1559-11ea-9de3-202011bf0904.png)

Stop to stop:

![Screen Shot 2019-12-02 at 11 16 29 PM](https://user-images.githubusercontent.com/44861283/70028562-cdf6d600-1559-11ea-91fe-1610195ee7c1.png)

(Could add emojis to route picker, "from stop" dropdown label, and map, depending on how far we want to take it).

## Link to demo, if any

n/a
