### PR TITLE
Temporarily limit date range queries on the front end to 10 days

### DIFF
--- a/frontend/src/UIConstants.js
+++ b/frontend/src/UIConstants.js
@@ -68,14 +68,18 @@ export const TIME_RANGES = [
   },
 ];
 
-export const MAX_DATE_RANGE = 90; // largest date range allowed, in days (30 might be more performant)
+export const MAX_DATE_RANGE = 10; // was 90, largest date range allowed, in days (30 might be more performant)
 
 // RadioGroup expects values to be strings, not numbers.
 export const DATE_RANGES = [
   { value: '1', label: 'Yesterday' },
   { value: '7', label: 'Last week' },
+/* temporarily disabled until performant
+
   { value: '30', label: 'Last 30 days' },
   { value: '90', label: 'Last 90 days' },
+
+  */
 ];
 
 // Values are Moment days of the week (0-6)


### PR DESCRIPTION


<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->
<!--
Fixes #1234. Fixes #2345. Fixes #3456.
-->

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

Temporarily limit date range queries on the front end to 10 days instead of 90.  Date range queries of 30 days or more seem to tie up the back end for too long and may be causing Flask worker timeouts.

I think Jesse is planning to optimize the graphql code, possibly as part of #511 , so these changes can be reverted when that goes in.

## Screenshot

n/a

## Link to demo, if any

n/a
