### PR TITLE
Quick fix for javascript crash after viewing react-select 

### DIFF
--- a/frontend/src/components/ReactSelect.jsx
+++ b/frontend/src/components/ReactSelect.jsx
@@ -426,7 +426,11 @@ function handleReposition(
     window[`${inputId}Timeout`] = setTimeout(
       () => {
         allowTransition.current = false;
-        setTextFieldDOMRect(textRef.current.getBoundingClientRect());
+        // textRef.current becomes null after going to the dashboard
+        // and scrolling there triggers this event handler. 
+        if (textRef.current) { 
+          setTextFieldDOMRect(textRef.current.getBoundingClientRect());
+        }
       },
       eventType === 'scroll' ? scrollHandlerDelay : 0,
     );


### PR DESCRIPTION


<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->
<!--
Fixes #1234. Fixes #2345. Fixes #3456.
-->

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

Fix production bug where:

1.  User views the screen for a route and selects a direction, causing the react-selects to render.
2.  User returns to the dashbard via the left arrow button (upper left corner)
3.  User scrolls the dashboard.  This causes a javascript crash.  Apparently the scrolling triggers an event handler for the react-select which probably expects the react-select to be present and visible, but it is not.

## Screenshot

n/a

## Link to demo, if any

n/a
