### PR TITLE
update readme to make it more applicable to non-SF developers, and add more information on the backend stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# OpenTransit's Metrics MVP
+# OpenTransit Metrics MVP
 
 Welcome to OpenTransit! We're passionate about using open data to improve
-public transit systems around the world, starting with San Francisco.
+public transit systems around the world.
 
-This app uses historical transit data to help riders understand
-the quality of SF Muni bus and subway lines. [Check out the app!](http://muni.opentransit.city/)
+This app uses historical transit data to help riders, transit advocates,
+and transit planners understand the quality of public transit systems.
+
+[Check out the app](http://muni.opentransit.city/) to see the performance
+of Muni bus and light rail lines in San Francisco.
 
 If you're visiting this repo and looking to contribute, [check out our onboarding doc!](http://bit.ly/opentransit-onboarding)
 
@@ -116,8 +119,14 @@ popular React framework and looks great on mobile.
 
 ### Backend
 
-- **Flask** - because our data science work was already done in iPython and using
-Python for the backend would ease the migration from experimentation to production.
+- **Flask** - provides API endpoints used by the frontend
+- **GraphQL/Graphene** - a flexible API for returning various metrics requested by the frontend
+- **Pandas** - much of the data processing logic is implemented using Pandas data frames, e.g. when computing arrival times from raw GPS data
+- **Numpy** - algorithms involving arrays are implemented using Numpy for better performance, e.g. computing wait times and trip times
+- **Amazon S3** - the backend stores various data files (including route configuration, timetables, historical arrival times, and precomputed stats) as publicly-readable gzipped JSON files in S3, allowing the frontend to fetch data directly from S3 without hitting the Flask backend, and allowing multiple developers to share the same data without having to compute it themselves
+- **orion** - A node.js app in a separate repo (https://github.com/trynmaps/orion) which fetches the raw GPS location data for all vehicles in a transit agency every 15 seconds and stores the data in S3.
+- **tryn-api** - A node.js app in a separate repo (https://github.com/trynmaps/tryn-api) which implements another GraphQL API that the backend uses to fetch the stored GPS location data from S3.
+- **Unittest** - Framework for testing the backend Python code
 
 ## Notes for developers
 

--- a/README.md
+++ b/README.md
@@ -119,14 +119,14 @@ popular React framework and looks great on mobile.
 
 ### Backend
 
-- **Flask** - provides API endpoints used by the frontend
-- **GraphQL/Graphene** - a flexible API for returning various metrics requested by the frontend
-- **Pandas** - much of the data processing logic is implemented using Pandas data frames, e.g. when computing arrival times from raw GPS data
-- **Numpy** - algorithms involving arrays are implemented using Numpy for better performance, e.g. computing wait times and trip times
-- **Amazon S3** - the backend stores various data files (including route configuration, timetables, historical arrival times, and precomputed stats) as publicly-readable gzipped JSON files in S3, allowing the frontend to fetch data directly from S3 without hitting the Flask backend, and allowing multiple developers to share the same data without having to compute it themselves
+- **Flask** - provides API endpoints used by the frontend.
+- **GraphQL/Graphene** - a flexible API for returning various metrics requested by the frontend.
+- **Pandas** - much of the data processing logic is implemented using Pandas data frames, e.g. when computing arrival times from raw GPS data.
+- **NumPy** - algorithms involving arrays are implemented using Numpy for better performance, e.g. computing wait times and trip times.
+- **Amazon S3** - the backend stores various data files (including route configuration, timetables, historical arrival times, and precomputed stats) as publicly-readable gzipped JSON files in S3, allowing the frontend to fetch data directly from S3 without hitting the Flask backend, and allowing multiple developers to share the same data without having to compute it themselves.
 - **orion** - A node.js app in a separate repo (https://github.com/trynmaps/orion) which fetches the raw GPS location data for all vehicles in a transit agency every 15 seconds and stores the data in S3.
 - **tryn-api** - A node.js app in a separate repo (https://github.com/trynmaps/tryn-api) which implements another GraphQL API that the backend uses to fetch the stored GPS location data from S3.
-- **Unittest** - Framework for testing the backend Python code
+- **Unittest** - Framework for testing the backend Python code.
 
 ## Notes for developers
 


### PR DESCRIPTION
The readme was a bit confusing for new Portland developers since it sounded like it was only for SF.

Also, it had a lot of information about the technologies used in the frontend stack, but not much information about the backend stack.