### PR TITLE
preserve query string when clicking stops on map or breadcrumbs on route screen

### DIFF
--- a/frontend/src/components/MapSpider.jsx
+++ b/frontend/src/components/MapSpider.jsx
@@ -129,6 +129,7 @@ class MapSpider extends Component {
               startStopId: startMarker.stopId,
               endStopId: lastStop.stopId,
             },
+            query: this.props.query,
           });
         }}
       ></Marker>
@@ -293,6 +294,7 @@ class MapSpider extends Component {
               startStopId: startMarker.stopId,
               endStopId: downstreamStops[i + 1].id,
             },
+            query: this.props.query,
           });
         }}
       >
@@ -528,6 +530,7 @@ const mapStateToProps = state => ({
   routeStats: state.routeStats,
   graphParams: state.graphParams,
   spiderSelection: state.spiderSelection,
+  query: state.location.query,
 });
 
 const mapDispatchToProps = dispatch => {

--- a/frontend/src/components/MapStops.jsx
+++ b/frontend/src/components/MapStops.jsx
@@ -407,6 +407,7 @@ class MapStops extends Component {
         startStopId,
         endStopId,
       },
+      query: this.props.query,
     });
   };
 
@@ -517,6 +518,7 @@ class MapStops extends Component {
 const mapStateToProps = state => ({
   graphParams: state.graphParams,
   precomputedStats: state.precomputedStats,
+  query: state.location.query,
 });
 
 const mapDispatchToProps = dispatch => {

--- a/frontend/src/screens/RouteScreen.jsx
+++ b/frontend/src/screens/RouteScreen.jsx
@@ -65,6 +65,7 @@ function RouteScreen(props) {
 
     let link = {
       type: 'ROUTESCREEN',
+      query: props.query,
     };
     const params = ['routeId', 'directionId', 'startStopId', 'endStopId'];
     const labels = (param, title) => {


### PR DESCRIPTION
Fixes #530.

Fixes an issue where clicking stops on the map or the breadcrumbs would reset the date range because the query string was not set as a property on the action.