### PR TITLE
Small fix to add query string support for the data diagnostic page

### DIFF
--- a/frontend/src/routesMap.js
+++ b/frontend/src/routesMap.js
@@ -103,7 +103,13 @@ export default {
       dispatch(handleGraphParams(newParams));
     },
   },
-  DATADIAGNOSTIC: '/dataDiagnostic',
+  DATADIAGNOSTIC: {
+    path: '/dataDiagnostic',
+    thunk: async (dispatch, getState) => {
+      const newParams = processQuery(getState);
+      dispatch(handleGraphParams(newParams));
+    },
+  },
   ROUTESCREEN: {
     /*
     Redux first router path syntax


### PR DESCRIPTION
<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->
<!--
Fixes #1234. Fixes #2345. Fixes #3456.
-->

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

A small fix to add query string support for our "Developer Tools" (data diagnostic) page.  This is something I missed when adding date params to the query string.  Noticed while testing #528 .

## Screenshot

n/a

## Link to demo, if any

n/a
