### PR TITLE
fix bug with invalid routes JSON if route does not have short name or long name in GTFS feed

### DIFF
--- a/backend/models/gtfs.py
+++ b/backend/models/gtfs.py
@@ -876,8 +876,10 @@ class GtfsScraper:
             title = f'{short_name}-{long_name}'
         elif isinstance(short_name, str):
             title = short_name
-        else:
+        elif isinstance(long_name, str):
             title = long_name
+        else:
+            title = gtfs_route_id
 
         type = int(route.route_type) if hasattr(route, 'route_type') else None
         url = route.route_url if hasattr(route, 'route_url') and isinstance(route.route_url, str) else None

--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -42,7 +42,7 @@ function computeDates(graphParams) {
 
 // S3 URL to route configuration
 export function generateRoutesURL(agencyId) {
-  return `https://${S3Bucket}.s3.amazonaws.com/routes/${RoutesVersion}/routes_${RoutesVersion}_${agencyId}.json.gz?q`;
+  return `https://${S3Bucket}.s3.amazonaws.com/routes/${RoutesVersion}/routes_${RoutesVersion}_${agencyId}.json.gz?r`;
 }
 
 /**


### PR DESCRIPTION
One of the routes in Trimet's current GTFS feed has no "short name" or "long name", which caused save_routes.py to save the route title as NaN in the JSON file, which caused an error when the frontend tried to parse the JSON file. This PR fixes this issue by using the GTFS route ID as the title if the route has no short name or long name in the GTFS feed.