### PR TITLE
Exclude routes in GTFS but not Nextbus when sorting in save_routes

### DIFF
--- a/backend/models/gtfs.py
+++ b/backend/models/gtfs.py
@@ -994,11 +994,27 @@ class GtfsScraper:
 
             routes_data.append(route_data)
 
+        excluded_routes = {}
+        # Skip routes without sort_order if the first route has a sort_order.
+        # For Nextbus agencies, the Nextbus route list is used,
+        # so the routes in GTFS that are not in Nextbus are skipped.
         if routes_data[0]['sort_order'] is not None:
             sort_key = lambda route_data: route_data['sort_order']
+            for route_data in routes_data:
+                if route_data['sort_order'] == None:
+                    excluded_routes[route_data['id']] = True
         else:
             sort_key = lambda route_data: route_data['id']
 
+        for excluded_route in excluded_routes:
+            print(
+                'Excluded Route, in GTFS but not in Nextbus:',
+                excluded_route,
+            )
+        routes_data = [
+            route_data for route_data in routes_data
+            if route_data['id'] not in excluded_routes
+        ]
         routes_data = sorted(routes_data, key=sort_key)
 
         routes = [routeconfig.RouteConfig(agency_id, route_data) for route_data in routes_data]

--- a/backend/models/gtfs.py
+++ b/backend/models/gtfs.py
@@ -8,7 +8,6 @@ import boto3
 import gzip
 import hashlib
 import zipfile
-from collections import OrderedDict
 
 from . import config, util, nextbus, routeconfig, timetables
 
@@ -968,16 +967,14 @@ class GtfsScraper:
 
         return route_data
 
-    def sort_routes(self, routes_df):
+    def sort_routes(self, routes_data):
         agency = self.agency
-        routes_data = []
         if agency.provider == 'nextbus':
             nextbus_route_order = [
                 route.id for route in nextbus.get_route_list(agency.nextbus_id)
             ]
         use_sort_order = False
-        for route in routes_df.itertuples():
-            route_data = self.get_route_data(route)
+        for route_data in routes_data:
             if agency.provider == 'nextbus':
                 try:
                     sort_order = nextbus_route_order.index(route_data['id'])
@@ -987,10 +984,9 @@ class GtfsScraper:
                     sort_order = None
             else:
                 sort_order = int(
-                    route.route_sort_order
-                ) if hasattr(route, 'route_sort_order') else None
+                    route_data['route_sort_order']
+                ) if hasattr(route_data, 'route_sort_order') else None
             route_data['sort_order'] = sort_order
-            routes_data.append(route_data)
         def get_sort_key(route_data):
             if use_sort_order:
                 if route_data['sort_order'] is None:
@@ -1002,36 +998,16 @@ class GtfsScraper:
             return route_data['id']
         return sorted(routes_data, key=get_sort_key)
 
-    def newer_route(self, newest_route_data, route_data):
-        try:
-            return int(
-                route_data['gtfs_route_id']
-            ) > int(newest_route_data['gtfs_route_id'])
-        except ValueError:
-            return route_data['gtfs_route_id'] > newest_route_data['gtfs_route_id']
-
-    def remove_duplicate_routes(self, routes_data):
-        """Remove routes with the same id that appear multiple times.
-        Keeps the route with the highest gtfs_route_id, converting it to
-        a number of possible."""
-        routes_dict = OrderedDict()
-        for route_data in routes_data:
-            if route_data['id'] not in routes_dict or self.newer_route(
-                routes_dict[route_data['id']],
-                route_data,
-            ):
-                routes_dict[route_data['id']] = route_data
-        return [
-            routes_dict[route_id] for route_id in routes_dict
-        ]
-
     def save_routes(self, save_to_s3=True):
         agency = self.agency
         agency_id = agency.id
 
         routes_df = self.get_gtfs_routes()
-        routes_data = self.sort_routes(routes_df)
-        routes_data = self.remove_duplicate_routes(routes_data)
+        routes_data = [
+            self.get_route_data(route)
+            for route in routes_df.itertuples()
+        ]
+        routes_data = self.sort_routes(routes_data)
         
         routes = [routeconfig.RouteConfig(agency_id, route_data) for route_data in routes_data]
 


### PR DESCRIPTION
<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->

Fixes #575 


<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

- If there are routes that don't have sort_order when the first one does, it means that they are in the GTFS but not in Nextbus (at the time of this PR). This could be when a new route is added, and so it appears in the GTFS ahead of time so that it'll be on Google Maps (as that takes a few days to update GTFS) but not on Nextbus until the day it starts service. This PR puts the new routes at the end (sort order of 9999), unless they're a subway line (special case for TTC), in which case they go to the front (sort order of 0).
- Previously the sort_order from Nextbus was used if the first route had it, which was not the case for TTC. This PR uses the sort_order from Nextbus if any route has it, which is determined before sorting.

Expected Result / Testing:
Now when running save_routes.py for Muni it no longer crashes and prints the following:
```
Excluded Route, in GTFS but not in Nextbus: KTBUS
Excluded Route, in GTFS but not in Nextbus: JBUS
Excluded Route, in GTFS but not in Nextbus: NBUS
Excluded Route, in GTFS but not in Nextbus: MBUS
Excluded Route, in GTFS but not in Nextbus: LBUS
```
As well, TTC routes are now sorted properly and subway lines appear at the top.