### PR TITLE
Improve algorithm for generating trips from possible arrivals; handle loops, figure-eights, routes that double back

### DIFF
--- a/backend/compute_trip_times.py
+++ b/backend/compute_trip_times.py
@@ -113,9 +113,9 @@ def add_trip_time_stats_for_route(all_trip_time_stats, timestamp_intervals, stat
             arrival_trip_values_by_stop[stop_id] = sorted_arrival_trip_values
             arrival_time_values_by_stop[stop_id] = sorted_arrival_time_values
 
-        j_end_index = num_stops - 1 if is_loop else num_stops
+        i_end_index = num_stops if is_loop else (num_stops - 1)
 
-        for i in range(0, num_stops-1):
+        for i in range(0, i_end_index):
 
             s1 = stop_ids[i]
 
@@ -138,7 +138,7 @@ def add_trip_time_stats_for_route(all_trip_time_stats, timestamp_intervals, stat
 
             j_start_index = 0 if is_loop else i + 1
 
-            for j in range(j_start_index, j_end_index):
+            for j in range(j_start_index, num_stops):
                 s2 = stop_ids[j]
 
                 for interval_index, _ in enumerate(timestamp_intervals):

--- a/backend/compute_trip_times.py
+++ b/backend/compute_trip_times.py
@@ -78,6 +78,8 @@ def add_trip_time_stats_for_route(all_trip_time_stats, timestamp_intervals, stat
     for dir_info in route_config.get_direction_infos():
         dir_id = dir_info.id
 
+        is_loop = dir_info.is_loop()
+
         for interval_index, _ in enumerate(timestamp_intervals):
             for stat_id in stat_ids:
                 all_trip_time_stats[interval_index][stat_id][route_id][dir_id] = {}
@@ -85,7 +87,8 @@ def add_trip_time_stats_for_route(all_trip_time_stats, timestamp_intervals, stat
         stop_ids = dir_info.get_stop_ids()
         num_stops = len(stop_ids)
 
-        trip_values_by_stop = {}
+        departure_trip_values_by_stop = {}
+        arrival_trip_values_by_stop = {}
         departure_time_values_by_stop = {}
         arrival_time_values_by_stop = {}
 
@@ -93,16 +96,30 @@ def add_trip_time_stats_for_route(all_trip_time_stats, timestamp_intervals, stat
             stop_df = route_df[(sid_values == stop_id) & (did_values == dir_id)]
 
             trip_values = stop_df['TRIP'].values
+            departure_time_values = stop_df['DEPARTURE_TIME'].values
+            arrival_time_values = stop_df['TIME'].values
 
-            trip_values_by_stop[stop_id] = trip_values
-            departure_time_values_by_stop[stop_id] = stop_df['DEPARTURE_TIME'].values
-            arrival_time_values_by_stop[stop_id] = stop_df['TIME'].values
+            if is_loop:
+                sorted_departure_time_values, sorted_departure_trip_values = trip_times.sort_parallel(departure_time_values, trip_values)
+                sorted_arrival_time_values, sorted_arrival_trip_values = trip_times.sort_parallel(arrival_time_values, trip_values)
+            else:
+                sorted_departure_trip_values = trip_values
+                sorted_arrival_trip_values = trip_values
+                sorted_departure_time_values = departure_time_values
+                sorted_arrival_time_values = arrival_time_values
+
+            departure_trip_values_by_stop[stop_id] = sorted_departure_trip_values
+            departure_time_values_by_stop[stop_id] = sorted_departure_time_values
+            arrival_trip_values_by_stop[stop_id] = sorted_arrival_trip_values
+            arrival_time_values_by_stop[stop_id] = sorted_arrival_time_values
+
+        j_end_index = num_stops - 1 if is_loop else num_stops
 
         for i in range(0, num_stops-1):
 
             s1 = stop_ids[i]
 
-            s1_trip_values = trip_values_by_stop[s1]
+            s1_trip_values = departure_trip_values_by_stop[s1]
 
             if len(s1_trip_values) == 0:
                 continue
@@ -119,15 +136,18 @@ def add_trip_time_stats_for_route(all_trip_time_stats, timestamp_intervals, stat
                 for stat_id in stat_ids:
                     all_trip_time_stats[interval_index][stat_id][route_id][dir_id][s1] = {}
 
-            for j in range(i + 1, num_stops):
+            j_start_index = 0 if is_loop else i + 1
+
+            for j in range(j_start_index, j_end_index):
                 s2 = stop_ids[j]
 
                 for interval_index, _ in enumerate(timestamp_intervals):
                     trip_min = trip_times.get_completed_trip_times(
                         s1_trip_values_by_interval[interval_index],
                         s1_departure_time_values_by_interval[interval_index],
-                        trip_values_by_stop[s2],
+                        arrival_trip_values_by_stop[s2],
                         arrival_time_values_by_stop[s2],
+                        is_loop=is_loop,
                         assume_sorted=True
                     )
 

--- a/backend/compute_trip_times.py
+++ b/backend/compute_trip_times.py
@@ -100,9 +100,11 @@ def add_trip_time_stats_for_route(all_trip_time_stats, timestamp_intervals, stat
             arrival_time_values = stop_df['TIME'].values
 
             if is_loop:
+                # for loop routes, pre-sort arrays by departure/arrival times for better performance.
                 sorted_departure_time_values, sorted_departure_trip_values = trip_times.sort_parallel(departure_time_values, trip_values)
                 sorted_arrival_time_values, sorted_arrival_trip_values = trip_times.sort_parallel(arrival_time_values, trip_values)
             else:
+                # for non-loop routes, arrays are already sorted by trip ID.
                 sorted_departure_trip_values = trip_values
                 sorted_arrival_trip_values = trip_values
                 sorted_departure_time_values = departure_time_values

--- a/backend/models/arrival_history.py
+++ b/backend/models/arrival_history.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import gzip
 import numpy as np
 
-DefaultVersion = 'v4b'
+DefaultVersion = 'v4c'
 
 class ArrivalHistory:
     def __init__(self, agency_id: str, route_id, stops_data, start_time = None, end_time = None, version = DefaultVersion):

--- a/backend/models/gtfs.py
+++ b/backend/models/gtfs.py
@@ -536,15 +536,8 @@ class GtfsScraper:
             if not is_matched:
                 unmatched_last_stop_arrivals.append(last_stop_arrival)
 
-        print(unmatched_last_stop_arrivals)
-
         if len(unmatched_last_stop_arrivals) > 0:
-            print(first_stop_id)
-            print(len(direction_arrivals[first_stop_id]))
-            print(direction_arrivals[first_stop_id])
             direction_arrivals[first_stop_id].extend(unmatched_last_stop_arrivals)
-            print(len(direction_arrivals[first_stop_id]))
-            print(direction_arrivals[first_stop_id])
 
         orig_trip_ints = {}
         for trip_int, prev_trip_int in prev_trip_ints.items():

--- a/backend/models/gtfs.py
+++ b/backend/models/gtfs.py
@@ -25,6 +25,7 @@ def get_stop_geometry(stop_xy, shape_lines_xy, shape_cumulative_dist, start_inde
     shape_index = start_index
 
     while shape_index < num_shape_lines:
+
         shape_line_offset = shape_lines_xy[shape_index].distance(stop_xy)
 
         if shape_line_offset < best_offset:
@@ -826,7 +827,7 @@ class GtfsScraper:
         shape_prev_lat = np.r_[shape_lat[0], shape_lat[:-1]]
 
         # shape_cumulative_dist[i] is the cumulative distance in meters along the shape geometry from 0th to ith coordinate
-        shape_cumulative_dist = np.cumsum(util.haver_distance(shape_lon, shape_lat, shape_prev_lon, shape_prev_lat))
+        shape_cumulative_dist = np.cumsum(util.haver_distance(shape_lat, shape_lon, shape_prev_lat, shape_prev_lon))
 
         shape_lines_xy = [shapely.geometry.LineString(xy_geometry.coords[i:i+2]) for i in range(0, len(xy_geometry.coords) - 1)]
 

--- a/backend/models/metrics.py
+++ b/backend/models/metrics.py
@@ -3,7 +3,7 @@ import pytz
 import sys
 import time
 from datetime import date
-from . import wait_times, util, arrival_history, trip_times, errors, constants, timetables
+from . import wait_times, util, arrival_history, trip_times, errors, constants, timetables, routeconfig
 
 import pandas as pd
 import numpy as np
@@ -232,6 +232,18 @@ class RouteMetrics:
         if end_stop_id is None:
             return None
 
+        is_loop = False
+        route_config = routeconfig.get_route_config(self.agency_id, self.route_id)
+        if route_config is not None:
+            if direction_id is not None:
+                dir_info = route_config.get_direction_info(direction_id)
+            else:
+                direction_ids = route_config.get_directions_for_stop(start_stop_id)
+                dir_info = route_config.get_direction_info(direction_ids[0]) if len(direction_ids) > 0 else None
+
+            if dir_info is not None:
+                is_loop = dir_info.is_loop()
+
         for d in rng.dates:
             s1_df = get_data_frame(d, stop_id=start_stop_id, direction_id=direction_id)
             s2_df = get_data_frame(d, stop_id=end_stop_id, direction_id=direction_id)
@@ -249,7 +261,8 @@ class RouteMetrics:
                 s1_df['TRIP'].values,
                 s1_df['DEPARTURE_TIME'].values,
                 s2_df['TRIP'].values,
-                s2_df['TIME'].values
+                s2_df['TIME'].values,
+                is_loop = is_loop
             )
             completed_trips_arr.append(completed_trip_times)
 

--- a/backend/models/routeconfig.py
+++ b/backend/models/routeconfig.py
@@ -34,6 +34,9 @@ class RouteConfig:
         self.sort_order = data['sort_order']
         self.gtfs_route_id = data['gtfs_route_id']
 
+        self.dir_infos = {}
+        self.stop_infos = {}
+
     def get_direction_ids(self):
         return [direction['id'] for direction in self.data['directions']]
 
@@ -51,17 +54,29 @@ class RouteConfig:
         return [StopInfo(self, stop) for stop in self.data['stops'].values()]
 
     def get_stop_info(self, stop_id):
+        if stop_id in self.stop_infos:
+            return self.stop_infos[stop_id]
+
         if stop_id in self.data['stops']:
-            return StopInfo(self, self.data['stops'][stop_id])
+            stop_info = StopInfo(self, self.data['stops'][stop_id])
+            self.stop_infos[stop_id] = stop_info
+            return stop_info
+
         return None
 
     def get_direction_infos(self):
         return [DirectionInfo(direction) for direction in self.data['directions']]
 
     def get_direction_info(self, direction_id):
+        if direction_id in self.dir_infos:
+            return self.dir_infos[direction_id]
+
         for direction in self.data['directions']:
             if direction['id'] == direction_id:
-                return DirectionInfo(direction)
+                dir_info = DirectionInfo(direction)
+                self.dir_infos[direction_id] = dir_info
+                return dir_info
+
         return None
 
     def get_directions_for_stop(self, stop_id):

--- a/backend/models/routeconfig.py
+++ b/backend/models/routeconfig.py
@@ -1,7 +1,7 @@
 import re, os, time, requests, json
 from . import util, config
 
-DefaultVersion = 'v3'
+DefaultVersion = 'v3a'
 
 class StopInfo:
     def __init__(self, route, data):
@@ -19,6 +19,9 @@ class DirectionInfo:
         self.data = data
         self.gtfs_direction_id = data['gtfs_direction_id']
         self.gtfs_shape_id = data['gtfs_shape_id']
+
+    def is_loop(self):
+        return self.data.get('loop', False)
 
     def get_stop_ids(self):
         return self.data['stops']

--- a/backend/models/trip_times.py
+++ b/backend/models/trip_times.py
@@ -20,16 +20,17 @@ def get_completed_trip_times(
     #
     # The s1 arrays and s2 arrays may have different lengths.
     #
-    # The trip times are not necessarily parallel to s1 or s2 arrays.
+    # The returned trip times are not necessarily parallel to s1 or s2 arrays.
     #
     # If assume_sorted is true, the s1 and s2 arrays should already be sorted by trip ID (if is_loop is false)
     # or by departure / arrival time (if is_loop is true).
 
-    # if s1_trip_values and s2_trip_values are empty, this throws a ValueError
     if (len(s1_trip_values) == 0) or (len(s2_trip_values) == 0):
         return []
 
     if is_loop:
+        # If s1 and s2 are the same stop, this will compute the time to complete 1 full loop
+
         if not assume_sorted:
             s1_departure_time_values, s1_trip_values = sort_parallel(s1_departure_time_values, s1_trip_values)
             s2_arrival_time_values, s2_trip_values = sort_parallel(s2_arrival_time_values, s2_trip_values)
@@ -51,6 +52,11 @@ def find_indexes_of_next_arrival_times(
     sorted_s1_trip_values, sorted_s1_departure_time_values,
     sorted_s2_trip_values, sorted_s2_arrival_time_values
 ):
+    # Given two pairs of parallel arrays for each stop with trip IDs and departure/arrival times,
+    # already sorted by departure/arrival time, returns parallel lists of indexes into these pairs of arrays:
+    # each pair of indexes corresponds to a departure time (from the first stop)
+    # and the *next* arrival time (at the second stop) after that departure time.
+
     s1_len = len(sorted_s1_trip_values)
     s2_len = len(sorted_s2_trip_values)
 

--- a/backend/models/trip_times.py
+++ b/backend/models/trip_times.py
@@ -70,7 +70,7 @@ def sort_parallel(arr, arr2):
     sort_order = np.argsort(arr)
     return arr[sort_order], arr2[sort_order]
 
-DefaultVersion = 'v1b'
+DefaultVersion = 'v1c'
 
 class CachedTripTimes:
     def __init__(self, trip_times_data):

--- a/backend/models/trip_times.py
+++ b/backend/models/trip_times.py
@@ -10,6 +10,7 @@ from . import util, config
 def get_completed_trip_times(
     s1_trip_values, s1_departure_time_values,
     s2_trip_values, s2_arrival_time_values,
+    is_loop=False,
     assume_sorted=False):
     # Returns an array of trip times in minutes from stop s1 to stop s2
     # for trip IDs contained in both s1_trip_values and s2_trip_values.
@@ -21,23 +22,64 @@ def get_completed_trip_times(
     #
     # The trip times are not necessarily parallel to s1 or s2 arrays.
     #
-    # If assume_sorted is true, the s1 and s2 arrays should already be sorted by trip ID (not by time).
-
-    if not assume_sorted:
-        s1_trip_values, s1_departure_time_values = sort_parallel(s1_trip_values, s1_departure_time_values)
-        s2_trip_values, s2_arrival_time_values = sort_parallel(s2_trip_values, s2_arrival_time_values)
+    # If assume_sorted is true, the s1 and s2 arrays should already be sorted by trip ID (if is_loop is false)
+    # or by departure / arrival time (if is_loop is true).
 
     # if s1_trip_values and s2_trip_values are empty, this throws a ValueError
-    if (len(s1_trip_values) > 0) and (len(s2_trip_values) > 0):
+    if (len(s1_trip_values) == 0) or (len(s2_trip_values) == 0):
+        return []
+
+    if is_loop:
+        if not assume_sorted:
+            s1_departure_time_values, s1_trip_values = sort_parallel(s1_departure_time_values, s1_trip_values)
+            s2_arrival_time_values, s2_trip_values = sort_parallel(s2_arrival_time_values, s2_trip_values)
+
+        s1_indexes, s2_indexes = find_indexes_of_next_arrival_times(
+            s1_trip_values, s1_departure_time_values,
+            s2_trip_values, s2_arrival_time_values
+        )
+    else:
+        if not assume_sorted:
+            s1_trip_values, s1_departure_time_values = sort_parallel(s1_trip_values, s1_departure_time_values)
+            s2_trip_values, s2_arrival_time_values = sort_parallel(s2_trip_values, s2_arrival_time_values)
+
         _, (s1_indexes, s2_indexes) = snp.intersect(s1_trip_values, s2_trip_values, indices=True)
 
-        return (s2_arrival_time_values[s2_indexes] - s1_departure_time_values[s1_indexes]) / 60
-    else:
-        return []
+    return (s2_arrival_time_values[s2_indexes] - s1_departure_time_values[s1_indexes]) / 60
+
+def find_indexes_of_next_arrival_times(
+    sorted_s1_trip_values, sorted_s1_departure_time_values,
+    sorted_s2_trip_values, sorted_s2_arrival_time_values
+):
+    s1_len = len(sorted_s1_trip_values)
+    s2_len = len(sorted_s2_trip_values)
+
+    sorted_s1_indexes = []
+    sorted_s2_indexes = []
+
+    s2_start_index = 0
+    for s1_index in range(s1_len):
+        s1_departure_time = sorted_s1_departure_time_values[s1_index]
+        s1_trip = sorted_s1_trip_values[s1_index]
+
+        for s2_index in range(s2_start_index, s2_len):
+            s2_arrival_time = sorted_s2_arrival_time_values[s2_index]
+
+            if s2_arrival_time > s1_departure_time:
+                s2_trip = sorted_s2_trip_values[s2_index]
+                if s2_trip == s1_trip:
+                    sorted_s1_indexes.append(s1_index)
+                    sorted_s2_indexes.append(s2_index)
+                    break
+            else:
+                s2_start_index = s2_index + 1
+
+    return sorted_s1_indexes, sorted_s2_indexes
 
 def get_matching_trips_and_arrival_times(
     s1_trip_values, s1_departure_time_values,
-    s2_trip_values, s2_arrival_time_values):
+    s2_trip_values, s2_arrival_time_values,
+    is_loop=False):
 
     # Returns a tuple (array of trip times in minutes, array of s2 arrival times).
     # The returned arrays are parallel to s1_trip_values and s1_departure_time_values.
@@ -47,12 +89,34 @@ def get_matching_trips_and_arrival_times(
     #
     # The input arrays do not need to be sorted.
 
-    sort_order = np.argsort(s1_trip_values)
-    sorted_s1_trip_values = s1_trip_values[sort_order]
+    if is_loop:
+        # for loop routes, there may be multiple arrivals at a particular stop with the same trip ID.
+        # sort by departure or arrival time, then find the first arrival that appears after the departure time
+        # with the same trip ID.
 
-    sorted_s2_trip_values, sorted_s2_arrival_time_values = sort_parallel(s2_trip_values, s2_arrival_time_values)
+        sort_order = np.argsort(s1_departure_time_values)
 
-    _, (sorted_s1_indexes, sorted_s2_indexes) = snp.intersect(sorted_s1_trip_values, sorted_s2_trip_values, indices=True)
+        sorted_s1_departure_time_values = s1_departure_time_values[sort_order]
+        sorted_s1_trip_values = s1_trip_values[sort_order]
+
+        sorted_s2_arrival_time_values, sorted_s2_trip_values = sort_parallel(s2_arrival_time_values, s2_trip_values)
+
+        sorted_s1_indexes, sorted_s2_indexes = find_indexes_of_next_arrival_times(
+            sorted_s1_trip_values,
+            sorted_s1_departure_time_values,
+            sorted_s2_trip_values,
+            sorted_s2_arrival_time_values
+        )
+
+    else:
+        # for non-loop routes, there should be at most 1 departure/arrival for a particular trip ID.
+        # sort by trip ID, then use snp for better performance to find the indexes of matching trip IDs
+        sort_order = np.argsort(s1_trip_values)
+        sorted_s1_trip_values = s1_trip_values[sort_order]
+
+        sorted_s2_trip_values, sorted_s2_arrival_time_values = sort_parallel(s2_trip_values, s2_arrival_time_values)
+
+        _, (sorted_s1_indexes, sorted_s2_indexes) = snp.intersect(sorted_s1_trip_values, sorted_s2_trip_values, indices=True)
 
     # start with an array of all nans
     s1_s2_arrival_time_values = np.full(len(s1_trip_values), np.nan)

--- a/backend/models/wait_times.py
+++ b/backend/models/wait_times.py
@@ -355,7 +355,7 @@ class WaitTimeStats:
 
         return waits[np.logical_not(np.isnan(waits))] / 60
 
-DefaultVersion = 'v1b'
+DefaultVersion = 'v1c'
 
 class CachedWaitTimes:
     def __init__(self, wait_times_data):

--- a/backend/trips.py
+++ b/backend/trips.py
@@ -61,11 +61,14 @@ if __name__ == '__main__':
 
     dir_info = route_config.get_direction_info(common_dirs[0])
 
-    for s in dir_info.get_stop_ids():
-        if s == s1:
-            break
-        if s == s2:
-            raise Exception(f"stop {s1} comes after stop {s2} in the {dir_info.name} direction")
+    is_loop = dir_info.is_loop()
+
+    if not is_loop:
+        for s in dir_info.get_stop_ids():
+            if s == s1:
+                break
+            if s == s2:
+                raise Exception(f"stop {s1} comes after stop {s2} in the {dir_info.name} direction")
 
     date_strs = []
     tz = agency.tz
@@ -100,9 +103,10 @@ if __name__ == '__main__':
             s1_df['DEPARTURE_TIME'].values,
             s2_df['TRIP'].values,
             s2_df['TIME'].values,
+            is_loop
         )
 
-        s1_df['DATE_TIME'] = s1_df['TIME'].apply(lambda t: datetime.fromtimestamp(t, tz))
+        s1_df['DATE_TIME'] = s1_df['DEPARTURE_TIME'].apply(lambda t: datetime.fromtimestamp(t, tz))
 
         if s1_df.empty:
             print(f"no arrival times found for stop {s1} on {d}")
@@ -113,7 +117,7 @@ if __name__ == '__main__':
 
                 trip_str = f'#{row.TRIP}'.rjust(5)
 
-                print(f"s1_t={row.DATE_TIME.date()} {row.DATE_TIME.time()} ({row.TIME}) s2_t={dest_arrival_time_str} ({dest_arrival_time}) vid:{row.VID}  {trip_str}   {round(row.trip_min, 1)} min trip")
+                print(f"s1_t={row.DATE_TIME.date()} {row.DATE_TIME.time()} ({row.DEPARTURE_TIME}) s2_t={dest_arrival_time_str} ({dest_arrival_time}) vid:{row.VID}  {trip_str}   {round(row.trip_min, 1)} min trip")
 
             completed_trips_arr.append(s1_df.trip_min[s1_df.trip_min.notnull()])
 

--- a/backend/vehicle.py
+++ b/backend/vehicle.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
             print(f"no arrival times found for vehicle {vid} on {date_str}")
             continue
 
-        df = df.sort_values('TIME', axis=0)
+        df = df.sort_values(['TIME','TRIP'], axis=0)
         df['DATE_TIME'] = df['TIME'].apply(lambda t: datetime.fromtimestamp(t, tz))
 
         for row in df.itertuples():

--- a/backend/vehicle.py
+++ b/backend/vehicle.py
@@ -13,6 +13,7 @@ if __name__ == '__main__':
 
     parser.add_argument('--date', help='Date (yyyy-mm-dd)', required=True)
     parser.add_argument('--vid', help='Vehicle ID', required=True)
+    parser.add_argument('--dir', help='Direction ID')
 
     parser.add_argument('--version')
 
@@ -30,6 +31,7 @@ if __name__ == '__main__':
     route_id = args.route
     date_str = args.date
     vid = args.vid
+    direction_id = args.dir
 
     start_time_str = args.start_time
     end_time_str = args.end_time
@@ -53,7 +55,7 @@ if __name__ == '__main__':
         start_time = util.get_timestamp_or_none(d, start_time_str, tz)
         end_time = util.get_timestamp_or_none(d, end_time_str, tz)
 
-        df = history.get_data_frame(vehicle_id=vid, start_time=start_time, end_time=end_time)
+        df = history.get_data_frame(vehicle_id=vid, direction_id=direction_id, start_time=start_time, end_time=end_time)
 
         if df.empty:
             print(f"no arrival times found for vehicle {vid} on {date_str}")

--- a/backend/waits.py
+++ b/backend/waits.py
@@ -7,13 +7,14 @@ import pytz
 import numpy as np
 import pandas as pd
 
-from models import config, arrival_history, util, metrics, wait_times
+from models import config, arrival_history, util, metrics, wait_times, timetables
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description = 'Compute wait times (in minutes) at a given stop in a given direction on a route, for one or more dates, optionally at particular times of day')
     parser.add_argument('--agency', required=True, help='Agency id')
     parser.add_argument('--route', required = True, help = 'Route id')
     parser.add_argument('--stop', required = True, help = 'Stop id')
+    parser.add_argument('--scheduled', dest='scheduled', action='store_true', help='show scheduled times')
 
     parser.add_argument('--date', help='Date (yyyy-mm-dd)')
     parser.add_argument('--start-date', help='Start date (yyyy-mm-dd)')
@@ -25,6 +26,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     agency = config.get_agency(args.agency)
+
+    show_scheduled = args.scheduled
 
     route_id = args.route
     date_str = args.date
@@ -67,7 +70,11 @@ if __name__ == '__main__':
         last_bus_date_times = []
 
         for d in dates:
-            hist = arrival_history.get_by_date(agency.id, route_id, d)
+            if show_scheduled:
+                hist = timetables.get_by_date(agency.id, route_id, d)
+            else:
+                hist = arrival_history.get_by_date(agency.id, route_id, d)
+
             arrivals = hist.get_data_frame(stop_id = stop, direction_id = stop_dir)
 
             start_time = util.get_timestamp_or_none(d, start_time_str, tz)

--- a/frontend/public/isochrone-worker.js
+++ b/frontend/public/isochrone-worker.js
@@ -363,8 +363,15 @@ function computeIsochrones(latlng, tripMins, enabledRoutes, dateStr, timeStr, st
                 desc:`wait for ${routeInfo.id}`
             };
 
-            for (let i = index + 1; i < direction.stops.length; i++)
+            const startIndex = direction.loop ? 0 : (index + 1);
+
+            for (let i = startIndex; i < direction.stops.length; i++)
             {
+                if (i == index) // no point in doing complete loops
+                {
+                    continue;
+                }
+
                 let nextStopId = direction.stops[i];
                 let nextStopInfo = routeInfo.stops[nextStopId];
 

--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -85,7 +85,7 @@ export function generateArrivalsURL(agencyId, dateStr, routeId) {
   return `https://${S3Bucket}.s3.amazonaws.com/arrivals/${ArrivalsVersion}/${agencyId}/${dateStr.replace(
     /-/g,
     '/',
-  )}/arrivals_${ArrivalsVersion}_${agencyId}_${dateStr}_${routeId}.json.gz?l`;
+  )}/arrivals_${ArrivalsVersion}_${agencyId}_${dateStr}_${routeId}.json.gz?r`;
 }
 
 export function fetchGraphData(params) {

--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -85,7 +85,7 @@ export function generateArrivalsURL(agencyId, dateStr, routeId) {
   return `https://${S3Bucket}.s3.amazonaws.com/arrivals/${ArrivalsVersion}/${agencyId}/${dateStr.replace(
     /-/g,
     '/',
-  )}/arrivals_${ArrivalsVersion}_${agencyId}_${dateStr}_${routeId}.json.gz?d`;
+  )}/arrivals_${ArrivalsVersion}_${agencyId}_${dateStr}_${routeId}.json.gz?l`;
 }
 
 export function fetchGraphData(params) {

--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -42,7 +42,7 @@ function computeDates(graphParams) {
 
 // S3 URL to route configuration
 export function generateRoutesURL(agencyId) {
-  return `https://${S3Bucket}.s3.amazonaws.com/routes/${RoutesVersion}/routes_${RoutesVersion}_${agencyId}.json.gz?m`;
+  return `https://${S3Bucket}.s3.amazonaws.com/routes/${RoutesVersion}/routes_${RoutesVersion}_${agencyId}.json.gz?p`;
 }
 
 /**
@@ -57,7 +57,7 @@ export function generateTripTimesURL(agencyId, dateStr, statPath, timePath) {
   return `https://${S3Bucket}.s3.amazonaws.com/trip-times/${TripTimesVersion}/${agencyId}/${dateStr.replace(
     /-/g,
     '/',
-  )}/trip-times_${TripTimesVersion}_${agencyId}_${dateStr}_${statPath}${timePath}.json.gz?n`;
+  )}/trip-times_${TripTimesVersion}_${agencyId}_${dateStr}_${statPath}${timePath}.json.gz?o`;
 }
 
 /**

--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -42,7 +42,7 @@ function computeDates(graphParams) {
 
 // S3 URL to route configuration
 export function generateRoutesURL(agencyId) {
-  return `https://${S3Bucket}.s3.amazonaws.com/routes/${RoutesVersion}/routes_${RoutesVersion}_${agencyId}.json.gz?g`;
+  return `https://${S3Bucket}.s3.amazonaws.com/routes/${RoutesVersion}/routes_${RoutesVersion}_${agencyId}.json.gz?m`;
 }
 
 /**
@@ -57,7 +57,7 @@ export function generateTripTimesURL(agencyId, dateStr, statPath, timePath) {
   return `https://${S3Bucket}.s3.amazonaws.com/trip-times/${TripTimesVersion}/${agencyId}/${dateStr.replace(
     /-/g,
     '/',
-  )}/trip-times_${TripTimesVersion}_${agencyId}_${dateStr}_${statPath}${timePath}.json.gz?e`;
+  )}/trip-times_${TripTimesVersion}_${agencyId}_${dateStr}_${statPath}${timePath}.json.gz?n`;
 }
 
 /**
@@ -72,7 +72,7 @@ export function generateWaitTimesURL(agencyId, dateStr, statPath, timePath) {
   return `https://${S3Bucket}.s3.amazonaws.com/wait-times/${WaitTimesVersion}/${agencyId}/${dateStr.replace(
     /-/g,
     '/',
-  )}/wait-times_${WaitTimesVersion}_${agencyId}_${dateStr}_${statPath}${timePath}.json.gz?e`;
+  )}/wait-times_${WaitTimesVersion}_${agencyId}_${dateStr}_${statPath}${timePath}.json.gz?f`;
 }
 
 /**
@@ -85,7 +85,7 @@ export function generateArrivalsURL(agencyId, dateStr, routeId) {
   return `https://${S3Bucket}.s3.amazonaws.com/arrivals/${ArrivalsVersion}/${agencyId}/${dateStr.replace(
     /-/g,
     '/',
-  )}/arrivals_${ArrivalsVersion}_${agencyId}_${dateStr}_${routeId}.json.gz?r`;
+  )}/arrivals_${ArrivalsVersion}_${agencyId}_${dateStr}_${routeId}.json.gz?u`;
 }
 
 export function fetchGraphData(params) {

--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -42,7 +42,7 @@ function computeDates(graphParams) {
 
 // S3 URL to route configuration
 export function generateRoutesURL(agencyId) {
-  return `https://${S3Bucket}.s3.amazonaws.com/routes/${RoutesVersion}/routes_${RoutesVersion}_${agencyId}.json.gz?p`;
+  return `https://${S3Bucket}.s3.amazonaws.com/routes/${RoutesVersion}/routes_${RoutesVersion}_${agencyId}.json.gz?q`;
 }
 
 /**
@@ -57,7 +57,7 @@ export function generateTripTimesURL(agencyId, dateStr, statPath, timePath) {
   return `https://${S3Bucket}.s3.amazonaws.com/trip-times/${TripTimesVersion}/${agencyId}/${dateStr.replace(
     /-/g,
     '/',
-  )}/trip-times_${TripTimesVersion}_${agencyId}_${dateStr}_${statPath}${timePath}.json.gz?o`;
+  )}/trip-times_${TripTimesVersion}_${agencyId}_${dateStr}_${statPath}${timePath}.json.gz?p`;
 }
 
 /**
@@ -85,7 +85,7 @@ export function generateArrivalsURL(agencyId, dateStr, routeId) {
   return `https://${S3Bucket}.s3.amazonaws.com/arrivals/${ArrivalsVersion}/${agencyId}/${dateStr.replace(
     /-/g,
     '/',
-  )}/arrivals_${ArrivalsVersion}_${agencyId}_${dateStr}_${routeId}.json.gz?u`;
+  )}/arrivals_${ArrivalsVersion}_${agencyId}_${dateStr}_${routeId}.json.gz?ab`;
 }
 
 export function fetchGraphData(params) {

--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -54,30 +54,28 @@ function ControlPanel(props) {
 
   const selectedRoute = getSelectedRouteInfo();
 
-  function getStopsInfoInGivenDirection(mySelectedRoute, directionId) {
+  function getDirectionInfo(mySelectedRoute, directionId) {
     return mySelectedRoute.directions.find(dir => dir.id === directionId);
   }
 
   function generateSecondStopList(mySelectedRoute, directionId, stopId) {
-    const secondStopInfo = getStopsInfoInGivenDirection(
+    const secondDirInfo = getDirectionInfo(
       mySelectedRoute,
       directionId,
     );
-    
-    const stopsList = secondStopInfo.stops;
+
+    const stopsList = secondDirInfo.stops;
     const secondStopListIndex = stopId
       ? stopsList.indexOf(stopId)
       : 0;
-    
-    // loop routes start and stop at same stop
-    const isLoopRoute = stopsList[0] === stopsList[stopsList.length - 1];
-    const oneWaySecondStopsList = stopsList.slice(secondStopListIndex + 1);
+
+    const isLoopRoute = secondDirInfo.loop;
 
     if (!isLoopRoute) {
-      return oneWaySecondStopsList;
+      return stopsList.slice(secondStopListIndex + 1);
     }
     // loop routes display all subsequent stops up to origin stop
-    return oneWaySecondStopsList.concat(stopsList.slice(1, secondStopListIndex));
+    return stopsList.slice(secondStopListIndex + 1, stopsList.length - 1).concat(stopsList.slice(0, secondStopListIndex));
   }
 
   function onSelectFirstStop(event) {
@@ -185,6 +183,12 @@ function ControlPanel(props) {
 
   const classes = useStyles();
 
+  const directionStops = selectedDirection ? selectedDirection.stops : [];
+
+  const visibleStops = selectedDirection && selectedDirection.loop
+    ? directionStops.slice(0, directionStops.length - 1)
+    : directionStops;
+
   return (
     <div className="ControlPanel">
       <Grid container>
@@ -236,7 +240,7 @@ function ControlPanel(props) {
                     onOpen={() => setAllowHover(true)}
                     onClose={handleSelectClose}
                   >
-                    {(selectedDirection.stops || []).map(firstStopId => {
+                    {visibleStops.map(firstStopId => {
                       const icon = document.querySelector(`.id${firstStopId}`);
                       const title = (
                         selectedRoute.stops[firstStopId] || {

--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -13,6 +13,7 @@ import Grid from '@material-ui/core/Grid';
 import StartStopIcon from '@material-ui/icons/DirectionsTransit';
 import EndStopIcon from '@material-ui/icons/Flag';
 import { handleGraphParams } from '../actions';
+import { getDownstreamStopIds } from '../helpers/mapGeometry';
 import { ROUTE, DIRECTION, FROM_STOP, TO_STOP, Path } from '../routeUtil';
 import { Colors } from '../UIConstants';
 
@@ -58,26 +59,6 @@ function ControlPanel(props) {
     return mySelectedRoute.directions.find(dir => dir.id === directionId);
   }
 
-  function generateSecondStopList(mySelectedRoute, directionId, stopId) {
-    const secondDirInfo = getDirectionInfo(
-      mySelectedRoute,
-      directionId,
-    );
-
-    const stopsList = secondDirInfo.stops;
-    const secondStopListIndex = stopId
-      ? stopsList.indexOf(stopId)
-      : 0;
-
-    const isLoopRoute = secondDirInfo.loop;
-
-    if (!isLoopRoute) {
-      return stopsList.slice(secondStopListIndex + 1);
-    }
-    // loop routes display all subsequent stops up to origin stop
-    return stopsList.slice(secondStopListIndex + 1, stopsList.length - 1).concat(stopsList.slice(0, secondStopListIndex));
-  }
-
   function onSelectFirstStop(event) {
     const stopId = event.target.value;
 
@@ -85,11 +66,6 @@ function ControlPanel(props) {
     const secondStopId = props.graphParams.endStopId;
     const mySelectedRoute = { ...getSelectedRouteInfo() };
 
-    secondStopList = generateSecondStopList(
-      mySelectedRoute,
-      directionId,
-      stopId,
-    );
     const path = new Path();
     path.buildPath(FROM_STOP, stopId);
 
@@ -174,9 +150,9 @@ function ControlPanel(props) {
   }
 
   if (selectedDirection) {
-    secondStopList = generateSecondStopList(
+    secondStopList = getDownstreamStopIds(
       selectedRoute,
-      graphParams.directionId,
+      selectedDirection,
       graphParams.startStopId,
     );
   }
@@ -184,10 +160,6 @@ function ControlPanel(props) {
   const classes = useStyles();
 
   const directionStops = selectedDirection ? selectedDirection.stops : [];
-
-  const visibleStops = selectedDirection && selectedDirection.loop
-    ? directionStops.slice(0, directionStops.length - 1)
-    : directionStops;
 
   return (
     <div className="ControlPanel">
@@ -240,7 +212,7 @@ function ControlPanel(props) {
                     onOpen={() => setAllowHover(true)}
                     onClose={handleSelectClose}
                   >
-                    {visibleStops.map(firstStopId => {
+                    {directionStops.map(firstStopId => {
                       const icon = document.querySelector(`.id${firstStopId}`);
                       const title = (
                         selectedRoute.stops[firstStopId] || {

--- a/frontend/src/components/MapSpider.jsx
+++ b/frontend/src/components/MapSpider.jsx
@@ -16,6 +16,9 @@ import * as d3 from 'd3';
 import { Snackbar } from '@material-ui/core';
 import { ROUTE, DIRECTION, FROM_STOP, TO_STOP, Path } from '../routeUtil';
 import {
+  getDownstreamStopIds
+} from '../helpers/mapGeometry';
+import {
   getAllWaits,
   filterRoutes,
   milesBetween,
@@ -238,7 +241,7 @@ class MapSpider extends Component {
 
     return (
       <CircleMarker
-        key={`startMarker-${startMarker.routeId}-terminal-${lastStop.stopId}`}
+        key={`startMarker-${startMarker.routeId}-terminal-${lastStop.id}`}
         center={terminalPosition}
         radius={3.0 + waitScaled / 2.0}
         fillColor={routeColor}
@@ -260,12 +263,12 @@ class MapSpider extends Component {
 
     return (
       <Polyline
-        key={`poly-${startMarker.routeId}-${downstreamStops[i].stopId}`}
+        key={`poly-${startMarker.routeId}-${downstreamStops[i].id}`}
         positions={getTripPoints(
           startMarker.routeInfo,
           startMarker.direction,
-          downstreamStops[i].stopId,
-          downstreamStops[i + 1].stopId,
+          downstreamStops[i].id,
+          downstreamStops[i + 1].id,
         )}
         color={routeColor}
         opacity={0.5}
@@ -294,7 +297,7 @@ class MapSpider extends Component {
             .buildPath(ROUTE, startMarker.routeId)
             .buildPath(DIRECTION, startMarker.direction.id)
             .buildPath(FROM_STOP, startMarker.stopId)
-            .buildPath(TO_STOP, downstreamStops[i + 1].stopId)
+            .buildPath(TO_STOP, downstreamStops[i + 1].id)
             .commitPath();
         }}
       >
@@ -389,25 +392,19 @@ class MapSpider extends Component {
   /**
    * Append info about the downstream stops to the given stop object for plotting on the map.
    */
-  addDownstreamStops(myStop) {
-    const targetStop = myStop;
+  addDownstreamStops(targetStop) {
+    const routeInfo = targetStop.routeInfo;
 
-    const selectedRoute = this.props.routes.find(
-      route => route.id === targetStop.routeId,
+    const stopIds = getDownstreamStopIds(
+      routeInfo,
+      targetStop.direction,
+      targetStop.stopId
     );
+    stopIds.unshift(targetStop.stopId);
 
-    const secondStopInfo = targetStop.direction;
-    const secondStopListIndex = secondStopInfo.stops.indexOf(targetStop.stopId);
-
-    const secondStopList = secondStopInfo.stops.slice(
-      secondStopListIndex /* + 1  include starting stop */,
-    );
-
-    const downstreamStops = secondStopList.map(stopId =>
-      Object.assign(selectedRoute.stops[stopId], { stopId }),
-    );
-
-    targetStop.downstreamStops = downstreamStops;
+    targetStop.downstreamStops = stopIds.map(stopId => {
+      return routeInfo.stops[stopId];
+    });
   }
 
   /**

--- a/frontend/src/components/MapStops.jsx
+++ b/frontend/src/components/MapStops.jsx
@@ -374,9 +374,9 @@ class MapStops extends Component {
           dir => dir.id === directionId,
         );
 
-        const stopSids = dirInfo.stops;
+        const stopIds = dirInfo.stops;
 
-        if (!dirInfo.loop && stopSids.indexOf(stop.id) < stopSids.indexOf(startStopId)) {
+        if (!dirInfo.loop && stopIds.indexOf(stop.id) < stopIds.indexOf(startStopId)) {
           endStopId = startStopId;
           startStopId = stop.id;
         } else {

--- a/frontend/src/components/MareyChart.jsx
+++ b/frontend/src/components/MareyChart.jsx
@@ -238,7 +238,7 @@ function MareyChart(props) {
       });
 
       const directionInfos = {};
-      const directionInfo = route.directions.forEach(direction => {
+      route.directions.forEach(direction => {
         directionInfos[direction.id] = direction;
       });
 

--- a/frontend/src/helpers/mapGeometry.js
+++ b/frontend/src/helpers/mapGeometry.js
@@ -6,6 +6,22 @@ import * as turf from '@turf/turf';
 import { milesBetween, metersToMiles } from './routeCalculations';
 import { getAgency } from '../config';
 
+export function getDownstreamStopIds(routeInfo, dirInfo, stopId) {
+  const stopsList = dirInfo.stops;
+  const secondStopListIndex = stopId
+    ? stopsList.indexOf(stopId)
+    : 0;
+
+  const isLoopRoute = dirInfo.loop;
+  const oneWaySecondStopsList = stopsList.slice(secondStopListIndex + 1);
+
+  if (!isLoopRoute) {
+    return oneWaySecondStopsList;
+  }
+  // loop routes display all subsequent stops up to and including origin stop
+  return oneWaySecondStopsList.concat(stopsList.slice(0, secondStopListIndex + 1));
+}
+
 /**
  * Gets coordinates that can be consumed by a Leaflet Polyline.  Uses
  * the GTFS stop geometry if possible, otherwise just stop to stop.
@@ -30,22 +46,41 @@ export function getTripPoints(
 
   if (fromStopGeometry && toStopGeometry) {
     tripPoints.push(fromStopInfo);
-    for (
-      let i = fromStopGeometry.after_index + 1;
-      i <= toStopGeometry.after_index;
-      i++
-    ) {
-      tripPoints.push(dirInfo.coords[i]);
+
+    const coords = dirInfo.coords;
+
+    let startIndex = fromStopGeometry.after_index + 1;
+
+    if (dirInfo.loop && toStopGeometry.after_index <= fromStopGeometry.after_index) {
+      for (let i = startIndex; i < coords.length; i++) {
+        tripPoints.push(coords[i]);
+      }
+      startIndex = 0;
     }
+
+    for (let i = startIndex; i <= toStopGeometry.after_index; i++) {
+      tripPoints.push(coords[i]);
+    }
+
     tripPoints.push(toStopInfo);
   } // if unknown geometry, draw straight lines between stops
   else {
-    const fromStopIndex = dirInfo.stops.indexOf(fromStop);
-    const toStopIndex = dirInfo.stops.indexOf(toStop);
+    const stopIds = dirInfo.stops;
+
+    const fromStopIndex = stopIds.indexOf(fromStop);
+    const toStopIndex = stopIds.indexOf(toStop);
     if (fromStopIndex !== -1 && toStopIndex !== -1) {
-      for (let i = fromStopIndex; i <= toStopIndex; i++) {
-        const stopInfo = routeInfo.stops[dirInfo.stops[i]];
-        tripPoints.push(stopInfo);
+
+      let startIndex = fromStopIndex;
+      if (dirInfo.loop && toStopIndex <= fromStopIndex) {
+        for (let i = startIndex; i < stopIds.length; i++) {
+          tripPoints.push(routeInfo.stops[stopIds[i]]);
+        }
+        startIndex = 0;
+      }
+
+      for (let i = startIndex; i <= toStopIndex; i++) {
+        tripPoints.push(routeInfo.stops[stopIds[i]]);
       }
     }
   }
@@ -67,23 +102,47 @@ export function getDistanceInMiles(
   fromStop = dirInfo.stops[0],
   toStop = dirInfo.stops[dirInfo.stops.length - 1],
 ) {
-  const fromStopInfo = routeInfo.stops[fromStop];
-  const toStopInfo = routeInfo.stops[toStop];
-
   const fromStopGeometry = dirInfo.stop_geometry[fromStop];
   const toStopGeometry = dirInfo.stop_geometry[toStop];
-  let distance = null;
 
   if (fromStopGeometry && toStopGeometry) {
-    distance = metersToMiles(
-      toStopGeometry.distance - fromStopGeometry.distance,
-    );
+    let distance = toStopGeometry.distance - fromStopGeometry.distance;
+
+    if (distance <= 0 && dirInfo.loop) {
+      distance += dirInfo.distance;
+    }
+
+    return metersToMiles(distance);
   } else {
     // if unknown geometry, draw straight lines between stops
+    const stopIds = dirInfo.stops;
+    const stops = routeInfo.stops;
+    const fromStopIndex = stopIds.indexOf(fromStop);
+    const toStopIndex = stopIds.indexOf(toStop);
+    let miles = 0;
 
-    distance = milesBetween(fromStopInfo, toStopInfo);
+    if (fromStopIndex !== -1 && toStopIndex !== -1) {
+      let startIndex = fromStopIndex;
+      const numStops = stopIds.length;
+      if (dirInfo.loop && toStopIndex <= fromStopIndex) {
+        for (let i = startIndex; i < numStops; i++) {
+          miles += milesBetween(
+            stops[stopIds[i]],
+            stops[stopIds[(i + 1) % numStops]]
+          );
+        }
+        startIndex = 0;
+      }
+
+      for (let i = startIndex; i < toStopIndex; i++) {
+        miles += milesBetween(
+          stops[stopIds[i]],
+          stops[stopIds[i + 1]]
+        );
+      }
+      return miles;
+    }
   }
-  return distance;
 }
 
 /**

--- a/frontend/src/helpers/routeCalculations.js
+++ b/frontend/src/helpers/routeCalculations.js
@@ -164,8 +164,7 @@ export function getEndToEndTripTime(
     lastStop = ignoreLast; // ignore stops after index specified by ignoreLast
   } else {
     // is a boolean
-    lastStop =
-      directionInfo.stops[directionInfo.stops.length - (ignoreLast ? 2 : 1)];
+    lastStop = directionInfo.stops[directionInfo.stops.length - (directionInfo.loop || ignoreLast ? 2 : 1)];
   }
 
   // console.log('found ' + Object.keys(tripTimesForFirstStop).length + ' keys' );

--- a/frontend/src/helpers/routeCalculations.js
+++ b/frontend/src/helpers/routeCalculations.js
@@ -164,7 +164,7 @@ export function getEndToEndTripTime(
     lastStop = ignoreLast; // ignore stops after index specified by ignoreLast
   } else {
     // is a boolean
-    lastStop = directionInfo.stops[directionInfo.stops.length - (directionInfo.loop || ignoreLast ? 2 : 1)];
+    lastStop = directionInfo.stops[directionInfo.stops.length - (ignoreLast ? 2 : 1)];
   }
 
   // console.log('found ' + Object.keys(tripTimesForFirstStop).length + ' keys' );


### PR DESCRIPTION
Fixes #312.
Fixes #425.
Fixes #465.

Previously, eclipses.py did not do a good job at grouping arrivals into trips for certain routes. The previous algorithm simply looked for 3 adjacent possible arrivals with ascending stop indexes. However, for routes that doubled back on themselves (or nearly so) there would be out-of-order possible arrivals between the actual arrivals.

For twisty routes where a single direction doubles back on itself (or nearly so), such as SF Muni's 39-Coit, 36-Teresita, 30-Stockton, 9-San Bruno, etc., it is possible that there may be out-of-order stop indexes in the "possible" arrivals.

As an example, suppose consecutive stop indexes of possible arrivals for some route is 1,2,6,3,7,4,5,6,3,4,7,8,9. In this case, the "best" trip has the stop indexes 1,2,3,4,5,6,7,8,9. 

The previous algorithm, which only looked for 3 or more consecutive ascending stop indexes, would likely find three separate trips: (1,2,6), (4,5,6), and (3,4,7,8,9).

Alternatively, if the algorithm only used the first ascending index it found, it would only find 1,2,6,7,8,9 and miss indexes 3,4,5.

In order to handle these cases, the algorithm keeps track of multiple possible sequences as it loops through the possible arrivals. To avoid needing to keep track of a large number of possible sequences, it drops possible sequences if they are strictly worse than another possible sequence.
A sequence is worse than another sequence, for example, if it is shorter than another sequence and ends in the same stop_index; or if it is the same size as another sequence but ends in a larger stop_index.

When all possible sequences end in a terminal, or if the algorithm processes several rows without being able to extend any of the possible sequences with an ascending stop index, it assumes that the trip has ended and chooses the longest possible sequence as the "best".

After it finds the end of a trip, it resets the possible sequences and continues processing possible arrivals where the previous sequence ended.

Various heuristics are used which seem to provide good results in practice for the routes tested:

* Each trip must contain arrivals at least 3 stops (unless the route only contains 2 stops in that direction)
* If there is a gap of more than 4 stops, the arrivals will be split into separate trips, unless the time between the two stops is less than 5 minutes. This avoids adding long gaps within a trip where a vehicle likely was out of service (which happens occasionally on various normal routes like the N-Judah), but avoids splitting trips in the case of 36-Teresita when the vehicle skips the Myra Way section after 9pm (https://www.sfmta.com/sites/default/files/36_teresita_pdf.pdf)
* If the algorithm processes 4 possible arrivals without being able to extend any possible trip sequences, it will determine that the trip has probably ended (even if it hasn't reached the terminal)

## Figure-eight routes

The 36-Teresita contains a figure-eight (https://www.sfmta.com/sites/default/files/36_teresita_pdf.pdf) where three stops in the Inbound direction along Clarendon Ave (Olympia Way, Galewood Circle, Panorama Drive) are repeated twice along the route (with identical stop IDs in the GTFS file). This PR handles this case by creating unique OpenTransit stop IDs for each subsequent time a stop is reached in a given trip. For example, the first time 36-Teresita reaches Clarendon Ave & Olympia Way, we use the stop ID 14035; the second time it reaches Clarendon Ave & Olympia Way, we use the stop ID 14035-2. This allows the frontend code to continue assuming that each stop ID uniquely identifies a single point along a route for a given direction.

## Loop routes

Portland Streetcar A-Loop and B-Loop have a defined start/end stop in the GTFS feed, which appears in stop_times.txt at the start and end of each trip with the same GTFS stop ID. However, in practice people can board the vehicle before the "end" stop and continue around the loop after the "start" stop. 

To simplify handling of loop routes, the GTFS parsing code sets a boolean `loop` property to `true` for the direction, and removes the duplicate "end" stop ID from the list of stops for that direction (instead of adding a "-2" stop like for figure-eight routes).

When parsing schedules for loop routes from the GTFS feed, arrival times at the end stop are added to the start stop. If the GTFS feed already defines an arrival time at the start stop within a few minutes, it is updated to use the arrival time at the previous end stop.

When computing arrival times for loop routes, get_arrivals_with_ascending_stop_index in eclipses.py continues appending arrivals to the same trip when the vehicle goes from stop index N-1 to stop index 0. (For loop routes, the difference of stop index is calculated mod N.)

For loop routes, the same vehicle may arrive at the same stop many different times with the same trip ID. When computing trip times for loop routes, trip_times.py finds the first arrival that appears after the departure time with the same trip ID. 

The frontend is updated to check the `loop` property in several places:
* computing the list of downstream stops after a given stop
* getting the coordinates along a route between two stops
* getting the distance along a route between two stops
* determining which segments to highlight between two stops

Some frontend code was refactored to avoid duplicating the same logic in multiple places.

## Route bounds

The route object in S3 now contains a `bounds` property which contains an array of two lat/lon coordinate objects that bound all stops along that route. The frontend uses these bounds when showing a particular route. 

## Fix to distance calculations

The code for parsing GTFS routes had a bug which transposed latitudes and longitudes when computing distances along a route, which caused all of the distances for directions and stops to be incorrect. This caused all of the statistics in the frontend based on distances, including speeds and scores, to be incorrect. The new route configuration has corrected distances in `stop_geometry` and the `distance` field for each direction.