### PR TITLE
Clean unused imports

### DIFF
--- a/backend/compare_versions.py
+++ b/backend/compare_versions.py
@@ -1,8 +1,6 @@
 import argparse
-import json
-import sys
-from datetime import datetime, timedelta
-from models import arrival_history, util, metrics, config
+from datetime import datetime
+from models import arrival_history, util, config
 import pytz
 import pandas as pd
 import numpy as np

--- a/backend/compute_arrivals.py
+++ b/backend/compute_arrivals.py
@@ -1,12 +1,7 @@
 from models import arrival_history, util, trynapi, eclipses, config
-import json
-import math
 import argparse
 from datetime import datetime, date, timedelta
-import pytz
 import time
-import boto3
-import gzip
 
 def compute_arrivals_for_date_and_start_hour(d: date, start_hour: int,
                 agency: config.Agency, route_ids: list,

--- a/backend/compute_new.py
+++ b/backend/compute_new.py
@@ -1,11 +1,10 @@
 import argparse
 import json
 import requests
-from datetime import datetime, timedelta, time
-import pytz
+from datetime import datetime, timedelta
 import boto3
 
-from models import config, util, wait_times
+from models import config, util
 
 from compute_arrivals import compute_arrivals
 from compute_stats import compute_stats

--- a/backend/compute_stats.py
+++ b/backend/compute_stats.py
@@ -1,9 +1,7 @@
-from models import metrics, util, arrival_history, trip_times, constants, config, timetables, precomputed_stats, wait_times
+from models import util, arrival_history, trip_times, constants, config, timetables, precomputed_stats, wait_times
 import argparse
-from datetime import datetime, date
-import pytz
+from datetime import date
 import collections
-import pandas as pd
 import numpy as np
 import time
 

--- a/backend/get_state.py
+++ b/backend/get_state.py
@@ -1,10 +1,5 @@
 from models import trynapi, util, config
-import json
 import argparse
-import re
-import pytz
-import os
-from datetime import datetime
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Download raw state data from tryn-api')

--- a/backend/headways.py
+++ b/backend/headways.py
@@ -1,9 +1,6 @@
 import argparse
-import json
-import sys
-from datetime import datetime, timedelta
+from datetime import datetime
 from models import config, arrival_history, util, metrics, timetables
-import pytz
 import time
 import numpy as np
 import pandas as pd

--- a/backend/metrics-api.py
+++ b/backend/metrics-api.py
@@ -1,9 +1,8 @@
 import os
-from flask import Flask, send_from_directory, request, Response
+from flask import Flask, send_from_directory, Response
 from flask_cors import CORS
 import json
-import sys
-from models import schema, config, wait_times, trip_times, routeconfig, arrival_history, precomputed_stats
+from models import schema, config, routeconfig, arrival_history, precomputed_stats
 from flask_graphql import GraphQLView
 #import cProfile
 

--- a/backend/models/arrival_history.py
+++ b/backend/models/arrival_history.py
@@ -1,11 +1,11 @@
-from datetime import date, datetime, timedelta
+from datetime import date
 import time
 import re
 import os
 import json
 import requests
 import pandas as pd
-from . import eclipses, util, config
+from . import util, config
 import boto3
 from pathlib import Path
 import gzip

--- a/backend/models/eclipses.py
+++ b/backend/models/eclipses.py
@@ -1,6 +1,5 @@
 import time
-from datetime import datetime, date, timedelta, timezone
-import pytz
+from datetime import date
 import pandas as pd
 import numpy as np
 from . import routeconfig, util, config

--- a/backend/models/gtfs.py
+++ b/backend/models/gtfs.py
@@ -1,4 +1,3 @@
-from datetime import date
 import shapely
 import partridge as ptg
 import numpy as np

--- a/backend/models/metrics.py
+++ b/backend/models/metrics.py
@@ -1,9 +1,8 @@
-import math
 import pytz
 import sys
 import time
 from datetime import date
-from . import wait_times, util, arrival_history, trip_times, errors, constants, timetables, routeconfig, config, precomputed_stats
+from . import wait_times, util, arrival_history, trip_times, constants, timetables, routeconfig, config, precomputed_stats
 
 import pandas as pd
 import numpy as np

--- a/backend/models/precomputed_stats.py
+++ b/backend/models/precomputed_stats.py
@@ -1,6 +1,5 @@
 from . import util, config
 from datetime import date
-import sys
 import re
 import requests
 from pathlib import Path

--- a/backend/models/schema.py
+++ b/backend/models/schema.py
@@ -1,7 +1,5 @@
-from . import nextbus, constants, metrics, util, wait_times, trip_times, config
-from graphene import ObjectType, String, Int, Float, List, Field, Boolean, Schema
-from datetime import date
-import sys
+from . import constants, metrics, util, config
+from graphene import ObjectType, String, Int, Float, List, Field, Schema
 import numpy as np
 import math
 

--- a/backend/models/trynapi.py
+++ b/backend/models/trynapi.py
@@ -1,6 +1,4 @@
 import requests
-import urllib
-import hashlib
 import os
 import re
 import json

--- a/backend/models/wait_times.py
+++ b/backend/models/wait_times.py
@@ -1,4 +1,3 @@
-import pandas as pd
 import numpy as np
 import sys
 

--- a/backend/parse_timepoint_csv.py
+++ b/backend/parse_timepoint_csv.py
@@ -1,12 +1,8 @@
-from models import arrival_history, util, trynapi
-import json
-import math
+from models import arrival_history
 import argparse
 from datetime import datetime, timedelta, time as dt_time
 import pytz
-import boto3
 import csv
-import gzip
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Compute and cache arrival history from Muni timepoint CSV')

--- a/backend/route.py
+++ b/backend/route.py
@@ -1,8 +1,5 @@
-from models import metrics, eclipses, config, util, arrival_history, timetables
-import json
+from models import config, util, arrival_history, timetables
 import argparse
-from datetime import datetime, date
-import pytz
 import pandas as pd
 import numpy as np
 

--- a/backend/routes.py
+++ b/backend/routes.py
@@ -1,10 +1,5 @@
-from models import metrics, eclipses, config, util, arrival_history
-import json
+from models import config
 import argparse
-from datetime import datetime, date
-import pytz
-import pandas as pd
-import numpy as np
 
 if __name__ == '__main__':
 

--- a/backend/timetable.py
+++ b/backend/timetable.py
@@ -1,12 +1,10 @@
-import json
 from datetime import datetime, date
 import argparse
 
 import pandas as pd
 import numpy as np
-import partridge as ptg
 
-from models import metrics, timetables, arrival_history, util, constants, errors, config
+from models import metrics, timetables, arrival_history, util, config
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description = "Get the timetable for stops on a given route")

--- a/backend/trips.py
+++ b/backend/trips.py
@@ -1,9 +1,6 @@
 import argparse
-import json
-import sys
-from datetime import datetime, timedelta
-from models import config, arrival_history, util, metrics, trip_times, timetables
-import pytz
+from datetime import datetime
+from models import config, arrival_history, util, trip_times, timetables
 import numpy as np
 import pandas as pd
 

--- a/backend/vehicle.py
+++ b/backend/vehicle.py
@@ -1,10 +1,6 @@
 import argparse
-import json
-import sys
-from datetime import datetime, timedelta
+from datetime import datetime
 from models import config, arrival_history, util
-import pytz
-import numpy
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Show stop history for a particular vehicle')

--- a/backend/waits.py
+++ b/backend/waits.py
@@ -1,13 +1,9 @@
 import argparse
-import json
-import sys
-from datetime import datetime, timedelta, time
-import pytz
+from datetime import datetime
 
 import numpy as np
-import pandas as pd
 
-from models import config, arrival_history, util, metrics, wait_times, timetables
+from models import config, arrival_history, util, wait_times, timetables
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description = 'Compute wait times (in minutes) at a given stop in a given direction on a route, for one or more dates, optionally at particular times of day')


### PR DESCRIPTION
### Background
I've been generating a picture of the logic of the backend code - I've got a handle on orion and tryn-api, and am busy working out how the backend talks to the tryn-api GraphQL endpoint, and in turn how the backend and frontend talk to each other (the end result of this should be a big, pretty SVG diagram that reduces the hurdle to backend dev work)

### Changes
There are 1387 flake8 errors in the backend/ folder, of which 109 are related to imports - some of these errors are just stylistic, and could be overridden with a config file. However, having lots of redundant imports makes it hard to track which bits of the codebase are used where. This PR removes those redundant imports.


### Suggestion for the future
In general, if multiple people are going to be contributing backend code, I'd suggest auto-running yapf or autopep8 on commits, similar to how we run the linter on the frontend code.