### PR TITLE
Store trynapi data by route on disk instead of in-memory

### DIFF
--- a/backend/models/trynapi.py
+++ b/backend/models/trynapi.py
@@ -102,7 +102,7 @@ def get_state(agency_id: str, d: date, start_time, end_time, route_ids) -> Cache
             f.write(json.dumps(states))
 
         state.add(route_id, cache_path)
-    # remove_route_temp_cache(agency_id)
+    remove_route_temp_cache(agency_id)
     return state
 
 
@@ -228,7 +228,10 @@ def read_temp_chunk_state(agency_id, route_id):
         return None
     chunk_state_dict = pd.read_csv(
         path,
-        dtype={'vid': str},
+        dtype={
+            'vid': str,
+            'did': str,
+        },
         float_precision='high', # keep precision for rounding lat/lon
     ).groupby('timestamp').agg(list).to_dict('index')
     chunk_state = {'routeId': route_id, 'states': []}


### PR DESCRIPTION
Resolves Issue #423, as to not longer store all vehicle
states for a chunk in memory, as this can cause out-of-memory
issues for agencies with a lot of vehicles (such as TTC).

## Proposed changes

This approach involves writing the chunks for each route for each date into a CSV file, which allows for appending vehicle rows. It avoids writing many small JSON files, which would take longer to load and assemble, and also uses less space.

Performance-wise the `get_state` function of compute_arrivals now takes about 10x longer for individual routes, excluding time spend on calls to `get_raw_state`. It shouldn't be an issue to deploy as it is, as 10x is, from about 0.5 to about 5 seconds for TTC route 32 (has 25-50 vehicles all day), and about 0.3 to about 2 seconds for tiny routes like TTC routes 30 (1 vehicle all day) and 176 (1 vehicle peak periods); vast majority of the time is still spent getting the data from tryn-api and processing the arrival data. Merging this PR as it is will add somewhere around 2-4 minutes to a daily Muni run.

When removing the conversion of the CSV temp to JSON, the time takes only slightly more than before (0.5 to 0.6 seconds for TTC route 32), so performance would be similar if we switch to CSV caches. This doesn't account for time saved from memory allocations, which take longer when running the old version for all the routes at once.

Space-wise, json.gz takes up slightly less space (about 10% less, samples of two TTC routes) than csv.gz, which was pretty surprising, so it'd increase AWS data-transfer costs.


## Testing

JSON cache files created by running compute_arrivals.py in master and in this branch are identical.