### PR TITLE
render route on map on table row hover

### DIFF
--- a/frontend/src/components/MapShield.jsx
+++ b/frontend/src/components/MapShield.jsx
@@ -14,14 +14,14 @@ export default function MapShield(props) {
 
   if (routeText.endsWith('R') || routeText.endsWith('X')) {
     html =
-      `<div style="width:30px; height:${r * 2}px; ` +
+      `<div style="width:${r * 3}px; height:${r * 2}px; ` +
       `border-radius:${routeText.endsWith('X') ? r : 0}px; `;
   } else {
     // all other routes get circular shields
 
     html =
-      `<div style="width:${r * 2}px; height:${r * 2}px; ` +
-      `border-radius: ${r+1}px; `;
+      `<div style="width:${r * 3}px; height:${r * 2}px; ` +
+      `border-radius: ${r + 1}px; `;
   }
 
   html +=
@@ -29,8 +29,7 @@ export default function MapShield(props) {
       'border-style:solid; border-color:'}${color}; ` +
     `border-width: ${waitScaled / 1.5 + 1.0}px;` +
     `background-color:white;` +
-    `font-size:${75 + waitScaled * 15}%; font-weight: ${400 +
-     waitScaled * 75};
+    `font-size:${75 + waitScaled * 15}%; font-weight: ${400 + waitScaled * 75};
      display:flex; align-items: center;
      justify-content: center;">${routeText}</div>`;
 

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -1,7 +1,7 @@
 import React, { useState, Fragment } from 'react';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
-import { lighten, makeStyles } from '@material-ui/core/styles';
+import { lighten, makeStyles, createMuiTheme } from '@material-ui/core/styles';
 import Chip from '@material-ui/core/Chip';
 import Popover from '@material-ui/core/Popover';
 import Table from '@material-ui/core/Table';
@@ -14,7 +14,7 @@ import Toolbar from '@material-ui/core/Toolbar';
 import Typography from '@material-ui/core/Typography';
 import IconButton from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
-import { createMuiTheme } from '@material-ui/core/styles';
+
 import FilterListIcon from '@material-ui/icons/FilterList';
 import InfoIcon from '@material-ui/icons/InfoOutlined';
 import { connect } from 'react-redux';
@@ -38,7 +38,6 @@ import {
  * @returns {Array}          The sorted array
  */
 function stableSort(array, sortOrder, orderBy) {
-
   // special case for title sorting that short circuits the use of the comparator
 
   if (orderBy === 'title') {
@@ -62,7 +61,7 @@ function stableSort(array, sortOrder, orderBy) {
 
 function getComparisonFunction(order, orderBy) {
   // Sort null values to bottom regardless of ascending/descending
-  var factor = order === 'desc' ? 1 : -1;
+  const factor = order === 'desc' ? 1 : -1;
   return (a, b) => {
     const aValue = a[orderBy];
     const bValue = b[orderBy];
@@ -201,9 +200,9 @@ const EnhancedTableToolbar = props => {
         ) : (
           <Typography variant="h6" id="tableTitle">
             Routes
-                  <IconButton size="small" onClick={handleClick}>
-                    <InfoIcon fontSize="small" />
-                  </IconButton>
+            <IconButton size="small" onClick={handleClick}>
+              <InfoIcon fontSize="small" />
+            </IconButton>
           </Typography>
         )}
       </div>
@@ -229,25 +228,26 @@ const EnhancedTableToolbar = props => {
           horizontal: 'center',
         }}
       >
-        <div className={classes.popover}><b>Score</b> is the average of subscores (0-100) for median wait,
-          long wait probability, average speed, and travel time variability.  Click on a route to see its metrics
-          and explanations of how the subscores are calculated.
-          <p/>
-          <b>Median Wait</b> is the 50th percentile (typical) wait time for a rider arriving
-          randomly at a stop while the route is running.
-          <p/>
-          <b>Long wait probability</b> is the chance a rider has of a wait of twenty minutes
-          or longer after arriving randomly at a stop.
-          <p/>
-          <b>Average speed</b> is the speed of the 50th percentile (typical) end to end trip, averaged
-          for all directions.
-          <p/>
-          <b>Travel time variability</b> is the 90th percentile end to end travel time minus the 10th percentile
-          travel time.  This measures how much extra travel time is needed for some trips.
-
+        <div className={classes.popover}>
+          <b>Score</b> is the average of subscores (0-100) for median wait, long
+          wait probability, average speed, and travel time variability. Click on
+          a route to see its metrics and explanations of how the subscores are
+          calculated.
+          <p />
+          <b>Median Wait</b> is the 50th percentile (typical) wait time for a
+          rider arriving randomly at a stop while the route is running.
+          <p />
+          <b>Long wait probability</b> is the chance a rider has of a wait of
+          twenty minutes or longer after arriving randomly at a stop.
+          <p />
+          <b>Average speed</b> is the speed of the 50th percentile (typical) end
+          to end trip, averaged for all directions.
+          <p />
+          <b>Travel time variability</b> is the 90th percentile end to end
+          travel time minus the 10th percentile travel time. This measures how
+          much extra travel time is needed for some trips.
         </div>
       </Popover>
-
     </Toolbar>
   );
 };
@@ -273,7 +273,7 @@ function RouteTable(props) {
   const dense = true;
   const theme = createMuiTheme();
 
-  const { routeStats } = props;
+  const { routeStats, setHoverRoute } = props;
 
   function handleRequestSort(event, property) {
     const isDesc = orderBy === property && order === 'desc';
@@ -294,40 +294,61 @@ function RouteTable(props) {
   const displayedRouteStats = routes.map(route => {
     return {
       route,
-      ...(routeStats[route.id] || {})
+      ...(routeStats[route.id] || {}),
     };
   });
 
   return (
     <div>
-        <EnhancedTableToolbar numSelected={0} />
-        <div className={classes.tableWrapper}>
-          <Table aria-labelledby="tableTitle" size={dense ? 'small' : 'medium'}>
-            <EnhancedTableHead
-              order={order}
-              orderBy={orderBy}
-              onRequestSort={handleRequestSort}
-              rowCount={displayedRouteStats.length}
-            />
-            <TableBody>
-              {stableSort(
-                displayedRouteStats,
-                order,
-                orderBy,
-              ).map((row, index) => {
+      <EnhancedTableToolbar numSelected={0} />
+      <div className={classes.tableWrapper}>
+        <Table aria-labelledby="tableTitle" size={dense ? 'small' : 'medium'}>
+          <EnhancedTableHead
+            order={order}
+            orderBy={orderBy}
+            onRequestSort={handleRequestSort}
+            rowCount={displayedRouteStats.length}
+          />
+          <TableBody
+            onMouseLeave={() => {
+              clearTimeout(global.hoverRoute);
+              setHoverRoute(null);
+            }}
+          >
+            {stableSort(displayedRouteStats, order, orderBy).map(
+              (row, index) => {
                 const labelId = `enhanced-table-checkbox-${index}`;
 
                 return (
-                  <TableRow hover role="checkbox" tabIndex={-1} key={row.route.id}>
+                  <TableRow
+                    hover
+                    role="checkbox"
+                    tabIndex={-1}
+                    key={row.route.id}
+                    onMouseEnter={() => {
+                      clearTimeout(global.hoverRoute);
+                      global.hoverRoute = setTimeout(
+                        () => setHoverRoute(row.route),
+                        30,
+                      );
+                    }}
+                  >
                     <TableCell
                       component="th"
                       id={labelId}
                       scope="row"
                       padding="none"
-                      style={{border:'none', paddingTop:6, paddingBottom:6}}
+                      style={{
+                        border: 'none',
+                        paddingTop: 6,
+                        paddingBottom: 6,
+                      }}
                     >
                       <Navlink
-                        style={{color: theme.palette.primary.dark, textDecoration: 'none'}}
+                        style={{
+                          color: theme.palette.primary.dark,
+                          textDecoration: 'none',
+                        }}
                         to={{
                           type: 'ROUTESCREEN',
                           payload: {
@@ -342,94 +363,121 @@ function RouteTable(props) {
                     <TableCell
                       align="right"
                       padding="none"
-                      style={{border:'none', paddingTop:6, paddingBottom:6}}
-                    >
-                    <Chip
                       style={{
-                        color: scoreContrastColor(row.totalScore),
-                        backgroundColor: scoreBackgroundColor(row.totalScore),
+                        border: 'none',
+                        paddingTop: 6,
+                        paddingBottom: 6,
                       }}
-                      label=
-                        {row.totalScore == null ? '--' : row.totalScore}
-                    />
+                    >
+                      <Chip
+                        style={{
+                          color: scoreContrastColor(row.totalScore),
+                          backgroundColor: scoreBackgroundColor(row.totalScore),
+                        }}
+                        label={row.totalScore == null ? '--' : row.totalScore}
+                      />
                     </TableCell>
                     <TableCell
                       align="right"
                       padding="none"
-                      style={{border:'none', paddingTop:6, paddingBottom:6}}
-                    >
-                    <Chip
                       style={{
-                        color: scoreContrastColor(row.medianWaitScore),
-                        backgroundColor: scoreBackgroundColor(row.medianWaitScore),
+                        border: 'none',
+                        paddingTop: 6,
+                        paddingBottom: 6,
                       }}
-                      label=
-                        {row.wait == null ? '--' : row.wait.toFixed(0) + ' min'}
-                    />
+                    >
+                      <Chip
+                        style={{
+                          color: scoreContrastColor(row.medianWaitScore),
+                          backgroundColor: scoreBackgroundColor(
+                            row.medianWaitScore,
+                          ),
+                        }}
+                        label={
+                          row.wait == null ? '--' : `${row.wait.toFixed(0)} min`
+                        }
+                      />
+                    </TableCell>
 
-                    </TableCell>
-
                     <TableCell
                       align="right"
-                      style={{border:'none'}}
+                      style={{ border: 'none' }}
                       padding="none"
                     >
-                    <Chip
-                      style={{
-                        color: scoreContrastColor(row.longWaitScore),
-                        backgroundColor: scoreBackgroundColor(row.longWaitScore),
-                      }}
-                      label=
-                        {row.longWait == null
-                        ? '--'
-                        : <Fragment>
-                            {(row.longWait * 100).toFixed(0)}{'%'}
-                          </Fragment>
-                      }
-                    />
-                    </TableCell>
-                    <TableCell
-                      align="right"
-                      padding="none"
-                      style={{border:'none', paddingTop:6, paddingBottom:6}}
-                    >
-                    <Chip
-                      style={{
-                        color: scoreContrastColor(row.speedScore),
-                        backgroundColor: scoreBackgroundColor(row.speedScore),
-                      }}
-                      label=
-                        {row.speed == null ? '--' : row.speed.toFixed(0) + ' mph'}
-
-                    />
+                      <Chip
+                        style={{
+                          color: scoreContrastColor(row.longWaitScore),
+                          backgroundColor: scoreBackgroundColor(
+                            row.longWaitScore,
+                          ),
+                        }}
+                        label={
+                          row.longWait == null ? (
+                            '--'
+                          ) : (
+                            <Fragment>
+                              {(row.longWait * 100).toFixed(0)}
+                              {'%'}
+                            </Fragment>
+                          )
+                        }
+                      />
                     </TableCell>
                     <TableCell
                       align="right"
                       padding="none"
-                      style={{border:'none', paddingTop:6, paddingBottom:6}}
-                    >
-                    <Chip
                       style={{
-                        color: scoreContrastColor(row.travelVarianceScore),
-                        backgroundColor: scoreBackgroundColor(row.travelVarianceScore),
+                        border: 'none',
+                        paddingTop: 6,
+                        paddingBottom: 6,
                       }}
-                      label=
-                        {row.variability == null
-                          ? '--'
-                          : <Fragment>
+                    >
+                      <Chip
+                        style={{
+                          color: scoreContrastColor(row.speedScore),
+                          backgroundColor: scoreBackgroundColor(row.speedScore),
+                        }}
+                        label={
+                          row.speed == null
+                            ? '--'
+                            : `${row.speed.toFixed(0)} mph`
+                        }
+                      />
+                    </TableCell>
+                    <TableCell
+                      align="right"
+                      padding="none"
+                      style={{
+                        border: 'none',
+                        paddingTop: 6,
+                        paddingBottom: 6,
+                      }}
+                    >
+                      <Chip
+                        style={{
+                          color: scoreContrastColor(row.travelVarianceScore),
+                          backgroundColor: scoreBackgroundColor(
+                            row.travelVarianceScore,
+                          ),
+                        }}
+                        label={
+                          row.variability == null ? (
+                            '--'
+                          ) : (
+                            <Fragment>
                               {'\u00b1'} {row.variability.toFixed(0)} min
                             </Fragment>
+                          )
                         }
-
-                    />
-
+                      />
                     </TableCell>
                   </TableRow>
                 );
-              })}
-            </TableBody>
-          </Table>
-        </div>
+              },
+            )}
+          </TableBody>
+        </Table>
+      </div>
     </div>
   );
 }

--- a/frontend/src/screens/Dashboard.jsx
+++ b/frontend/src/screens/Dashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import Grid from '@material-ui/core/Grid';
 import Toolbar from '@material-ui/core/Toolbar';
 import AppBar from '@material-ui/core/AppBar';
@@ -14,6 +14,7 @@ import { fetchRoutes, handleGraphParams } from '../actions';
 
 function Dashboard(props) {
   const { routes } = props;
+  const [hoverRoute, setHoverRoute] = useState(null);
   const myFetchRoutes = props.fetchRoutes;
   const myHandleGraphParams = props.handleGraphParams;
 
@@ -40,11 +41,11 @@ function Dashboard(props) {
         {/* Using spacing causes horizontal scrolling, see https://material-ui.com/components/grid/#negative-margin */}
         <Grid item xs={12} sm={6}>
           {/* map and table are both full width for 640px windows or smaller, else half width */}
-          <MapSpider />
+          <MapSpider hoverRoute={hoverRoute} />
         </Grid>
         <Grid item xs={12} sm={6} style={{ padding: 12 }}>
           {/* Doing the spacing between Grid items ourselves.  See previous comment. */}
-          <RouteTable routes={routes} />
+          <RouteTable routes={routes} setHoverRoute={setHoverRoute} />
         </Grid>
       </Grid>
     </div>


### PR DESCRIPTION
Fixes #389 

## Proposed changes

Render route on map when hovering over route table. When no spider exists both directions are rendered. When spider exists only render directions already on the spider. 

Currently on hover, the starting stop (closest stop to spider marker) of the route and stops are fully opaque whilst polylines are slightly less transparent (only when spider exists), and of course everything is slightly larger. I find that when the polylines are too transparent you sometimes see a mess of colors underneath making it harder to see but when it's too solid you can't see the stops. Thoughts?

Also the map shields of other routes currently stay on top of the hovered route (except the shield). Is this preferable?

## Link to demo, if any

https://open-transit-hover-line.herokuapp.com/
