### PR TITLE
Simplify code for computing and displaying route stats

### DIFF
--- a/frontend/src/components/InfoScoreCard.jsx
+++ b/frontend/src/components/InfoScoreCard.jsx
@@ -14,8 +14,8 @@ import InfoIcon from '@material-ui/icons/InfoOutlined';
 import Rating from '@material-ui/lab/Rating';
 import Box from '@material-ui/core/Box';
 import {
-  quartileBackgroundColor,
-  quartileContrastColor,
+  scoreBackgroundColor,
+  scoreContrastColor,
 } from '../helpers/routeCalculations';
 
 /**
@@ -25,8 +25,7 @@ import {
  */
 export default function InfoScoreCard(props) {
   const {
-    grades,
-    gradeName,
+    score,
     hideRating,
     title,
     largeValue,
@@ -54,25 +53,25 @@ export default function InfoScoreCard(props) {
     setAnchorEl(null);
   }
 
-  const cardStyle = (myGrades, myGradeName) => {
+  const cardStyle = (score) => {
     return {
-      background: myGrades
-        ? quartileBackgroundColor(myGrades[myGradeName] / 100.0)
+      background: (score != null)
+        ? scoreBackgroundColor(score)
         : 'gray',
-      color: myGrades
-        ? quartileContrastColor(myGrades[myGradeName] / 100.0)
+      color: (score != null)
+        ? scoreContrastColor(score)
         : 'black',
       margin: 4,
     };
   };
 
-  const rating = grades
-    ? Math.max(Math.round(grades[gradeName] / 10.0) / 2.0, 0.5)
+  const rating = (score != null)
+    ? Math.max(Math.round(score / 10.0) / 2.0, 0.5)
     : 0;
 
   return (
     <Fragment>
-      <Grid item xs component={Paper} style={cardStyle(grades, gradeName)}>
+      <Grid item xs component={Paper} style={cardStyle(score)}>
         <Box
           display="flex"
           flexDirection="column"

--- a/frontend/src/components/InfoScoreLegend.jsx
+++ b/frontend/src/components/InfoScoreLegend.jsx
@@ -7,8 +7,8 @@ import React from 'react';
 import { Table, TableBody, TableCell, TableRow } from '@material-ui/core';
 
 import {
-  quartileBackgroundColor,
-  quartileContrastColor,
+  scoreBackgroundColor,
+  scoreContrastColor,
 } from '../helpers/routeCalculations';
 
 export default function InfoScoreLegend(props) {
@@ -24,8 +24,8 @@ export default function InfoScoreLegend(props) {
               <TableCell
                 align="right"
                 style={{
-                  color: quartileContrastColor(row.value / 100),
-                  backgroundColor: quartileBackgroundColor(row.value / 100),
+                  color: scoreContrastColor(row.value),
+                  backgroundColor: scoreBackgroundColor(row.value),
                 }}
               >
                 {row.value}

--- a/frontend/src/components/InfoTripSummary.jsx
+++ b/frontend/src/components/InfoTripSummary.jsx
@@ -18,7 +18,8 @@ import Popover from '@material-ui/core/Popover';
 import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import {
-  computeGrades,
+  computeScores,
+  HighestPossibleScore
 } from '../helpers/routeCalculations';
 import {
   getDistanceInMiles
@@ -101,15 +102,15 @@ export default function InfoTripSummary(props) {
       getPercentileValue(tripTimes, TENTH_PERCENTILE)) / 2.0;
   }
 
-  const grades =
+  const scores =
     speed && waitTimes.median
-      ? computeGrades(
+      ? computeScores(
           waitTimes.median,
           longWaitProbability,
           speed,
           travelVariabilityTime,
         )
-      : null;
+      : {};
 
   let whyNoData = null;
   if (!distance) {
@@ -148,39 +149,39 @@ export default function InfoTripSummary(props) {
   const typicalWait = Math.round(waitTimes.median);
   const typicalTravel = Math.round(tripTimes.median); // note: can have NaN issues here due to lack of trip data between stops
 
-  const popoverContentTotalScore = grades ? (
+  const popoverContentTotalScore = (
     <Fragment>
-      Trip score of {grades.totalScore} is the average of the following
+      Trip score of {scores.totalScore} is the average of the following
       subscores:
       <Box pt={2}>
         <Table>
           <TableBody>
             <TableRow>
               <TableCell>Median wait</TableCell>
-              <TableCell align="right">{grades.medianWaitScore}</TableCell>
+              <TableCell align="right">{scores.medianWaitScore}</TableCell>
             </TableRow>
             <TableRow>
               <TableCell>Long wait probability</TableCell>
-              <TableCell align="right">{grades.longWaitScore}</TableCell>
+              <TableCell align="right">{scores.longWaitScore}</TableCell>
             </TableRow>
             <TableRow>
               <TableCell>Speed for median trip</TableCell>
-              <TableCell align="right"> {grades.speedScore}</TableCell>
+              <TableCell align="right"> {scores.speedScore}</TableCell>
             </TableRow>
             <TableRow>
               <TableCell>Travel time variability</TableCell>
-              <TableCell align="right"> {grades.travelVarianceScore}</TableCell>
+              <TableCell align="right"> {scores.travelVarianceScore}</TableCell>
             </TableRow>
           </TableBody>
         </Table>
       </Box>
     </Fragment>
-  ) : null;
+  );
 
-  const popoverContentWait = grades ? (
+  const popoverContentWait = (
     <Fragment>
       Median wait of {waitTimes.median.toFixed(1)} min gets a score of{' '}
-      {grades.medianWaitScore}.
+      {scores.medianWaitScore}.
       <Box pt={2}>
         <InfoScoreLegend
           rows={[
@@ -193,15 +194,15 @@ export default function InfoTripSummary(props) {
         />
       </Box>
     </Fragment>
-  ) : null;
+  );
 
-  const popoverContentLongWait = grades ? (
+  const popoverContentLongWait = (
     <Fragment>
       Long wait probability is the chance a rider has of a wait of twenty minutes or
       longer after arriving randomly at the "from" stop.
       Probability of{' '}
       {(longWaitProbability * 100).toFixed(1) /* be more precise than card */}%
-      gets a score of {grades.longWaitScore}.
+      gets a score of {scores.longWaitScore}.
       <Box pt={2}>
         <InfoScoreLegend
           rows={[
@@ -214,12 +215,12 @@ export default function InfoTripSummary(props) {
         />
       </Box>
     </Fragment>
-  ) : null;
+  );
 
-  const popoverContentSpeed = grades ? (
+  const popoverContentSpeed = (
     <Fragment>
       Speed for median trip of {speed.toFixed(1)}{' '}
-      mph gets a score of {grades.speedScore}.
+      mph gets a score of {scores.speedScore}.
       <Box pt={2}>
         <InfoScoreLegend
           rows={[
@@ -232,14 +233,14 @@ export default function InfoTripSummary(props) {
         />
       </Box>
     </Fragment>
-  ) : null;
+  );
 
-  const popoverContentTravelVariability = grades ? (
+  const popoverContentTravelVariability = (
     <Fragment>
       Travel time variability is the 90th percentile travel time minus the 10th percentile
       travel time.  This measures how much extra travel time is needed for some trips.
       Variability of {'\u00b1' + travelVariabilityTime.toFixed(1)} min gets a score of{' '}
-      {grades.travelVarianceScore}.
+      {scores.travelVarianceScore}.
       <Box pt={2}>
         <InfoScoreLegend
           rows={[
@@ -252,12 +253,12 @@ export default function InfoTripSummary(props) {
         />
       </Box>
     </Fragment>
-  ) : null;
+  );
 
   return (
     <Fragment>
       <div style={{ padding: 8 }}>
-        {grades ? (
+        {scores ? (
           <Fragment>
             <Grid container spacing={4}>
               {/* spacing doesn't work exactly right here, just pads the Papers */}
@@ -321,18 +322,16 @@ export default function InfoTripSummary(props) {
                 </Box>
               </Grid>
               <InfoScoreCard
-                grades={grades}
-                gradeName="totalScore"
+                score={scores.totalScore}
                 hideRating
                 title="Trip Score"
-                largeValue={grades ? grades.totalScore : '--'}
-                smallValue={`/${grades ? grades.highestPossibleScore : '--'}`}
+                largeValue={scores.totalScore != null ? scores.totalScore : '--'}
+                smallValue={`/${HighestPossibleScore}`}
                 bottomContent="&nbsp;"
                 popoverContent={popoverContentTotalScore}
               />
               <InfoScoreCard
-                grades={grades}
-                gradeName="medianWaitScore"
+                score={scores.medianWaitScore}
                 title="Median Wait"
                 largeValue={Math.round(waitTimes.median)}
                 smallValue="&nbsp;min"
@@ -340,8 +339,7 @@ export default function InfoTripSummary(props) {
                 popoverContent={popoverContentWait}
               />
               <InfoScoreCard
-                grades={grades}
-                gradeName="longWaitScore"
+                score={scores.longWaitScore}
                 title="Long Wait %"
                 largeValue={Math.round(longWaitProbability * 100)}
                 smallValue="%"
@@ -353,17 +351,15 @@ export default function InfoTripSummary(props) {
                 popoverContent={popoverContentLongWait}
               />
               <InfoScoreCard
-                grades={grades}
-                gradeName="speedScore"
+                score={scores.speedScore}
                 title="Median Trip Speed"
                 largeValue={speed.toFixed(0)}
                 smallValue="&nbsp;mph"
-                bottomContent={`${distance.toFixed(1)} miles`}
+                bottomContent={`${distance != null ? distance.toFixed(1) : '--'} miles`}
                 popoverContent={popoverContentSpeed}
               />
               <InfoScoreCard
-                grades={grades}
-                gradeName="travelVarianceScore"
+                score={scores.travelVarianceScore}
                 title="Travel Time Variability"
                 largeValue={'\u00b1' + travelVariability}
                 smallValue="&nbsp;min"

--- a/frontend/src/components/InfoTripSummary.jsx
+++ b/frontend/src/components/InfoTripSummary.jsx
@@ -180,7 +180,7 @@ export default function InfoTripSummary(props) {
 
   const popoverContentWait = (
     <Fragment>
-      Median wait of {waitTimes.median.toFixed(1)} min gets a score of{' '}
+      Median wait of {(waitTimes && waitTimes.median != null) ? waitTimes.median.toFixed(1) : '--'} min gets a score of{' '}
       {scores.medianWaitScore}.
       <Box pt={2}>
         <InfoScoreLegend

--- a/frontend/src/components/MapSpider.jsx
+++ b/frontend/src/components/MapSpider.jsx
@@ -201,8 +201,7 @@ class MapSpider extends Component {
 
         const stats = routeStats[startMarker.routeId] || {};
 
-        // scale wait score to 0, 1, or 2
-        let waitScaled = (stats.medianWaitScore != null) ? Math.trunc((stats.medianWaitScore / HighestPossibleScore) * 3) : 0;
+        let waitScaled = stats.waitRankCount ? Math.trunc((1 - stats.waitRank / stats.waitRankCount) * 3) : 0;
 
         for (let i = 0; i < downstreamStops.length - 1; i++) {
           // for each stop

--- a/frontend/src/components/MapSpider.jsx
+++ b/frontend/src/components/MapSpider.jsx
@@ -199,7 +199,7 @@ class MapSpider extends Component {
         // Add a base polyline connecting the stops.  One polyline between each stop gives better tooltips
         // when selecting a line.
 
-        const stats = routeStats[startMarker.routeId];
+        const stats = routeStats[startMarker.routeId] || {};
 
         // scale wait score to 0, 1, or 2
         let waitScaled = (stats.medianWaitScore != null) ? Math.trunc((stats.medianWaitScore / HighestPossibleScore) * 3) : 0;

--- a/frontend/src/components/MapSpider.jsx
+++ b/frontend/src/components/MapSpider.jsx
@@ -18,9 +18,9 @@ import {
   getDownstreamStopIds
 } from '../helpers/mapGeometry';
 import {
-  getAllWaits,
   filterRoutes,
   milesBetween,
+  HighestPossibleScore
 } from '../helpers/routeCalculations';
 import { handleSpiderMapClick } from '../actions';
 import { Agencies } from '../config';
@@ -182,10 +182,7 @@ class MapSpider extends Component {
    * Rendering of route from nearest stop to terminal.
    */
   DownstreamLines = () => {
-    const allWaits = getAllWaits(
-      this.props.precomputedStats.waitTimes,
-      this.props.routes,
-    );
+    const routeStats = this.props.routeStats;
 
     // One polyline for each start marker
 
@@ -202,16 +199,10 @@ class MapSpider extends Component {
         // Add a base polyline connecting the stops.  One polyline between each stop gives better tooltips
         // when selecting a line.
 
-        // get wait rank, most frequent is highest (largest) rank
-        const waitRank = allWaits.findIndex(
-          wait => wait.routeId === startMarker.routeId,
-        );
+        const stats = routeStats[startMarker.routeId];
 
-        // scale wait rank to 0, 1, or 2
-        let waitScaled = Math.trunc((waitRank / allWaits.length) * 3);
-        if (!isFinite(waitScaled)) {
-          waitScaled = 0;
-        }
+        // scale wait score to 0, 1, or 2
+        let waitScaled = (stats.medianWaitScore != null) ? Math.trunc((stats.medianWaitScore / HighestPossibleScore) * 3) : 0;
 
         for (let i = 0; i < downstreamStops.length - 1; i++) {
           // for each stop
@@ -536,6 +527,7 @@ class MapSpider extends Component {
 const mapStateToProps = state => ({
   routes: state.routes.data,
   precomputedStats: state.precomputedStats,
+  routeStats: state.routeStats,
   graphParams: state.graphParams,
   spiderSelection: state.spiderSelection,
 });

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -21,50 +21,24 @@ import { connect } from 'react-redux';
 import Navlink from 'redux-first-router-link';
 import {
   filterRoutes,
-  getAllWaits,
-  getAllSpeeds,
-  getAllScores,
-  quartileBackgroundColor,
-  quartileContrastColor,
+  scoreBackgroundColor,
+  scoreContrastColor,
 } from '../helpers/routeCalculations';
 
-function desc(a, b, orderBy) {
-  // Treat NaN as infinity, so that it goes to the bottom of the table in an ascending sort.
-  // NaN needs special handling because NaN < 3 is false as is Nan > 3.
-
-  if (Number.isNaN(a[orderBy]) && Number.isNaN(b[orderBy])) {
-    return 0;
-  }
-  if (Number.isNaN(a[orderBy])) {
-    return -1;
-  }
-  if (Number.isNaN(b[orderBy])) {
-    return 1;
-  }
-
-  if (b[orderBy] < a[orderBy]) {
-    return -1;
-  }
-  if (b[orderBy] > a[orderBy]) {
-    return 1;
-  }
-  return 0;
-}
-
 /**
- * Sorts the given array using a comparator.  Equal values are ordered by array index.
+ * Sorts the given array by an object property.  Equal values are ordered by array index.
  *
  * Sorting by title is a special case because the original order of the routes array is
  * better than sorting route title alphabetically.  For example, 1 should be followed by
  * 1AX rather than 10 and 12.
  *
  * @param {Array} array      Array to sort
- * @param {Function} cmp     Comparator to use
  * @param {String} sortOrder Either 'desc' or 'asc'
- * @param {String} orderBy   Column to sort by
+ * @param {String} orderBy   Property to sort by
  * @returns {Array}          The sorted array
  */
-function stableSort(array, cmp, sortOrder, orderBy) {
+function stableSort(array, sortOrder, orderBy) {
+
   // special case for title sorting that short circuits the use of the comparator
 
   if (orderBy === 'title') {
@@ -75,6 +49,8 @@ function stableSort(array, cmp, sortOrder, orderBy) {
     return array;
   }
 
+  const cmp = getComparisonFunction(sortOrder, orderBy);
+
   const stabilizedThis = array.map((el, index) => [el, index]);
   stabilizedThis.sort((a, b) => {
     const order = cmp(a[0], b[0]);
@@ -84,10 +60,31 @@ function stableSort(array, cmp, sortOrder, orderBy) {
   return stabilizedThis.map(el => el[0]);
 }
 
-function getSorting(order, orderBy) {
-  return order === 'desc'
-    ? (a, b) => desc(a, b, orderBy)
-    : (a, b) => -desc(a, b, orderBy);
+function getComparisonFunction(order, orderBy) {
+  // Sort null values to bottom regardless of ascending/descending
+  var factor = order === 'desc' ? 1 : -1;
+  return (a, b) => {
+    const aValue = a[orderBy];
+    const bValue = b[orderBy];
+
+    if (aValue == null && bValue == null) {
+      return 0;
+    }
+    if (aValue == null) {
+      return 1;
+    }
+    if (bValue == null) {
+      return -1;
+    }
+
+    if (bValue < aValue) {
+      return -factor;
+    }
+    if (bValue > aValue) {
+      return factor;
+    }
+    return 0;
+  };
 }
 
 const headRows = [
@@ -276,7 +273,7 @@ function RouteTable(props) {
   const dense = true;
   const theme = createMuiTheme();
 
-  const { precomputedStats } = props;
+  const { routeStats } = props;
 
   function handleRequestSort(event, property) {
     const isDesc = orderBy === property && order === 'desc';
@@ -294,35 +291,10 @@ function RouteTable(props) {
     routes = routes.filter(myRoute => spiderRouteIds.includes(myRoute.id));
   }
 
-  const allWaits = getAllWaits(precomputedStats.waitTimes, routes);
-  const allSpeeds = getAllSpeeds(
-    precomputedStats.tripTimes,
-    routes,
-  );
-  const allScores = getAllScores(routes, allWaits, allSpeeds);
-
-  routes = routes.map(route => {
-    const waitObj = allWaits.find(
-      thisWaitObj => thisWaitObj.routeId === route.id,
-    );
-    const speedObj = allSpeeds.find(
-      thisSpeedObj => thisSpeedObj.routeId === route.id,
-    );
-    const scoreObj = allScores.find(
-      thisScoreObj => thisScoreObj.routeId === route.id,
-    );
-
+  const displayedRouteStats = routes.map(route => {
     return {
-      ...route,
-      wait: waitObj ? waitObj.wait : NaN,
-      longWait: waitObj ? waitObj.longWait : NaN,
-      speed: speedObj ? speedObj.speed : NaN,
-      variability: speedObj ? speedObj.variability : NaN,
-      totalScore: scoreObj ? scoreObj.totalScore : NaN,
-      medianWaitScore: scoreObj ? scoreObj.medianWaitScore : NaN,
-      longWaitScore: scoreObj ? scoreObj.longWaitScore : NaN,
-      speedScore: scoreObj ? scoreObj.speedScore : NaN,
-      travelVarianceScore: scoreObj ? scoreObj.travelVarianceScore : NaN,
+      route,
+      ...(routeStats[route.id] || {})
     };
   });
 
@@ -335,19 +307,18 @@ function RouteTable(props) {
               order={order}
               orderBy={orderBy}
               onRequestSort={handleRequestSort}
-              rowCount={routes.length}
+              rowCount={displayedRouteStats.length}
             />
             <TableBody>
               {stableSort(
-                routes,
-                getSorting(order, orderBy),
+                displayedRouteStats,
                 order,
                 orderBy,
               ).map((row, index) => {
                 const labelId = `enhanced-table-checkbox-${index}`;
 
                 return (
-                  <TableRow hover role="checkbox" tabIndex={-1} key={row.id}>
+                  <TableRow hover role="checkbox" tabIndex={-1} key={row.route.id}>
                     <TableCell
                       component="th"
                       id={labelId}
@@ -360,12 +331,12 @@ function RouteTable(props) {
                         to={{
                           type: 'ROUTESCREEN',
                           payload: {
-                            agencyId: row.agencyId,
-                            routeId: row.id,
+                            agencyId: row.route.agencyId,
+                            routeId: row.route.id,
                           },
                         }}
                       >
-                        {row.title}
+                        {row.route.title}
                       </Navlink>
                     </TableCell>
                     <TableCell
@@ -375,15 +346,11 @@ function RouteTable(props) {
                     >
                     <Chip
                       style={{
-                        color: quartileContrastColor(
-                          row.totalScore / 100,
-                        ),
-                        backgroundColor: quartileBackgroundColor(
-                          row.totalScore / 100,
-                        ),
+                        color: scoreContrastColor(row.totalScore),
+                        backgroundColor: scoreBackgroundColor(row.totalScore),
                       }}
                       label=
-                        {Number.isNaN(row.totalScore) ? '--' : row.totalScore}
+                        {row.totalScore == null ? '--' : row.totalScore}
                     />
                     </TableCell>
                     <TableCell
@@ -393,15 +360,11 @@ function RouteTable(props) {
                     >
                     <Chip
                       style={{
-                        color: quartileContrastColor(
-                          row.medianWaitScore / 100
-                        ),
-                        backgroundColor: quartileBackgroundColor(
-                          row.medianWaitScore / 100
-                        ),
+                        color: scoreContrastColor(row.medianWaitScore),
+                        backgroundColor: scoreBackgroundColor(row.medianWaitScore),
                       }}
                       label=
-                        {Number.isNaN(row.wait) ? '--' : row.wait.toFixed(0) + ' min'}
+                        {row.wait == null ? '--' : row.wait.toFixed(0) + ' min'}
                     />
 
                     </TableCell>
@@ -413,15 +376,11 @@ function RouteTable(props) {
                     >
                     <Chip
                       style={{
-                        color: quartileContrastColor(
-                          row.longWaitScore / 100,
-                        ),
-                        backgroundColor: quartileBackgroundColor(
-                          row.longWaitScore / 100,
-                        ),
+                        color: scoreContrastColor(row.longWaitScore),
+                        backgroundColor: scoreBackgroundColor(row.longWaitScore),
                       }}
                       label=
-                        {Number.isNaN(row.longWait)
+                        {row.longWait == null
                         ? '--'
                         : <Fragment>
                             {(row.longWait * 100).toFixed(0)}{'%'}
@@ -429,7 +388,6 @@ function RouteTable(props) {
                       }
                     />
                     </TableCell>
-
                     <TableCell
                       align="right"
                       padding="none"
@@ -437,15 +395,11 @@ function RouteTable(props) {
                     >
                     <Chip
                       style={{
-                        color: quartileContrastColor(
-                          row.speedScore / 100,
-                        ),
-                        backgroundColor: quartileBackgroundColor(
-                          row.speedScore / 100,
-                        ),
+                        color: scoreContrastColor(row.speedScore),
+                        backgroundColor: scoreBackgroundColor(row.speedScore),
                       }}
                       label=
-                        {Number.isNaN(row.speed) ? '--' : row.speed.toFixed(0) + ' mph'}
+                        {row.speed == null ? '--' : row.speed.toFixed(0) + ' mph'}
 
                     />
                     </TableCell>
@@ -456,15 +410,11 @@ function RouteTable(props) {
                     >
                     <Chip
                       style={{
-                        color: quartileContrastColor(
-                          row.travelVarianceScore / 100,
-                        ),
-                        backgroundColor: quartileBackgroundColor(
-                          row.travelVarianceScore / 100,
-                        ),
+                        color: scoreContrastColor(row.travelVarianceScore),
+                        backgroundColor: scoreBackgroundColor(row.travelVarianceScore),
                       }}
                       label=
-                        {Number.isNaN(row.variability)
+                        {row.variability == null
                           ? '--'
                           : <Fragment>
                               {'\u00b1'} {row.variability.toFixed(0)} min
@@ -486,7 +436,7 @@ function RouteTable(props) {
 
 const mapStateToProps = state => ({
   spiderSelection: state.spiderSelection,
-  precomputedStats: state.precomputedStats,
+  routeStats: state.routeStats,
 });
 
 const mapDispatchToProps = dispatch => {

--- a/frontend/src/helpers/routeCalculations.js
+++ b/frontend/src/helpers/routeCalculations.js
@@ -475,36 +475,26 @@ export function getAllScores(routes, waits, speeds) {
   return allScores;
 }
 
+const backgroundColorScale = d3.scaleThreshold()
+  .domain([0.25, 0.5, 0.75])
+  .range([red[300], yellow[300], lightGreen[700], green[900]]);
+
 export const scoreBackgroundColor = score => {
   if (score == null || Number.isNaN(score)) {
     return null;
   }
-  if (score <= 25) {
-    return red[300];
-  }
-  if (score <= 50) {
-    return yellow[300];
-  }
-  if (score <= 75) {
-    return lightGreen[700];
-  }
-  return green[900];
+  return backgroundColorScale(score / HighestPossibleScore);
 }
+
+const contrastColorScale = d3.scaleThreshold()
+  .domain([0.25, 0.5, 0.75])
+  .range(['rgba(0,0,0,0.87)', 'rgba(0,0,0,0.87)', 'white', 'white']);
 
 export const scoreContrastColor = score => {
   if (score == null || Number.isNaN(score)) {
     return null;
   }
-  if (score <= 25) {
-    return 'rgba(0,0,0,0.87)';
-  }
-  if (score <= 50) {
-    return 'rgba(0,0,0,0.87)';
-  }
-  if (score <= 75) {
-    return 'white';
-  }
-  return 'white';
+  return contrastColorScale(score / HighestPossibleScore);
 }
 
 /**

--- a/frontend/src/helpers/routeCalculations.js
+++ b/frontend/src/helpers/routeCalculations.js
@@ -69,7 +69,7 @@ function getTripTimesUsingHeuristics(
   route,
   directionId,
 ) {
-  const routeId = route.id;
+  const routeId = route ? route.id : null;
   const tripTimesForDir = getTripTimesForDirection(
     tripTimes,
     routeId,

--- a/frontend/src/reducers/index.js
+++ b/frontend/src/reducers/index.js
@@ -157,3 +157,12 @@ export function precomputedStats(state = initialPrecomputedStats, action) {
       return state;
   }
 };
+
+export function routeStats(state = {}, action) {
+  switch (action.type) {
+    case 'COMPUTED_ROUTE_STATS':
+      return action.stats;
+    default:
+      return state;
+  }
+};


### PR DESCRIPTION
This PR simplifies the code for computing displaying route-level statistics and scores. It uses a Redux action to store computed statistics and scores for each route (for the current date/time selection). This allows UI components like RouteTable and RouteSummary to easily display route-level statistics and scores without needing to repeat the code to compute them. This will make it easier to add or remove statistics from the route table and route summary in the future.

The unused A/B/C/D letter grade calculations were removed to simplify the code, and the term 'grade' was replaced by 'score'.

Minor functionality changes include always sorting "--" rows to the bottom of the RouteTable in both ascending/descending sorts, and using medianWaitScore instead of waitRank in MapSpider to compute the width of the lines used to draw each route.