### PR TITLE
fix bugs with loop routes

### DIFF
--- a/backend/models/metrics.py
+++ b/backend/models/metrics.py
@@ -445,6 +445,9 @@ class DirectionIntervalMetrics:
             to_stop_id = stop_ids[next_index]
             segment_metrics_arr.append(SegmentIntervalMetrics(self, from_stop_id, to_stop_id))
 
+        if dir_info.is_loop():
+            segment_metrics_arr.append(SegmentIntervalMetrics(self, stop_ids[len(stop_ids) - 1], stop_ids[0]))
+
         return segment_metrics_arr
 
     def get_cumulative_segment_interval_metrics(self):
@@ -466,6 +469,9 @@ class DirectionIntervalMetrics:
 
             if to_stop_id == end_stop_id:
                 break
+
+        if dir_info.is_loop():
+            segment_metrics_arr.append(SegmentIntervalMetrics(self, from_stop_id, from_stop_id))
 
         return segment_metrics_arr
 

--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -48,7 +48,7 @@ function computeDates(graphParams) {
 
 // S3 URL to route configuration
 export function generateRoutesURL(agencyId) {
-  return `https://${S3Bucket}.s3.amazonaws.com/routes/${RoutesVersion}/routes_${RoutesVersion}_${agencyId}.json.gz?r`;
+  return `https://${S3Bucket}.s3.amazonaws.com/routes/${RoutesVersion}/routes_${RoutesVersion}_${agencyId}.json.gz?u`;
 }
 
 /**
@@ -61,7 +61,7 @@ export function generateArrivalsURL(agencyId, dateStr, routeId) {
   return `https://${S3Bucket}.s3.amazonaws.com/arrivals/${ArrivalsVersion}/${agencyId}/${dateStr.replace(
     /-/g,
     '/',
-  )}/arrivals_${ArrivalsVersion}_${agencyId}_${dateStr}_${routeId}.json.gz?ab`;
+  )}/arrivals_${ArrivalsVersion}_${agencyId}_${dateStr}_${routeId}.json.gz?ai`;
 }
 
 export function fetchTripMetrics(params) {

--- a/frontend/src/components/TravelTimeChart.jsx
+++ b/frontend/src/components/TravelTimeChart.jsx
@@ -72,18 +72,17 @@ export function getTripDataSeries(routeMetrics, route, directionId) {
       }
     });
 
-    if (directionInfo.loop) {
-        const firstStopId = directionInfo.stops[0];
-        const segment = segmentsMap[firstStopId];
-        if (segment && segment.medianTripTime != null) {
-            dataSeries.push({
-              x: metersToMiles(directionInfo.distance),
-              y: segment.medianTripTime,
-              title: route.stops[firstStopId].title,
-              stopIndex: directionInfo.stops.length,
-              numTrips: segment.trips,
-            });
-        }
+    if (directionInfo.loop && firstStopId) {
+      const segment = segmentsMap[firstStopId];
+      if (segment && segment.medianTripTime != null) {
+        dataSeries.push({
+          x: metersToMiles(directionInfo.distance),
+          y: segment.medianTripTime,
+          title: route.stops[firstStopId].title,
+          stopIndex: directionInfo.stops.length,
+          numTrips: segment.trips,
+        });
+      }
     }
   }
 

--- a/frontend/src/components/TravelTimeChart.jsx
+++ b/frontend/src/components/TravelTimeChart.jsx
@@ -71,6 +71,20 @@ export function getTripDataSeries(routeMetrics, route, directionId) {
         });
       }
     });
+
+    if (directionInfo.loop) {
+        const firstStopId = directionInfo.stops[0];
+        const segment = segmentsMap[firstStopId];
+        if (segment && segment.medianTripTime != null) {
+            dataSeries.push({
+              x: metersToMiles(directionInfo.distance),
+              y: segment.medianTripTime,
+              title: route.stops[firstStopId].title,
+              stopIndex: directionInfo.stops.length,
+              numTrips: segment.trips,
+            });
+        }
+    }
   }
 
   return dataSeries;


### PR DESCRIPTION
Fixes several bugs with loop routes.

* SegmentIntervalMetrics were missing between last stop and first stop in GraphQL API
* TravelTimeChart didn't show time to return to first stop
* When computing arrival/departure times for the first or last stop of a loop route, it did not take into account the distance to one of the adjacent (last or first) stops. This caused problems with detecting arrivals at the 11th and Marshall stop on the Portland Streetcar B Loop, which is close to the 10th and Northrup stop.
* When determining arrival times for a loop route that crossed over itself (e.g. figure-eight or lollipop), every stop it passed close to was counted as an arrival, leading to a lot of extra arrivals. This caused issues with the TriMet loop routes 50, 53, and 84. The updated algorithm avoids this by tracking the implied number of loops that were traversed in each sequence, and dropping potential sequences that have extra loops. 