### PR TITLE
Update codeowners for backend reviewers

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -7,7 +7,7 @@
 /frontend/      @exxonvaldez @akgupta89 @ckrajewski
 
 # Backend
-/backend/ 	    @youngj @wllgrnt
+/backend/ 	    @youngj @wllgrnt @EddyIonescu
 
 # Kubernetes reviewer suggestions
 /kubernetes/    @youngj

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -7,7 +7,7 @@
 /frontend/      @exxonvaldez @akgupta89 @ckrajewski
 
 # Backend
-/backend/ 	 @youngj @jtanquil
+/backend/ 	    @youngj @wllgrnt
 
 # Kubernetes reviewer suggestions
 /kubernetes/    @youngj


### PR DESCRIPTION
## Proposed changes

- Removing Jose from backend who has been MIA for over 8 months
- Adding Will to backend who is skilled at Backend+Python+DS
- Adding Eddy to backend reviewers