### PR TITLE
Fix save_routes failing because muni routes changed

### DIFF
--- a/backend/agencies/muni.yaml
+++ b/backend/agencies/muni.yaml
@@ -31,33 +31,10 @@ custom_directions:
       title: "Outbound to 48th Ave & Point Lobos Ave via V.A. Hospital"
       gtfs_direction_id: "0"
       included_stop_ids: ["15511","13608"]
-  '47':
-    - id: "1"
-      gtfs_direction_id: "1"
-      excluded_stop_ids: ["14967"]
-    - id: "1-3rd"
-      title: "Inbound to Powell St & Beach St via 3rd St"
-      gtfs_direction_id: "1"
-      included_stop_ids: ["14967"]
-    - id: "0"
-      gtfs_direction_id: "0"
-      included_stop_ids: ["13723"]
   '81X':
     - id: "1"
       gtfs_direction_id: "1"
       included_stop_ids: ["16694"]
-  '83X':
-    - id: "0"
-      gtfs_direction_id: "0"
-      included_stop_ids: ["17776"]
-    - id: "1-18010"
-      title: "Inbound to 9th St & Market St via Brannan St & 8th St"
-      gtfs_direction_id: "1"
-      included_stop_ids: ["18010"]
-    - id: "1-17683"
-      title: "Inbound to 9th St & Market St via Townsend St & 8th St"
-      gtfs_direction_id: "1"
-      included_stop_ids: ["17683"]
 default_day_start_hour: 3
 custom_day_start_hours:
   - start_hour: 0 # owl routes run from 1AM to 5AM so they are associated with the same day

--- a/backend/models/gtfs.py
+++ b/backend/models/gtfs.py
@@ -553,7 +553,7 @@ class GtfsScraper:
 
         return sorted_shapes
 
-    def get_custom_direction_data(self, custom_direction_info, route_trips_df):
+    def get_custom_direction_data(self, custom_direction_info, route_trips_df, route_id):
         direction_id = custom_direction_info['id']
         print(f' custom direction = {direction_id}')
 
@@ -771,7 +771,7 @@ class GtfsScraper:
 
         if route_id in agency.custom_directions:
             route_data['directions'] = [
-                self.get_custom_direction_data(custom_direction_info, route_trips_df)
+                self.get_custom_direction_data(custom_direction_info, route_trips_df, route_id)
                 for custom_direction_info in agency.custom_directions[route_id]
             ]
         else:


### PR DESCRIPTION
save_routes.py was raising an exception because the custom directions for Muni 47 and 83X changed and the custom direction stop filters no longer matched any shapes in the new GTFS feed. Since Muni 47 and 83X only have 1 shape per direction in the new GTFS feed, the custom direction configuration can be removed now (note that storing old route configuration has not yet been implemented).

Also, fixes a bug where save_routes.py raised another exception while trying to raise the first exception because `route_id` was not defined in `get_custom_direction_data`.