### PR TITLE
Remove routes without any service_ids that cover today's date

### DIFF
--- a/backend/models/gtfs.py
+++ b/backend/models/gtfs.py
@@ -191,8 +191,9 @@ class GtfsScraper:
 
     def get_services_by_date(self, ignore_day_of_week=False):
         """Returns map of a date object to a list of service_ids.
-        Can optionally supply ignore_day_of_week, which specifies that service_ids
-        for any day of week to be included as long as the date is within their range."""
+        Can optionally supply ignore_day_of_week, which includes all service_ids
+        that are active on a date within a date range provided in calendar.txt
+        regardless of the day of the week."""
         calendar_df = self.feed.calendar
         calendar_dates_df = self.feed.calendar_dates
 
@@ -1052,9 +1053,6 @@ class GtfsScraper:
     def save_routes(self, save_to_s3, d):
         agency = self.agency
         agency_id = agency.id
-
-        routes_data = []
-
         routes_df = self.get_gtfs_routes()
         routes_df = self.get_active_routes(routes_df, d)
         routes_data = [

--- a/backend/models/gtfs.py
+++ b/backend/models/gtfs.py
@@ -189,15 +189,18 @@ class GtfsScraper:
 
         return self.stop_times_df
 
-    def get_services_by_date(self):
+    def get_services_by_date(self, ignore_day_of_week=False):
+        """Returns map of a date object to a list of service_ids.
+        Can optionally supply ignore_day_of_week, which specifies that service_ids
+        for any day of week to be included as long as the date is within their range."""
         calendar_df = self.feed.calendar
         calendar_dates_df = self.feed.calendar_dates
 
         dates_map = {}
 
         for calendar_row in calendar_df.itertuples():
-
-            start_date = calendar_row.start_date # partridge library already parses date strings as Python date objects
+            # partridge library already parses date strings as Python date objects
+            start_date = calendar_row.start_date
             end_date = calendar_row.end_date
 
             weekdays = []
@@ -215,6 +218,9 @@ class GtfsScraper:
                 weekdays.append(5)
             if calendar_row.saturday == 1:
                 weekdays.append(6)
+
+            if ignore_day_of_week:
+                weekdays = [0, 1, 2, 3, 4, 5, 6]
 
             service_id = calendar_row.service_id
 
@@ -238,7 +244,10 @@ class GtfsScraper:
                     if service_id in dates_map[d]:
                         dates_map[d].remove(service_id)
                     else:
-                        print(f"error in GTFS feed: service {service_id} removed from {d}, but it was not scheduled on that date")
+                        print((
+                            f"error in GTFS feed: service {service_id} removed "
+                            f"from {d}, but it was not scheduled on that date"
+                        ))
 
         return dates_map
 
@@ -969,6 +978,36 @@ class GtfsScraper:
 
         return route_data
 
+    def get_active_routes(self, routes_df, date):
+        """Returns routes in routes_df whose service_ids all have a
+        start_date that is at or before and an end_date that is at or
+        after the given date."""
+        trips_df = self.get_gtfs_trips()
+        dates_map = self.get_services_by_date(ignore_day_of_week=True)
+        active_services = set(dates_map[date])
+        def has_active_service_id(service_ids):
+            for (_, service_id) in service_ids.iteritems():
+                if service_id in active_services:
+                    return True
+            return False
+        active_routes_df = trips_df.groupby('route_id').agg({
+            'service_id': has_active_service_id,
+        }).merge(
+            routes_df.set_index('route_id'),
+            left_index=True,
+            right_index=True,
+            validate='one_to_one',
+        ).rename(columns={
+            'service_id': 'has_active_service_id',
+        }).reset_index()
+        active_routes_df = active_routes_df[
+            active_routes_df['has_active_service_id']
+        ]
+        active_routes_df = active_routes_df.drop(
+            columns='has_active_service_id'
+        )
+        return active_routes_df
+
     def sort_routes(self, routes_data):
         agency = self.agency
         if agency.provider == 'nextbus':
@@ -999,11 +1038,12 @@ class GtfsScraper:
             return route_data['title']
         return sorted(routes_data, key=get_sort_key)
 
-    def save_routes(self, save_to_s3=True):
+    def save_routes(self, save_to_s3, date):
         agency = self.agency
         agency_id = agency.id
-
+        routes_data = []
         routes_df = self.get_gtfs_routes()
+        routes_df = self.get_active_routes(routes_df, date)
         routes_data = [
             self.get_route_data(route)
             for route in routes_df.itertuples()

--- a/backend/save_routes.py
+++ b/backend/save_routes.py
@@ -1,6 +1,7 @@
 from models import gtfs, config
 from compute_stats import compute_stats_for_dates
 import argparse
+from datetime import date
 
 # Downloads and parses the GTFS specification
 # and saves the configuration for all routes to S3.
@@ -50,10 +51,11 @@ if __name__ == '__main__':
     agencies = [config.get_agency(args.agency)] if args.agency is not None else config.agencies
 
     save_to_s3 = args.s3
+    date = date.today()
 
     for agency in agencies:
         scraper = gtfs.GtfsScraper(agency)
-        scraper.save_routes(save_to_s3)
+        scraper.save_routes(save_to_s3, date)
 
         if args.timetables:
             timetables_updated = scraper.save_timetables(save_to_s3=save_to_s3, skip_existing=True)

--- a/backend/save_routes.py
+++ b/backend/save_routes.py
@@ -51,11 +51,11 @@ if __name__ == '__main__':
     agencies = [config.get_agency(args.agency)] if args.agency is not None else config.agencies
 
     save_to_s3 = args.s3
-    date = date.today()
+    d = date.today()
 
     for agency in agencies:
         scraper = gtfs.GtfsScraper(agency)
-        scraper.save_routes(save_to_s3, date)
+        scraper.save_routes(save_to_s3, d)
 
         if args.timetables:
             timetables_updated = scraper.save_timetables(save_to_s3=save_to_s3, skip_existing=True)


### PR DESCRIPTION
Fixes #581. Fixes #584.

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

Muni's GTFS contains each route twice, once from before February 22, and again starting from February 22, when they modified service on a few routes. This PR modifies save_routes to remove routes that don't have any service_ids that cover the date in which the script is being run, which is set to the current date (when versioned GTFS is added the date will be made an argument).

## Testing

Removes the duplicate routes, keeping the ones valid after February 22. Running Muni is still blocked by #576, which would need to be merged beforehand. 

- For TriMet, after removing the calendar.txt file and setting the date to a Sunday, all routes including the 92 South Beaverton Express (weekday peak-periods only) appear.
- For Muni, setting the date to February 22 (first date of changes) results in only the new routes being shown.
