### PR TITLE
Fix missing keys in per column paragraphs and TableCells and use relative paths in manifest.json

### DIFF
--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -3,37 +3,37 @@
   "name": "OpenTransit",
   "icons": [
    {
-    "src": "\/favicons/android-icon-36x36.png",
+    "src": "favicons/android-icon-36x36.png",
     "sizes": "36x36",
     "type": "image\/png",
     "density": "0.75"
    },
    {
-    "src": "\/favicons/android-icon-48x48.png",
+    "src": "favicons/android-icon-48x48.png",
     "sizes": "48x48",
     "type": "image\/png",
     "density": "1.0"
    },
    {
-    "src": "\/favicons/android-icon-72x72.png",
+    "src": "favicons/android-icon-72x72.png",
     "sizes": "72x72",
     "type": "image\/png",
     "density": "1.5"
    },
    {
-    "src": "\/favicons/android-icon-96x96.png",
+    "src": "favicons/android-icon-96x96.png",
     "sizes": "96x96",
     "type": "image\/png",
     "density": "2.0"
    },
    {
-    "src": "\/favicons/android-icon-144x144.png",
+    "src": "favicons/android-icon-144x144.png",
     "sizes": "144x144",
     "type": "image\/png",
     "density": "3.0"
    },
    {
-    "src": "\/favicons/android-icon-192x192.png",
+    "src": "favicons/android-icon-192x192.png",
     "sizes": "192x192",
     "type": "image\/png",
     "density": "4.0"

--- a/frontend/src/components/RouteTable.jsx
+++ b/frontend/src/components/RouteTable.jsx
@@ -211,7 +211,9 @@ const EnhancedTableToolbar = props => {
       >
         <div className={classes.popover}>
           {columns.map(column => {
-            return column.helpContent ? <p>{column.helpContent}</p> : null;
+            return column.helpContent ? (
+              <p key={column.id}>{column.helpContent}</p>
+            ) : null;
           })}
         </div>
       </Popover>
@@ -426,6 +428,7 @@ function RouteTable(props) {
                   {columns.map(column => {
                     return (
                       <TableCell
+                        key={column.id}
                         align={column.numeric ? 'right' : 'left'}
                         padding="none"
                         style={{


### PR DESCRIPTION
<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->
<!--
Fixes #1234. Fixes #2345. Fixes #3456.
-->

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

React wants stable "key" properties for items in a list, otherwise warnings are issued on the browser console.  The refactored RouteTable code was missing keys for the p tags that made up the "help" popover, as well as the TableCells that made up the table header.

Also fix manifest.json to use relative paths to the high res icons (for mobile bookmarks), because the production URL differs from dev ( / vs /frontend/build/).  This was added with the logo update.

## Screenshot

![Screen Shot 2020-02-28 at 12 14 25 AM](https://user-images.githubusercontent.com/44861283/75522636-4d603e00-59bf-11ea-9908-c65745fa16dc.png)

.
.
.

![Screen Shot 2020-02-28 at 12 09 39 AM](https://user-images.githubusercontent.com/44861283/75522342-a085c100-59be-11ea-9395-7c5fac29afba.png)

## Link to demo, if any

n/a
