### PR TITLE
Precompute median service frequency (headway) for each direction, and add to GraphQL API

### DIFF
--- a/backend/compute_stats.py
+++ b/backend/compute_stats.py
@@ -1,13 +1,16 @@
-from models import util, arrival_history, trip_times, constants, config, timetables, precomputed_stats, wait_times
+from models import util, arrival_history, trip_times, constants, config, timetables, precomputed_stats, wait_times, metrics
 import argparse
 from datetime import date
 import collections
 import numpy as np
 import time
 
+combined_stat_id = precomputed_stats.StatIds.Combined
+median_trip_times_stat_id = precomputed_stats.StatIds.MedianTripTimes
+
 all_stat_ids = [
-    'combined',
-    'median-trip-times',
+    combined_stat_id,
+    median_trip_times_stat_id,
 ]
 
 def filter_departures_by_interval(s1_trip_values, s1_departure_time_values, timestamp_intervals):
@@ -33,7 +36,7 @@ def filter_departures_by_interval(s1_trip_values, s1_departure_time_values, time
 
     return s1_trip_values_by_interval, s1_departure_time_values_by_interval
 
-def add_wait_time_stats_for_route(all_stats, timestamp_intervals, route_config, history_df):
+def add_headway_and_wait_time_stats_for_route(all_stats, timestamp_intervals, route_config, history_df):
     route_id = route_config.id
     history_df = history_df.sort_values('DEPARTURE_TIME', axis=0)
     sid_values = history_df['SID'].values
@@ -44,23 +47,35 @@ def add_wait_time_stats_for_route(all_stats, timestamp_intervals, route_config, 
         dir_id = dir_info.id
         stop_ids = dir_info.get_stop_ids()
 
+        all_median_headways = collections.defaultdict(list)
+        all_median_wait_times = collections.defaultdict(list)
+
         for i, stop_id in enumerate(stop_ids):
             stop_df = history_df[(sid_values == stop_id) & (did_values == dir_id)]
 
             all_time_values = stop_df['DEPARTURE_TIME'].values
 
             for interval_index, (start_time, end_time) in enumerate(timestamp_intervals):
+
+                dir_stats = all_stats[combined_stat_id][interval_index][route_id]['directions'][dir_id]
+
+                headways = metrics.compute_headway_minutes(all_time_values, start_time, end_time)
+
+                if len(headways) > 0:
+                    all_median_headways[interval_index].append(np.median(headways))
+
                 wait_time_stats = wait_times.get_stats(all_time_values, start_time, end_time)
 
                 median_wait_time = wait_time_stats.get_quantile(0.5)
                 if median_wait_time is not None:
-                    dir_stats = all_stats['combined'][interval_index][route_id]['directions'][dir_id]
-                    dir_stats['medianWaitTimes'][stop_id] = round(median_wait_time, 1)
+                    all_median_wait_times[interval_index].append(median_wait_time)
+                    all_stats[median_trip_times_stat_id][interval_index][route_id]['directions'][dir_id]['medianWaitTimes'][stop_id] = round(median_wait_time, 1)
 
         for interval_index, (start_time, end_time) in enumerate(timestamp_intervals):
-            add_median_wait_time_stats_for_direction(
-                all_stats['combined'][interval_index][route_id]['directions'][dir_id]
-            )
+            dir_stats = all_stats[combined_stat_id][interval_index][route_id]['directions'][dir_id]
+
+            dir_stats['medianWaitTime'] = get_median_or_none(all_median_wait_times[interval_index])
+            dir_stats['medianHeadway'] = get_median_or_none(all_median_headways[interval_index])
 
 def add_schedule_adherence_stats_for_route(all_stats, timestamp_intervals, route_config, history_df, timetable_df):
     route_id = route_config.id
@@ -78,6 +93,8 @@ def add_schedule_adherence_stats_for_route(all_stats, timestamp_intervals, route
 
         dir_id = dir_info.id
         stop_ids = dir_info.get_stop_ids()
+
+        all_on_time_rates = collections.defaultdict(list)
 
         for i, stop_id in enumerate(stop_ids):
             stop_history_df = history_df[(history_sid_values == stop_id) & (history_did_values == dir_id)]
@@ -107,28 +124,17 @@ def add_schedule_adherence_stats_for_route(all_stats, timestamp_intervals, route
 
                 if num_scheduled_departures > 0:
                     on_time_rate = round(np.sum(interval_comparison_df['on_time']) / num_scheduled_departures, 3)
-                    dir_stats = all_stats['combined'][interval_index][route_id]['directions'][dir_id]
-                    dir_stats['onTimeRates'][stop_id] = on_time_rate
+                    all_on_time_rates[interval_index].append(on_time_rate)
 
         for interval_index, _ in enumerate(timestamp_intervals):
-            add_median_schedule_adherence_stats_for_direction(
-                all_stats['combined'][interval_index][route_id]['directions'][dir_id]
-            )
+            dir_stats = all_stats[combined_stat_id][interval_index][route_id]['directions'][dir_id]
+            dir_stats['onTimeRate'] = get_median_or_none(all_on_time_rates[interval_index], precision=3)
 
-def add_median_schedule_adherence_stats_for_direction(
-    dir_stats
-):
-    dir_stat_values = np.array([stat_value for _, stat_value in dir_stats['onTimeRates'].items()])
-
-    if len(dir_stat_values) > 0:
-        dir_stats['onTimeRates']["median"] = round(np.median(dir_stat_values), 3)
-
-def add_median_wait_time_stats_for_direction(
-    dir_stats
-):
-    dir_stat_values = np.array([stat_value for _, stat_value in dir_stats['medianWaitTimes'].items()])
-    if len(dir_stat_values) > 0:
-        dir_stats['medianWaitTimes']['median'] = round(np.median(dir_stat_values), 1)
+def get_median_or_none(values, precision=1):
+    if len(values) > 0:
+        return round(np.median(values), precision)
+    else:
+        return None
 
 def add_trip_time_stats_for_route(all_stats, timestamp_intervals, route_config, history_df):
 
@@ -153,8 +159,8 @@ def add_trip_time_stats_for_route(all_stats, timestamp_intervals, route_config, 
         arrival_time_values_by_stop = {}
 
         for interval_index, _ in enumerate(timestamp_intervals):
-            all_stats['combined'][interval_index][route_id]['directions'][dir_id]['tripTimes'] = collections.defaultdict(dict)
-            all_stats['median-trip-times'][interval_index][route_id]['directions'][dir_id]['medianTripTimes'] = collections.defaultdict(dict)
+            all_stats[combined_stat_id][interval_index][route_id]['directions'][dir_id]['tripTimes'] = collections.defaultdict(dict)
+            all_stats[median_trip_times_stat_id][interval_index][route_id]['directions'][dir_id]['medianTripTimes'] = collections.defaultdict(dict)
 
         for stop_id in stop_ids:
             stop_df = history_df[(sid_values == stop_id) & (did_values == dir_id)]
@@ -221,13 +227,13 @@ def add_trip_time_stats_for_route(all_stats, timestamp_intervals, route_config, 
                         median_trip_time = round(util.quantile_sorted(sorted_trip_min, 0.5), 1)
 
                         # save all pairs of stops in median-trip-times stat, used for the isochrone map
-                        all_stats['median-trip-times'][interval_index][route_id]['directions'][dir_id]['medianTripTimes'][s1][s2] = median_trip_time
+                        all_stats[median_trip_times_stat_id][interval_index][route_id]['directions'][dir_id]['medianTripTimes'][s1][s2] = median_trip_time
 
                         # only store median trip times for adjacent stops, or from the first three stops in combined stats
                         # to reduce file size and loading time, since the frontend only needs this for displaying segments
                         # and cumulative time along a route.
                         if (i <= 2) or (j == (i + 1) % num_stops) or s1 == start_stop_id:
-                            all_stats['combined'][interval_index][route_id]['directions'][dir_id]['tripTimes'][s1][s2] = [
+                            all_stats[combined_stat_id][interval_index][route_id]['directions'][dir_id]['tripTimes'][s1][s2] = [
                                 round(util.quantile_sorted(sorted_trip_min, 0.1), 1),
                                 median_trip_time,
                                 round(util.quantile_sorted(sorted_trip_min, 0.9), 1),
@@ -296,7 +302,7 @@ def compute_stats(d: date, agency: config.Agency, routes, save_to_s3=True):
                     all_stats[stat_id][interval_index][route_id]['directions'][dir_id] = collections.defaultdict(dict)
 
         add_trip_time_stats_for_route(all_stats, timestamp_intervals, route_config, history_df)
-        add_wait_time_stats_for_route(all_stats, timestamp_intervals, route_config, history_df)
+        add_headway_and_wait_time_stats_for_route(all_stats, timestamp_intervals, route_config, history_df)
         add_schedule_adherence_stats_for_route(all_stats, timestamp_intervals, route_config, history_df, timetable_df)
 
         t2 = time.time()

--- a/backend/models/metrics.py
+++ b/backend/models/metrics.py
@@ -456,7 +456,7 @@ class AgencyMetrics:
         all_trip_times = []
 
         for d in rng.dates:
-            stats = self.get_precomputed_stats('combined', d, rng.start_time_str, rng.end_time_str)
+            stats = self.get_precomputed_stats(precomputed_stats.StatIds.Combined, d, rng.start_time_str, rng.end_time_str)
             if stats is None:
                 continue
 
@@ -470,7 +470,7 @@ class AgencyMetrics:
         total_trips = None
 
         for d in rng.dates:
-            stats = self.get_precomputed_stats('combined', d, rng.start_time_str, rng.end_time_str)
+            stats = self.get_precomputed_stats(precomputed_stats.StatIds.Combined, d, rng.start_time_str, rng.end_time_str)
             if stats is None:
                 continue
 
@@ -507,7 +507,7 @@ class AgencyMetrics:
 
         for d in rng.dates:
 
-            stats = self.get_precomputed_stats('combined', d, rng.start_time_str, rng.end_time_str)
+            stats = self.get_precomputed_stats(precomputed_stats.StatIds.Combined, d, rng.start_time_str, rng.end_time_str)
             if stats is None:
                 continue
 
@@ -549,7 +549,7 @@ class AgencyMetrics:
             raise Exception(f'invalid distance {dist} between {first_stop_id} and {last_stop_id} in route_id {route_id} direction {direction_id}') # file=sys.stderr)
 
         for d in rng.dates:
-            stats = self.get_precomputed_stats('combined', d, rng.start_time_str, rng.end_time_str)
+            stats = self.get_precomputed_stats(precomputed_stats.StatIds.Combined, d, rng.start_time_str, rng.end_time_str)
             if stats is None:
                 continue
 
@@ -560,33 +560,28 @@ class AgencyMetrics:
 
         return np.median(all_speeds) if len(all_speeds) > 0 else None
 
-    def get_median_wait_time(self, route_id, direction_id, stop_id, rng: Range):
-        all_wait_times = []
+    def _get_direction_stat_value(self, route_id, direction_id, rng: Range, stat_key: str):
+        all_values = []
 
         for d in rng.dates:
-            stats = self.get_precomputed_stats('combined', d, rng.start_time_str, rng.end_time_str)
+            stats = self.get_precomputed_stats(precomputed_stats.StatIds.Combined, d, rng.start_time_str, rng.end_time_str)
             if stats is None:
                 continue
 
-            wait_time = stats.get_median_wait_time(route_id, direction_id, stop_id)
-            if wait_time is not None:
-                all_wait_times.append(wait_time)
+            stat_value = stats.get_direction_stat_value(route_id, direction_id, stat_key)
+            if stat_value is not None:
+                all_values.append(stat_value)
 
-        return np.median(all_wait_times) if len(all_wait_times) > 0 else None
+        return np.median(all_values) if len(all_values) > 0 else None
 
-    def get_on_time_rate(self, route_id, direction_id, stop_id, rng: Range):
-        all_on_time_rates = []
+    def get_median_wait_time(self, route_id, direction_id, rng: Range):
+        return self._get_direction_stat_value(route_id, direction_id, rng, 'medianWaitTime')
 
-        for d in rng.dates:
-            stats = self.get_precomputed_stats('combined', d, rng.start_time_str, rng.end_time_str)
-            if stats is None:
-                continue
+    def get_median_headway(self, route_id, direction_id, rng: Range):
+        return self._get_direction_stat_value(route_id, direction_id, rng, 'medianHeadway')
 
-            on_time_rate = stats.get_on_time_rate(route_id, direction_id, stop_id)
-            if on_time_rate is not None:
-                all_on_time_rates.append(on_time_rate)
-
-        return np.median(all_on_time_rates) if len(all_on_time_rates) > 0 else None
+    def get_on_time_rate(self, route_id, direction_id, rng: Range):
+        return self._get_direction_stat_value(route_id, direction_id, rng, 'onTimeRate')
 
 def compute_headway_minutes(time_values, start_time=None, end_time=None):
     if start_time is not None:

--- a/backend/models/schema.py
+++ b/backend/models/schema.py
@@ -526,6 +526,7 @@ class SegmentIntervalMetrics(ObjectType):
 class DirectionIntervalMetrics(ObjectType):
     directionId = String()
     medianWaitTime = Float() # minutes
+    medianHeadway = Float()
     averageSpeed = Float(
         units = String(required=False),
     )
@@ -546,10 +547,13 @@ class DirectionIntervalMetrics(ObjectType):
         return round_or_none(parent["agency_metrics"].get_average_speed(parent["route_id"], parent["direction_id"], parent["range"], units))
 
     def resolve_medianWaitTime(parent, info):
-        return round_or_none(parent["agency_metrics"].get_median_wait_time(parent["route_id"], parent["direction_id"], "median", parent["range"]))
+        return round_or_none(parent["agency_metrics"].get_median_wait_time(parent["route_id"], parent["direction_id"], parent["range"]))
+
+    def resolve_medianHeadway(parent, info):
+        return round_or_none(parent["agency_metrics"].get_median_headway(parent["route_id"], parent["direction_id"], parent["range"]))
 
     def resolve_onTimeRate(parent, info):
-        return round_or_none(parent["agency_metrics"].get_on_time_rate(parent["route_id"], parent["direction_id"], "median", parent["range"]))
+        return round_or_none(parent["agency_metrics"].get_on_time_rate(parent["route_id"], parent["direction_id"], parent["range"]))
 
     def resolve_numCompletedTrips(parent, info):
         return parent["agency_metrics"].get_num_completed_trips(parent["route_id"], parent["direction_id"], parent["range"])

--- a/frontend/public/isochrone-worker.js
+++ b/frontend/public/isochrone-worker.js
@@ -21,7 +21,6 @@ const FirstStopMinWaitMinutes = 1.0;
 
 let curComputeId = null;
 let tripTimesCache = {};
-let waitTimesCache = {};
 
 // todo: support multiple agencies on one map
 const agencyId = thisUrl.searchParams.get('agency_id');
@@ -124,7 +123,7 @@ function getTimePath(timeStr)
     return timeStr ? ('_' + timeStr.replace(/:/g,'').replace('-','_').replace(/\+/g,'%2B')) : '';
 }
 
-async function getTripTimesFromStop(agencyId, routeId, directionId, startStopId, dateStr, timeStr)
+async function getTripTimes(agencyId, dateStr, timeStr)
 {
     const cacheKey = agencyId + dateStr + timeStr;
     let tripTimes = tripTimesCache[cacheKey];
@@ -144,11 +143,19 @@ async function getTripTimesFromStop(agencyId, routeId, directionId, startStopId,
         });
     }
 
+    return tripTimes;
+}
+
+async function getTripTimesFromStop(agencyId, routeId, directionId, startStopId, dateStr, timeStr)
+{
+    const tripTimes = await getTripTimes(agencyId, dateStr, timeStr);
+
     let routeStats = tripTimes.routes[routeId];
     if (!routeStats)
     {
         return null;
     }
+
     let directionStats = routeStats.directions[directionId];
     if (!directionStats)
     {
@@ -166,26 +173,9 @@ async function getTripTimesFromStop(agencyId, routeId, directionId, startStopId,
 
 async function getWaitTimeAtStop(agencyId, routeId, directionId, stopId, dateStr, timeStr)
 {
-    const cacheKey = dateStr + timeStr;
+    const tripTimes = await getTripTimes(agencyId, dateStr, timeStr);
 
-    let waitTimes = waitTimesCache[cacheKey];
-
-    if (!waitTimes)
-    {
-        var timePath = getTimePath(timeStr);
-
-        let s3Url = 'https://'+S3Bucket+'.s3.amazonaws.com/precomputed-stats/'+PrecomputedStatsVersion+'/'+agencyId+'/'+
-            dateStr.replace(/\-/g, '/')+
-            '/precomputed-stats_'+PrecomputedStatsVersion+'_'+agencyId+'_combined_'+dateStr+timePath+'.json.gz';
-
-        waitTimes = waitTimesCache[cacheKey] = await loadJson(s3Url).catch(function(e) {
-            e.message = 'error loading wait times: ' + e.message;
-            sendError(e);
-            throw e;
-        });
-    }
-
-    let routeStats = waitTimes.routes[routeId];
+    let routeStats = tripTimes.routes[routeId];
     if (!routeStats)
     {
         return null;
@@ -196,6 +186,7 @@ async function getWaitTimeAtStop(agencyId, routeId, directionId, stopId, dateStr
     {
         return null;
     }
+
     let medianWaitTimes = directionStats.medianWaitTimes;
     if (!medianWaitTimes)
     {


### PR DESCRIPTION
This change partially implements #554, adding a medianHeadway field on the DirectionIntervalMetrics GraphQL type to make it possible to show median service frequency for each route on the dashboard and route screen. This PR doesn't update the UI to actually show median service frequency yet.

To avoid increasing the size of the "combined" precomputed stats file, it doesn't store the median headways for each stop, but only the median of the median headways for all stops in each direction.

Similarly, the "combined" precomputed stats file now only stores the median of the median wait time and on-time rate for each stop. This reduces the file size from about 700 kB to about 650 kB. Most of the file size is due to the stats used for the travel time chart, average speed, and travel time variability.

Only the isochrone map needs precomputed median wait time stats for each stop, so these were moved into the median-trip-times file that the isochrone map is already using.