### PR TITLE
add scripts for running lint within docker container; run lint via github actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,3 +11,7 @@ jobs:
       run: docker build --target flask -t opentransit/flask:latest .
     - name: Run tests
       run: docker run opentransit/flask:latest python -m unittest discover -s tests
+    - name: Build Docker react-dev image
+      run: docker build --target react-dev -t opentransit/react-dev:latest .
+    - name: Run lint
+      run: docker run opentransit/react-dev:latest npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,5 @@ jobs:
       run: docker run opentransit/flask:latest python -m unittest discover -s tests
     - name: Build Docker react-dev image
       run: docker build --target react-dev -t opentransit/react-dev:latest .
-    - name: Run lint
-      run: docker run opentransit/react-dev:latest npm run lint
+    - name: Run lint:check
+      run: docker run opentransit/react-dev:latest npm run lint:check

--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ then you'll see a guide to get in.
 
 To get started, see the Issues page. You may want to [identify good first issues](https://github.com/trynmaps/metrics-mvp/labels/Good%20First%20Issue).
 
+### Code Style
+
+This repository uses eslint to enforce a consistent style for frontend JavaScript code.
+
+Before committing, run `dev/docker-lint.sh` (Mac/Linux) or `dev\docker-lint.bat` (Windows) to check for style errors and automatically fix formatting issues. (You will need to run `docker-compose up` or `docker-compose build` at least once before the docker-lint script will work.)
+
+GitHub automatically runs tests for each push to check for eslint errors. If eslint reports any style errors, pull requests will show a failing check.
+
 ### Deploying to Heroku
 
 When you make a Pull Request, we would suggest you deploy your branch to Heroku so that other

--- a/dev/docker-lint.bat
+++ b/dev/docker-lint.bat
@@ -1,0 +1,1 @@
+docker run -v "%~dp0..\frontend\src:/app/frontend/src" metrics-mvp_react-dev:latest npm run lint

--- a/dev/docker-lint.sh
+++ b/dev/docker-lint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+DEV_DIR=$(cd `dirname $0` && pwd)
+ROOT_DIR=`dirname $DEV_DIR`
+
+set -eux
+
+docker run -v "$ROOT_DIR/frontend/src:/app/frontend/src" metrics-mvp_react-dev:latest npm run lint

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       OPENTRANSIT_AGENCY_IDS: muni
   react-dev:
     container_name: metrics-react-dev
+    image: metrics-mvp_react-dev:latest
     build:
       context: .
       dockerfile: Dockerfile

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -24,11 +24,17 @@
         "ignoreUrls": true
       }
     ],
+    "no-param-reassign": [
+      "error",
+      {
+        "props": false
+      }
+    ],
     "func-names": "off",
     "prefer-destructuring": "off",
     "no-plusplus": [
       "error",
-      { "allowForLoopAfterthoughts": true } 
+      { "allowForLoopAfterthoughts": true }
     ],
     "no-underscore-dangle": "warn",
     "react/destructuring-assignment": "off",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,6 +55,7 @@
     "eject": "react-scripts eject",
     "heroku-postbuild": "npm build",
     "lint": "eslint src --fix --ext .jsx,.js",
+    "lint:check": "eslint src --ext .jsx,.js",
     "lint:all": "eslint --fix --ext src/**/*.{js,jsx}"
   },
   "eslintConfig": {

--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -121,7 +121,9 @@ function ControlPanel(props) {
    * Handle mouseout event on Select TO & From dropdown list item.
    */
   function handleItemMouseOut(node) {
-    node && node.classList.remove('on-hover');
+    if (node) {
+      node.classList.remove('on-hover');
+    }
   }
   /**
    * Handle Select component close

--- a/frontend/src/components/DateTimePanel.jsx
+++ b/frontend/src/components/DateTimePanel.jsx
@@ -293,6 +293,24 @@ function DateTimePanel(props) {
     });
   };
 
+  const allFalse = (dictionary, array) => {
+    for (let i = 0; i < array.length; i++) {
+      if (dictionary[array[i].value]) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  const allTrue = (dictionary, array) => {
+    for (let i = 0; i < array.length; i++) {
+      if (!dictionary[array[i].value]) {
+        return false;
+      }
+    }
+    return true;
+  };
+
   /**
    * Bulk toggle.
    */
@@ -313,24 +331,6 @@ function DateTimePanel(props) {
     applyGraphParams({
       daysOfTheWeek: newDaysOfTheWeek,
     });
-  };
-
-  const allFalse = (dictionary, array) => {
-    for (let i = 0; i < array.length; i++) {
-      if (dictionary[array[i].value]) {
-        return false;
-      }
-    }
-    return true;
-  };
-
-  const allTrue = (dictionary, array) => {
-    for (let i = 0; i < array.length; i++) {
-      if (!dictionary[array[i].value]) {
-        return false;
-      }
-    }
-    return true;
   };
 
   const open = Boolean(anchorEl);

--- a/frontend/src/components/InfoByDay.jsx
+++ b/frontend/src/components/InfoByDay.jsx
@@ -35,6 +35,8 @@ function InfoByDay(props) {
   const [selectedOption, setSelectedOption] = useState(AVERAGE_TIME); // radio button starts on average time
   const [crosshairValues, setCrosshairValues] = useState([]); // tooltip starts out empty
 
+  const { byDayData, routes, graphParams } = props;
+
   /**
    * Event handler for radio buttons
    * @param {changeEvent} The change event on the radio buttons.
@@ -50,21 +52,6 @@ function InfoByDay(props) {
    */
   const onMouseLeave = () => {
     setCrosshairValues([]);
-  };
-
-  /**
-   * Event handler for onNearestX.
-   * @param {Object} value Selected value.
-   * @param {index} index Index of the value in the data array.
-   * @private
-   */
-  const onNearestX = (_value, { index }) => {
-    setCrosshairValues([waitData[index], tripData[index]]);
-  };
-
-  const onNearestXGeneric = (_value, { index }) => {
-    // TODO: need to make only one chart's crosshair visible at a time,
-    // this currently makes it appear on all charts: setCrosshairValues([_value]);
   };
 
   const computeDistance = (myGraphParams, myRoutes) => {
@@ -128,8 +115,6 @@ function InfoByDay(props) {
       };
     };
   };
-
-  const { byDayData, routes, graphParams } = props;
 
   const waitData =
     byDayData && byDayData.map(mapDays('waitTimes', selectedOption));
@@ -229,6 +214,21 @@ function InfoByDay(props) {
       </div>
     );
   }
+
+  /**
+   * Event handler for onNearestX.
+   * @param {Object} value Selected value.
+   * @param {index} index Index of the value in the data array.
+   * @private
+   */
+  const onNearestX = (_value, { index }) => {
+    setCrosshairValues([waitData[index], tripData[index]]);
+  };
+
+  const onNearestXGeneric = (/* _value, { index } */) => {
+    // TODO: need to make only one chart's crosshair visible at a time,
+    // this currently makes it appear on all charts: setCrosshairValues([_value]);
+  };
 
   return (
     <div>

--- a/frontend/src/components/InfoScoreCard.jsx
+++ b/frontend/src/components/InfoScoreCard.jsx
@@ -53,12 +53,10 @@ export default function InfoScoreCard(props) {
     setAnchorEl(null);
   }
 
-  const cardStyle = score => {
-    return {
-      background: score != null ? scoreBackgroundColor(score) : 'gray',
-      color: score != null ? scoreContrastColor(score) : 'black',
-      margin: 4,
-    };
+  const cardStyle = {
+    background: score != null ? scoreBackgroundColor(score) : 'gray',
+    color: score != null ? scoreContrastColor(score) : 'black',
+    margin: 4,
   };
 
   const rating =
@@ -66,7 +64,7 @@ export default function InfoScoreCard(props) {
 
   return (
     <Fragment>
-      <Grid item xs component={Paper} style={cardStyle(score)}>
+      <Grid item xs component={Paper} style={cardStyle}>
         <Box
           display="flex"
           flexDirection="column"

--- a/frontend/src/components/InfoTripSummary.jsx
+++ b/frontend/src/components/InfoTripSummary.jsx
@@ -205,8 +205,8 @@ export default function InfoTripSummary(props) {
   const popoverContentLongWait = (
     <Fragment>
       Long wait probability is the chance a rider has of a wait of twenty
-      minutes or longer after arriving randomly at the "from" stop. Probability
-      of{' '}
+      minutes or longer after arriving randomly at the &quot;from&quot; stop.
+      Probability of{' '}
       {(longWaitProbability * 100).toFixed(1) /* be more precise than card */}%
       gets a score of {scores.longWaitScore}.
       <Box pt={2}>

--- a/frontend/src/components/MapSpider.jsx
+++ b/frontend/src/components/MapSpider.jsx
@@ -15,15 +15,14 @@ import Control from 'react-leaflet-control';
 import * as d3 from 'd3';
 import { Snackbar } from '@material-ui/core';
 import {
-  getDownstreamStopIds
+  getDownstreamStopIds,
+  getTripPoints,
+  isInServiceArea,
 } from '../helpers/mapGeometry';
-import {
-  filterRoutes,
-  milesBetween,
-} from '../helpers/routeCalculations';
+import { filterRoutes, milesBetween } from '../helpers/routeCalculations';
 import { handleSpiderMapClick } from '../actions';
 import { Agencies } from '../config';
-import { getTripPoints, isInServiceArea } from '../helpers/mapGeometry';
+
 import MapShield from './MapShield';
 
 const CLICK_RADIUS_MI = 0.25; // maximum radius for stops near a point
@@ -128,8 +127,8 @@ class MapSpider extends Component {
               routeId: startMarker.routeId,
               directionId: startMarker.direction.id,
               startStopId: startMarker.stopId,
-              endStopId: lastStop.stopId
-            }
+              endStopId: lastStop.stopId,
+            },
           });
         }}
       ></Marker>
@@ -144,10 +143,9 @@ class MapSpider extends Component {
 
     /* eslint-disable react/no-array-index-key */
 
-    var selectedStops = this.props.spiderSelection.stops;
+    const selectedStops = this.props.spiderSelection.stops;
 
     if (selectedStops) {
-
       items = selectedStops.map((startMarker, index) => {
         const position = [startMarker.stop.lat, startMarker.stop.lon];
         const routeColor = this.routeColor(startMarker.routeIndex % 10);
@@ -200,7 +198,9 @@ class MapSpider extends Component {
 
         const stats = routeStats[startMarker.routeId] || {};
 
-        let waitScaled = stats.waitRankCount ? Math.trunc((1 - stats.waitRank / stats.waitRankCount) * 3) : 0;
+        const waitScaled = stats.waitRankCount
+          ? Math.trunc((1 - stats.waitRank / stats.waitRankCount) * 3)
+          : 0;
 
         for (let i = 0; i < downstreamStops.length - 1; i++) {
           // for each stop
@@ -291,8 +291,8 @@ class MapSpider extends Component {
               routeId: startMarker.routeId,
               directionId: startMarker.direction.id,
               startStopId: startMarker.stopId,
-              endStopId: downstreamStops[i + 1].id
-            }
+              endStopId: downstreamStops[i + 1].id,
+            },
           });
         }}
       >
@@ -393,7 +393,7 @@ class MapSpider extends Component {
     const stopIds = getDownstreamStopIds(
       routeInfo,
       targetStop.direction,
-      targetStop.stopId
+      targetStop.stopId,
     );
     stopIds.unshift(targetStop.stopId);
 

--- a/frontend/src/components/MapStops.jsx
+++ b/frontend/src/components/MapStops.jsx
@@ -91,11 +91,10 @@ class MapStops extends Component {
         html:
           `<svg viewBox="-10 -10 10 10"><g transform="rotate(${rotation} -5 -5)">` +
           // First we draw a white circle
-
           `<circle cx="-5" cy="-5" r="3" fill="white" stroke="${Colors.INDIGO}" stroke-width="0.75"/>` +
           // Then the "v" shape point to zero degrees (east).  The entire parent svg is rotated.
-
-          `<polyline points="-5.5,-6 -4,-5 -5.5,-4" stroke-linecap="round" stroke-linejoin="round" stroke="${Colors.INDIGO}" stroke-width="0.6" fill="none"/>` +
+          `<polyline points="-5.5,-6 -4,-5 -5.5,-4" stroke-linecap="round" stroke-linejoin="round"
+            stroke="${Colors.INDIGO}" stroke-width="0.6" fill="none"/>` +
           `</g>` +
           `</svg>`,
       });
@@ -123,10 +122,10 @@ class MapStops extends Component {
    * @returns {Number} The angle in degrees (where 0 is east, 90 is south)
    */
   angleFromTo = (fromPoint, toPoint) => {
-    const delta_x = toPoint.lon - fromPoint.lon;
+    const deltaX = toPoint.lon - fromPoint.lon;
     // Note that y is reversed due to latitude's postive direction being reverse of screen y
-    const delta_y = fromPoint.lat - toPoint.lat;
-    const rotation = Math.round((Math.atan2(delta_y, delta_x) * 180) / Math.PI);
+    const deltaY = fromPoint.lat - toPoint.lat;
+    const rotation = Math.round((Math.atan2(deltaY, deltaX) * 180) / Math.PI);
     return rotation;
   };
 
@@ -455,7 +454,7 @@ class MapStops extends Component {
       selectedRoute = routes.find(route => route.id === graphParams.routeId);
 
       if (selectedRoute) {
-        selectedRoute.directions.forEach((direction, index) => {
+        selectedRoute.directions.forEach(direction => {
           // plot only the selected direction if we have one, or else all directions
 
           if (
@@ -476,13 +475,20 @@ class MapStops extends Component {
       }
     }
 
-    const mapInstruction = !graphParams.directionId
-      ? 'Select a direction to see stops in that direction.'
-      : !graphParams.startStopId
-      ? 'Click an origin stop.'
-      : !graphParams.endStopId
-      ? 'Click a destination stop.'
-      : '';
+    function getMapInstruction() {
+      if (!graphParams.directionId) {
+        return 'Select a direction to see stops in that direction.';
+      }
+      if (!graphParams.startStopId) {
+        return 'Click an origin stop.';
+      }
+      if (!graphParams.endStopId) {
+        return 'Click a destination stop.';
+      }
+      return '';
+    }
+
+    const mapInstruction = getMapInstruction();
 
     return (
       <Map

--- a/frontend/src/components/RouteSummary.jsx
+++ b/frontend/src/components/RouteSummary.jsx
@@ -314,11 +314,4 @@ const mapStateToProps = state => ({
   routeStats: state.routeStats,
 });
 
-const mapDispatchToProps = dispatch => {
-  return {};
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(RouteSummary);
+export default connect(mapStateToProps)(RouteSummary);

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -25,6 +25,33 @@ import {
   scoreContrastColor,
 } from '../helpers/routeCalculations';
 
+function getComparisonFunction(order, orderBy) {
+  // Sort null values to bottom regardless of ascending/descending
+  const factor = order === 'desc' ? 1 : -1;
+  return (a, b) => {
+    const aValue = a[orderBy];
+    const bValue = b[orderBy];
+
+    if (aValue == null && bValue == null) {
+      return 0;
+    }
+    if (aValue == null) {
+      return 1;
+    }
+    if (bValue == null) {
+      return -1;
+    }
+
+    if (bValue < aValue) {
+      return -factor;
+    }
+    if (bValue > aValue) {
+      return factor;
+    }
+    return 0;
+  };
+}
+
 /**
  * Sorts the given array by an object property.  Equal values are ordered by array index.
  *
@@ -57,33 +84,6 @@ function stableSort(array, sortOrder, orderBy) {
     return a[1] - b[1];
   });
   return stabilizedThis.map(el => el[0]);
-}
-
-function getComparisonFunction(order, orderBy) {
-  // Sort null values to bottom regardless of ascending/descending
-  const factor = order === 'desc' ? 1 : -1;
-  return (a, b) => {
-    const aValue = a[orderBy];
-    const bValue = b[orderBy];
-
-    if (aValue == null && bValue == null) {
-      return 0;
-    }
-    if (aValue == null) {
-      return 1;
-    }
-    if (bValue == null) {
-      return -1;
-    }
-
-    if (bValue < aValue) {
-      return -factor;
-    }
-    if (bValue > aValue) {
-      return factor;
-    }
-    return 0;
-  };
 }
 
 const headRows = [
@@ -477,11 +477,4 @@ const mapStateToProps = state => ({
   query: state.location.query,
 });
 
-const mapDispatchToProps = dispatch => {
-  return {};
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(RouteTable);
+export default connect(mapStateToProps)(RouteTable);

--- a/frontend/src/components/SidebarButton.jsx
+++ b/frontend/src/components/SidebarButton.jsx
@@ -14,7 +14,7 @@ import TimelineRoundedIcon from '@material-ui/icons/TimelineRounded';
 import CodeRoundedIcon from '@material-ui/icons/CodeRounded';
 import InfoRoundedIcon from '@material-ui/icons/InfoRounded';
 import Divider from '@material-ui/core/Divider';
-import { components } from '../reducers/page.js';
+import { components } from '../reducers/page';
 
 function SidebarButton(props) {
   const currentPage = props.currentPage;

--- a/frontend/src/helpers/graphData.js
+++ b/frontend/src/helpers/graphData.js
@@ -2,6 +2,8 @@
  * Helper functions for working with graph data.
  */
 
+/* eslint import/prefer-default-export: "off" */
+
 /**
  * Helper method to get a specific percentile out of histogram graph data
  * where percentile is 0-100.

--- a/frontend/src/helpers/mapGeometry.js
+++ b/frontend/src/helpers/mapGeometry.js
@@ -141,6 +141,7 @@ export function getDistanceInMiles(
     }
     return miles;
   }
+  return null;
 }
 
 /**

--- a/frontend/src/helpers/routeCalculations.js
+++ b/frontend/src/helpers/routeCalculations.js
@@ -18,15 +18,6 @@ import {
 
 import { getAgency } from '../config';
 
-/**
- * Given an array of routes, return only the routes we want to show.
- */
-export function filterRoutes(routes) {
-  return routes.filter(route => {
-    return !isIgnoredRoute(route);
-  });
-}
-
 export function isIgnoredRoute(route) {
   const routeHeuristics = getAgency(route.agencyId).routeHeuristics;
   return (
@@ -34,6 +25,15 @@ export function isIgnoredRoute(route) {
     routeHeuristics[route.id] &&
     routeHeuristics[route.id].ignoreRoute
   );
+}
+
+/**
+ * Given an array of routes, return only the routes we want to show.
+ */
+export function filterRoutes(routes) {
+  return routes.filter(route => {
+    return !isIgnoredRoute(route);
+  });
 }
 
 /**
@@ -191,16 +191,16 @@ export function getEndToEndTripTime(
   // if there is no trip time to the last stop, then use the highest trip time actually observed
 
   if (!tripTime) {
-    const tripTimes = getTripTimeStat(tripTimesForFirstStop, statIndex);
-    const stopIds = Object.keys(tripTimes);
+    const tripTimesMap = getTripTimeStat(tripTimesForFirstStop, statIndex);
+    const stopIds = Object.keys(tripTimesMap);
     tripTime = 0;
 
     for (let i = 0; i < stopIds.length; i++) {
       if (
-        tripTimes[stopIds[i]] > tripTime &&
+        tripTimesMap[stopIds[i]] > tripTime &&
         directionInfo.stop_geometry[stopIds[i]]
       ) {
-        tripTime = tripTimes[stopIds[i]];
+        tripTime = tripTimesMap[stopIds[i]];
         tripDistance =
           directionInfo.stop_geometry[stopIds[i]].distance - firstStopDistance;
       }

--- a/frontend/src/screens/RouteScreen.jsx
+++ b/frontend/src/screens/RouteScreen.jsx
@@ -221,7 +221,7 @@ const mapStateToProps = state => ({
   tripMetricsLoading: state.loading.TRIP_METRICS,
   routes: state.routes.data,
   graphParams: state.graphParams,
-  query: state.location.query,  
+  query: state.location.query,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/frontend/src/screens/RouteScreen.jsx
+++ b/frontend/src/screens/RouteScreen.jsx
@@ -81,7 +81,7 @@ function RouteScreen(props) {
         // return paths with non null values
         return !!path;
       })
-      .map((path, index, paths) => {
+      .map((path, index) => {
         const hasNextValue = paths[index + 1];
         const param = params[index];
         const payload = {};


### PR DESCRIPTION
Currently it seems that most frontend developers (including me) haven't been running `npm run lint` on their PRs. If one developer runs lint on their PR, lint will then make a lot of changes unrelated to their PR, which makes reviewing and merging difficult (e.g. https://github.com/trynmaps/metrics-mvp/pull/509).

However, in order for a developer to run `npm run lint`, they need npm installed on their host, but many developers do not have npm installed on their host, because normally npm runs inside a Docker container.

This PR adds scripts to allow developers using Docker to run lint inside a Docker container, so it is no longer necessary for developers to have npm installed on their host.

It also runs the lint task via Github Actions on each push so that we can see failing lint checks when reviewing PRs, and fixes all existing lint errors.