### PR TITLE
When computing end to end trip times and scanning all stops, handle c…

### DIFF
--- a/frontend/src/helpers/routeCalculations.js
+++ b/frontend/src/helpers/routeCalculations.js
@@ -193,7 +193,7 @@ export function getEndToEndTripTime(
     tripTime = 0;
 
     for (let i = 0; i < stopIds.length; i++) {
-      if (tripTimes[stopIds[i]] > tripTime) {
+      if (tripTimes[stopIds[i]] > tripTime && directionInfo.stop_geometry[stopIds[i]]) {
         tripTime = tripTimes[stopIds[i]];
         tripDistance = directionInfo.stop_geometry[stopIds[i]].distance - firstStopDistance;
       }


### PR DESCRIPTION


<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->
<!--
Fixes #1234. Fixes #2345. Fixes #3456.
-->

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

When computing end to end trip times for routes and needing to scan all stops for highest observed trip time, handle case where stop geometry is not available for a stop by ignoring it.  Have to do this since distance along route is not available.

## Screenshot

n/a

## Link to demo, if any

n/a
