### PR TITLE
DateTimePopover fixes from #461.

### DIFF
--- a/frontend/src/components/DateTimePopover.jsx
+++ b/frontend/src/components/DateTimePopover.jsx
@@ -71,12 +71,16 @@ function DateTimePopover(props) {
     graphParams[targetRange] || initialGraphParams.firstDateRange,
   );
 
-  // Whenever targetRange changes, we need to resync our local state with Redux
-
-  useEffect(() => {
+  function resetLocalDateRangeParams() {
     setLocalDateRangeParams(
       graphParams[targetRange] || initialGraphParams.firstDateRange,
     );
+  }
+
+  // Whenever targetRange changes, we need to resync our local state with Redux
+
+  useEffect(() => {
+    resetLocalDateRangeParams();
   }, [targetRange, graphParams]);
 
   const classes = useStyles();
@@ -99,9 +103,17 @@ function DateTimePopover(props) {
   }
 
   /**
-   * On close, we apply to local changes to the Redux state.
+   * On close (x), we don't apply changes and revert the local form state.
    */
-  function handleClose() {
+  function handleCancel() {
+    resetLocalDateRangeParams();
+    setAnchorEl(null);
+  }
+
+  /**
+   * Apply to local changes to the Redux state then close the popover.
+   */
+  function handleApply() {
     applyGraphParams();
     setAnchorEl(null);
   }
@@ -252,7 +264,7 @@ function DateTimePopover(props) {
       id={id}
       open={open}
       anchorEl={anchorEl}
-      onClose={handleClose}
+      onClose={handleCancel}
       anchorOrigin={{
         vertical: 'bottom',
         horizontal: 'right',
@@ -266,7 +278,7 @@ function DateTimePopover(props) {
         size="small"
         aria-label="close"
         className={classes.closeButton}
-        onClick={handleClose}
+        onClick={handleCancel}
       >
         <CloseIcon />
       </IconButton>
@@ -457,7 +469,17 @@ function DateTimePopover(props) {
           </FormControl>
         </ListItem>
         <ListItem>
-          <Button onClick={handleReset}>Reset</Button>
+          <Grid
+            container
+            alignItems="flex-start"
+            justify="space-between"
+            direction="row"
+          >
+            <Button onClick={handleReset}>Reset</Button>
+            <Button onClick={handleApply} color="primary" variant="contained">
+              Apply
+            </Button>
+          </Grid>
         </ListItem>
       </List>
     </Popover>

--- a/frontend/src/routesMap.js
+++ b/frontend/src/routesMap.js
@@ -135,6 +135,17 @@ export function fullQueryFromParams(params) {
   const query = {};
   query.firstDateRange = dateQueryFromDateRangeParams(params.firstDateRange);
   query.secondDateRange = dateQueryFromDateRangeParams(params.secondDateRange);
+
+  // Edge case:  second date range matches defaults and thus is empty.  Use a flag
+  // to signify that it is active.
+
+  if (
+    query.secondDateRange &&
+    Object.entries(query.secondDateRange).length === 0
+  ) {
+    // this goes in the query string just to get the second range populated
+    query.secondDateRange.isActive = true;
+  }
   return query;
 }
 


### PR DESCRIPTION


<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->

Fixes #550 

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

-DateTmePopover: Add an "Apply" button that does what "x" used to do, as in Uber Movement.  Make "x" into a cancel button that reverts the local form state.

- routesMap: Fix bug noted in #550 where second date range cannot be the default (yesterday) by adding a flag on the query string that signifies that the second range is active.

## Screenshot

<img width="803" alt="Screen Shot 2020-02-27 at 7 00 50 PM" src="https://user-images.githubusercontent.com/44861283/75506660-8d113080-5993-11ea-842e-9b39b97ef2bd.png">


## Link to demo, if any

https://ot-terence-date-range-compare.herokuapp.com/
