### PR TITLE
When arrival history is not found, return an empty history instead of…

### DIFF
--- a/backend/models/metrics.py
+++ b/backend/models/metrics.py
@@ -40,8 +40,8 @@ class RouteMetrics:
         try:
             self.arrival_histories[d] = history = arrival_history.get_by_date(self.agency_id, self.route_id, d)
         except FileNotFoundError as ex:
-            raise errors.ArrivalHistoryNotFoundError(f"Arrival history not found for route {self.route_id} on {d}")
-
+            print(f'Arrival history not found for route {self.route_id} on {d}', file=sys.stderr)
+            history = arrival_history.ArrivalHistory(self.agency_id, self.route_id, {});
         return history
 
     def get_data_frame(self, d, stop_id=None, direction_id=None):


### PR DESCRIPTION


<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->

Fixes #486 


<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

When an arrival history is not found, return an empty history instead of throwing an error.  This allows date range queries to span days that a route is not running.

If no histories at all are found (e.g., a query for one future date), then the UI reports "No trip summary (No trip data between selected stops.)" instead of showing a backend error message.



## Screenshot

![Screen Shot 2019-12-12 at 5 26 22 PM](https://user-images.githubusercontent.com/44861283/70762173-89f79400-1d04-11ea-9992-1749ce2e7f2c.png)

## Link to demo, if any

n/a
