### PR TITLE
Compute wait time statistics over multiple days

### DIFF
--- a/backend/models/metrics.py
+++ b/backend/models/metrics.py
@@ -97,7 +97,10 @@ class RouteMetrics:
 
             wait_stats_arr.append(wait_stats)
 
-        return wait_stats_arr
+        if len(wait_stats_arr) == 1:
+            return wait_stats_arr[0]
+        else:
+            return wait_times.combine_stats(wait_stats_arr)
 
     def get_arrivals(self, direction_id, stop_id, rng: Range):
         return self._get_count(direction_id, stop_id, rng, self.get_history_data_frame, 'TIME')

--- a/backend/models/wait_times.py
+++ b/backend/models/wait_times.py
@@ -9,7 +9,10 @@ from pathlib import Path
 import json
 
 def get_stats(time_values, start_time=None, end_time=None):
-    return WaitTimeStats(time_values, start_time, end_time)
+    return IntervalWaitTimeStats(time_values, start_time, end_time)
+
+def combine_stats(interval_stats_arr):
+    return MultiIntervalWaitTimeStats(interval_stats_arr)
 
 # WaitTimeStats allows computing statistics about wait times within an interval,
 # (such as averages, percentiles, and histograms),
@@ -100,6 +103,85 @@ def get_stats(time_values, start_time=None, end_time=None):
 # Note: all returned statistics are in minutes (not seconds)
 #
 class WaitTimeStats:
+    def get_cumulative_distribution(self):
+        raise NotImplementedError
+
+    def get_average(self):
+        raise NotImplementedError
+
+    def get_quantiles(self, quantiles):
+        cdf_points = self.get_cumulative_distribution()
+        if cdf_points is None:
+            return None
+
+        cdf_domain, cdf_range = cdf_points.T
+
+        quantile_values = []
+
+        for quantile in quantiles:
+            segment_end_index = np.searchsorted(cdf_range, quantile)
+            if segment_end_index == 0:
+                quantile_values.append(cdf_domain[0])
+            else:
+                segment_start_index = segment_end_index - 1
+                # linear interpolation to find wait time where value of CDF = quantile
+                quantile_value = cdf_domain[segment_start_index] + \
+                    (quantile - cdf_range[segment_start_index]) / \
+                    (cdf_range[segment_end_index] - cdf_range[segment_start_index]) * \
+                    (cdf_domain[segment_end_index] - cdf_domain[segment_start_index])
+                quantile_values.append(quantile_value)
+
+        return np.array(quantile_values)
+
+    def get_quantile(self, quantile):
+        quantiles = self.get_quantiles([quantile])
+        if quantiles is None:
+            return None
+        return quantiles[0]
+
+    def get_percentiles(self, percentiles):
+        return self.get_quantiles(np.array(percentiles) / 100)
+
+    def get_percentile(self, percentile):
+        return self.get_quantile(percentile / 100)
+
+    def get_histogram(self, bins):
+        cdf_points = self.get_cumulative_distribution()
+        if cdf_points is None:
+            return None
+
+        cdf_domain, cdf_range = cdf_points.T
+
+        histogram = []
+        prev_cumulative_value = None
+        for bin_index, bin_value in enumerate(bins):
+            cumulative_value = evaluate_cdf(bin_value, cdf_domain, cdf_range)
+
+            if prev_cumulative_value is not None:
+                histogram.append(cumulative_value - prev_cumulative_value)
+
+            prev_cumulative_value = cumulative_value
+
+        return np.array(histogram)
+
+    def get_probability_less_than(self, wait_time):
+        cdf_points = self.get_cumulative_distribution()
+        if cdf_points is None:
+            return None
+
+        cdf_domain, cdf_range = cdf_points.T
+
+        return evaluate_cdf(wait_time, cdf_domain, cdf_range)
+
+    def get_probability_greater_than(self, wait_time):
+        prob_less = self.get_probability_less_than(wait_time)
+
+        if prob_less is None:
+            return None
+
+        return 1.0 - prob_less
+
+class IntervalWaitTimeStats(WaitTimeStats):
     def __init__(self, time_values, start_time = None, end_time = None):
         self.time_values = time_values
 
@@ -220,7 +302,7 @@ class WaitTimeStats:
                 num_occurrences_with_smaller_wait_time = num_wait_time_values - i
                 if end_wait_time is not None and wait_time <= end_wait_time:
                     # for wait times less than or equal to end_wait_time,
-                    # adjust num_occurrences_with_smaller_headway to avoid counting end_wait_time and end_wait_time + end_elapsed_time
+                    # adjust num_occurrences_with_smaller_wait_time to avoid counting end_wait_time and end_wait_time + end_elapsed_time
                     # otherwise, no adjustment needed
                     num_occurrences_with_smaller_wait_time -= 2
 
@@ -255,85 +337,6 @@ class WaitTimeStats:
 
         return self.cdf_points
 
-    def get_quantiles(self, quantiles):
-        cdf_points = self.get_cumulative_distribution()
-        if cdf_points is None:
-            return None
-
-        cdf_domain, cdf_range = cdf_points.T
-
-        quantile_values = []
-
-        for quantile in quantiles:
-            segment_end_index = np.searchsorted(cdf_range, quantile)
-            if segment_end_index == 0:
-                quantile_values.append(cdf_domain[0])
-            else:
-                segment_start_index = segment_end_index - 1
-                # linear interpolation to find wait time where value of CDF = quantile
-                quantile_value = cdf_domain[segment_start_index] + \
-                    (quantile - cdf_range[segment_start_index]) / \
-                    (cdf_range[segment_end_index] - cdf_range[segment_start_index]) * \
-                    (cdf_domain[segment_end_index] - cdf_domain[segment_start_index])
-                quantile_values.append(quantile_value)
-
-        return np.array(quantile_values)
-
-    def get_percentiles(self, percentiles):
-        return self.get_quantiles(np.array(percentiles) / 100)
-
-    def get_histogram(self, bins):
-        cdf_points = self.get_cumulative_distribution()
-        if cdf_points is None:
-            return None
-
-        cdf_domain, cdf_range = cdf_points.T
-
-        histogram = []
-        prev_cumulative_value = None
-        for bin_index, bin_value in enumerate(bins):
-            cumulative_value = self._get_probability_less_than(bin_value, cdf_domain, cdf_range)
-
-            if prev_cumulative_value is not None:
-                histogram.append(cumulative_value - prev_cumulative_value)
-
-            prev_cumulative_value = cumulative_value
-
-        return np.array(histogram)
-
-    def get_probability_less_than(self, wait_time):
-        cdf_points = self.get_cumulative_distribution()
-        if cdf_points is None:
-            return None
-
-        cdf_domain, cdf_range = cdf_points.T
-
-        return self._get_probability_less_than(wait_time, cdf_domain, cdf_range)
-
-    def get_probability_greater_than(self, wait_time):
-        prob_less = self.get_probability_less_than(wait_time)
-
-        if prob_less is None:
-            return None
-
-        return 1.0 - prob_less
-
-    def _get_probability_less_than(self, wait_time, cdf_domain, cdf_range):
-        segment_end_index = np.searchsorted(cdf_domain, wait_time)
-
-        if segment_end_index >= len(cdf_domain):
-            return 1.0
-        elif segment_end_index == 0:
-            return 0.0
-        else:
-            segment_start_index = segment_end_index - 1
-
-            # linear interpolation to find value of CDF with wait time = bin_value
-            return cdf_range[segment_start_index] + \
-                (wait_time - cdf_domain[segment_start_index]) / \
-                (cdf_domain[segment_end_index] - cdf_domain[segment_start_index]) * \
-                (cdf_range[segment_end_index] - cdf_range[segment_start_index])
-
     def get_sampled_waits(self, sample_sec=60):
         if self.is_empty:
             return None
@@ -354,6 +357,91 @@ class WaitTimeStats:
         waits = next_arrival_times - sample_time_values
 
         return waits[np.logical_not(np.isnan(waits))] / 60
+
+class MultiIntervalWaitTimeStats(WaitTimeStats):
+    def __init__(self, interval_stats_arr):
+        self.interval_stats_arr = interval_stats_arr
+        self.cdf_points = None
+
+    def get_average(self):
+        # With each interval weighted equally, the average wait time for all intervals
+        # is the average of the average wait times for each interval.
+
+        count = 0
+        total = 0
+
+        for interval_stats in self.interval_stats_arr:
+            interval_avg = interval_stats.get_average()
+            if interval_avg is not None:
+                total += interval_avg
+                count += 1
+
+        if count == 0:
+            return None
+
+        return total / count
+
+    def get_cumulative_distribution(self):
+        if self.cdf_points is not None:
+            return self.cdf_points
+
+        num_intervals = 0
+        cdf_domains = []
+        cdf_ranges = []
+
+        # With each interval weighted equally, the probability of a wait time less than a certain amount
+        # (CDF value) is the average of the values of the CDFs for each interval.
+        # Since each interval's CDF is piecewise linear, the combined CDF will be piecewise linear
+        # between all of the unique domain values defining the intervals' CDFs.
+
+        for interval_stats in self.interval_stats_arr:
+            cdf_points = interval_stats.get_cumulative_distribution()
+
+            if cdf_points is not None:
+                cdf_domain, cdf_range = cdf_points.T
+                cdf_domains.append(cdf_domain)
+                cdf_ranges.append(cdf_range)
+                num_intervals += 1
+
+        if num_intervals == 0:
+            return None
+
+        combined_domain = np.unique(np.concatenate(cdf_domains))
+
+        combined_cdf_points = []
+
+        for wait_time in combined_domain:
+            total_value = 0
+            for cdf_domain, cdf_range in zip(cdf_domains, cdf_ranges):
+                total_value += evaluate_cdf(wait_time, cdf_domain, cdf_range)
+
+            combined_cdf_points.append((wait_time, total_value / num_intervals))
+
+        self.cdf_points = np.array(combined_cdf_points)
+
+        return self.cdf_points
+
+def evaluate_cdf(wait_time, cdf_domain, cdf_range):
+    segment_end_index = np.searchsorted(cdf_domain, wait_time)
+
+    if segment_end_index >= len(cdf_domain):
+        return 1.0
+    elif segment_end_index == 0:
+        return 0.0
+    else:
+        segment_start_index = segment_end_index - 1
+
+        prev_value = cdf_range[segment_start_index]
+        extra_wait_time = wait_time - cdf_domain[segment_start_index]
+
+        if extra_wait_time == 0:
+            return prev_value
+
+        # linear interpolation to find value of CDF with wait time = bin_value
+        return prev_value + \
+             extra_wait_time / \
+            (cdf_domain[segment_end_index] - cdf_domain[segment_start_index]) * \
+            (cdf_range[segment_end_index] - cdf_range[segment_start_index])
 
 DefaultVersion = 'v1b'
 

--- a/backend/waits.py
+++ b/backend/waits.py
@@ -50,19 +50,11 @@ if __name__ == '__main__':
     else:
         raise Exception('missing date, start-date, or end-date')
 
-    waits = []
-
     # print results for each direction
     for stop_dir in stop_dirs:
         dir_info = route_config.get_direction_info(stop_dir)
 
-        averages = []
-        minimums = []
-        medians = []
-        p10s = []
-        p90s = []
-        maximums = []
-
+        interval_stats_arr = []
         first_bus_date_times = []
         last_bus_date_times = []
 
@@ -81,17 +73,8 @@ if __name__ == '__main__':
             last_bus_date_times.append(datetime.fromtimestamp(departure_times[-1], tz))
 
             stats = wait_times.get_stats(departure_times, start_time, end_time)
-            average = stats.get_average()
-            if average is not None:
-                averages.append(average)
 
-            quantiles = stats.get_quantiles([0,0.1,0.5,0.9,1])
-            if quantiles is not None:
-                minimums.append(quantiles[0])
-                p10s.append(quantiles[1])
-                medians.append(quantiles[2])
-                p90s.append(quantiles[3])
-                maximums.append(quantiles[4])
+            interval_stats_arr.append(stats)
 
         print(f"Date: {', '.join([str(date) for date in dates])}")
         print(f"Local Time Range: [{start_time_str}, {end_time_str}]")
@@ -99,18 +82,17 @@ if __name__ == '__main__':
         print(f"Stop: {stop} ({stop_info.title})")
         print(f"Direction: {stop_dir} ({dir_info.title})")
 
-        if len(averages) > 0:
-            print(f'first bus departure = {" ".join([str(dt) for dt in first_bus_date_times])}')
-            print(f'last bus departure  = {" ".join([str(dt) for dt in last_bus_date_times])}')
+        if len(interval_stats_arr) == 1:
+            stats = interval_stats_arr[0]
+        else:
+            stats = wait_times.combine_stats(interval_stats_arr)
 
-            # approximate average over multiple days by taking average of averages
-            print(f'average wait time   = {round(np.average(averages),1)} min')
+        print(f'first bus departure = {" ".join([str(dt) for dt in first_bus_date_times])}')
+        print(f'last bus departure  = {" ".join([str(dt) for dt in last_bus_date_times])}')
 
-            print(f'shortest wait time  = {round(np.min(minimums),1)} min')
-
-            # approximate percentiles over multiple days by taking median of each percentile
-            print(f'10% wait time       = {round(np.median(p10s),1)} min')
-            print(f'median wait time    = {round(np.median(medians),1)} min')
-            print(f'90% wait time       = {round(np.median(p90s),1)} min')
-
-            print(f'longest wait time   = {round(np.max(maximums),1)} min')
+        print(f'average wait time   = {round(stats.get_average(),1)} min')
+        print(f'shortest wait time  = {round(stats.get_quantile(0),1)} min')
+        print(f'10% wait time       = {round(stats.get_quantile(0.1),1)} min')
+        print(f'median wait time    = {round(stats.get_quantile(0.5),1)} min')
+        print(f'90% wait time       = {round(stats.get_quantile(0.9),1)} min')
+        print(f'longest wait time   = {round(stats.get_quantile(1),1)} min')

--- a/docs/metrics_api.md
+++ b/docs/metrics_api.md
@@ -724,6 +724,37 @@ Contains metrics data that shows how well the actual arrival or departure times 
 | `scheduledCount` | `Int` | The total number of scheduled arrival/departure times. This should be used as the denominator when computing the rate of on-time/late/early/missing arrivals. |
 | `closestDeltas` | [`BasicStats`](#basicstats) | Contains metrics for the difference between the closest actual time and the scheduled time (in minutes), for each scheduled time. Positive values indicate that the actual arrival or departure occurred after the scheduled time. (Each scheduled time is counted once, although the closest deltas for different scheduled times may correspond to the same actual arrival/departure time.) |
 
+### WaitTimeStats
+
+Contains statistics about wait times at a stop within one or more intervals.
+For each interval, these statistics are computed assuming that a rider has an equal probability of arriving at the stop any time in that interval,
+but not before the first departure of the day or after the last departure of the day.
+If statistics are computed over multiple intervals, each interval will be weighted equally (not weighted by the length of the interval).
+These statistics assume that the rider arrives at the stop at a "random" time without using schedules or predictions.
+
+| Field Name | Type | Description |
+| --- | --- | --- |
+| `avg` | `Float` | The average wait time. |
+| `min` | `Float` | The minimum wait time (will be 0 if there are any arrivals in the interval). |
+| `median` | `Float` | The median wait time. |
+| `max` | `Float` | The maximum wait time. |
+| `percentiles` | [`[PercentileData]`](#percentiledata) | Data for percentile values of wait times. |
+| `histogram` | [`[HistogramBin]`](#histogrambin) | Data for rendering histograms on the frontend. |
+
+#### Parameters for `percentiles`
+
+| Parameter Name | Type | Description |
+| --- | --- | --- |
+| `percentiles` | `[Float]` | List of percentiles to return. |
+
+#### Parameters for `histogram`
+
+| Parameter Name | Type | Description |
+| --- | --- | --- |
+| `min` | `Float` | Start of first histogram bin. |
+| `max` | `Float` | End of last histogram bin. |
+| `binSize` | `Float` | Size of histogram bins. |
+
 ### BasicIntervalMetrics
 
 Contains metrics data at a particular pair of stops on a single route at a particular time range and list of dates.


### PR DESCRIPTION
Fixes #488.

The GraphQL API allows returning wait time statistics over multiple days, but previously the returned statistics were only actually from the first day.

This PR implements a MultiIntervalWaitTimeStats class that returns statistics over multiple intervals, assuming each interval is weighted equally (not weighted by their length).

Most wait time statistics (other than the average) are computed from the cumulative distribution function (CDF), which gives the probability of having a wait time less than a given number of minutes if someone arrives at a stop at a random time between the first and last departure time of the day. 

With each interval weighted equally, the probability of a wait time less than a given number of minutes (CDF value) is the average of the values of the CDFs for each interval. Since each interval's CDF is piecewise linear, the combined CDF will be piecewise linear between all of the unique domain values defining the intervals' CDFs.