### PR TITLE
Add custom directions and route heuristics for TriMet

### DIFF
--- a/backend/agencies/trimet.yaml
+++ b/backend/agencies/trimet.yaml
@@ -6,3 +6,142 @@ js_properties:
   title: TriMet
   initialMapCenter: { lat: 45.525, lng: -122.677 }
   initialMapZoom: 12
+  routeHeuristics: {
+    '12': {
+      '1': {
+        ignoreLastStop: true,
+      },
+    },
+    '15': {
+      '1': {
+        ignoreFirstStop: true,
+        ignoreLastStop: true,
+      },
+    },
+    '20': {
+      '0': {
+        ignoreFirstStop: true,
+      },
+    },
+    '20a': { # apparent duplicate of route 20 in GTFS feed
+      ignoreRoute: true,
+    },
+    '22': {
+      '1': {
+        ignoreLastStop: true,
+      },
+    },
+    '23': {
+      '1': {
+        ignoreLastStop: true,
+      },
+    },
+    '25': {
+      '0': {
+        ignoreLastStop: true,
+      },
+    },
+    '30': {
+      '1': {
+        ignoreLastStop: true,
+      },
+    },
+    '31': {
+      '1': {
+        ignoreLastStop: true,
+      },
+    },
+    '33': {
+      '1': {
+        ignoreLastStop: true,
+      },
+    },
+    '34': {
+      '1': {
+        ignoreLastStop: true,
+      },
+    },
+    '38': {
+      '0': {
+        ignoreLastStop: true,
+      },
+    },
+    '52': {
+      '0': {
+        ignoreLastStop: true,
+      },
+      '1': {
+        ignoreFirstStop: '8840',
+      },
+    },
+    '62': {
+      '0': {
+        ignoreLastStop: true,
+      },
+    },
+    '63': {
+      '1': {
+        ignoreLastStop: true,
+      },
+    },
+    '67': {
+      '0': {
+        ignoreLastStop: true,
+      },
+    },
+    '71': {
+      '0': {
+        ignoreLastStop: true,
+      },
+    },
+    '72': {
+      '1': {
+        ignoreLastStop: true,
+      },
+    },
+    '76a': { # apparent duplicate of route 76 in GTFS feed
+      ignoreRoute: true,
+    },
+    '77': {
+      '1': {
+        ignoreLastStop: true,
+      },
+    },
+    '79': {
+      '1': {
+        ignoreLastStop: true,
+      },
+    },
+    '78a': { # apparent duplicate of route 78 in GTFS feed
+      ignoreRoute: true,
+    },
+    '82': {
+      '0': {
+        ignoreFirstStop: true,
+      },
+    },
+    '88': {
+      '1': {
+        ignoreFirstStop: '265',
+      },
+    },
+    '152': {
+      '0': {
+        ignoreLastStop: true,
+      },
+    },
+    '155': {
+      '1': {
+        ignoreLastStop: true,
+      },
+    },
+    '203': { # WES Commuter rail
+      ignoreRoute: true,
+    },
+    '272': { # PDX Night Bus
+      ignoreRoute: true,
+    },
+    '291': { # Orange Night Bus
+      ignoreRoute: true,
+    },
+  }

--- a/backend/agencies/trimet.yaml
+++ b/backend/agencies/trimet.yaml
@@ -2,6 +2,85 @@ id: trimet
 gtfs_url: https://developer.trimet.org/schedule/gtfs.zip
 gtfs_agency_id: TRIMET
 timezone_id: America/Los_Angeles
+custom_directions:
+  '15':
+    - id: "0"
+      title: "To NW Yeon & 44th"
+      gtfs_direction_id: "0"
+      included_stop_ids: ["6470"]
+    - id: "0-T"
+      title: "To NW Thurman & 27th"
+      gtfs_direction_id: "0"
+      included_stop_ids: ["5836"]
+    - id: "1"
+      title: "From NW Yeon & 44th to Gateway Transit Center"
+      gtfs_direction_id: "1"
+      included_stop_ids: ["6470"]
+    - id: "1-T"
+      title: "From NW Thurman & 28th to Gateway Transit Center"
+      gtfs_direction_id: "1"
+      included_stop_ids: ["5837"]
+  '50':
+    - id: "0"
+      title: "Evening Loop"
+      gtfs_direction_id: "0"
+    - id: "1"
+      title: "Morning Loop"
+      gtfs_direction_id: "1"
+  '51':
+    - id: "0-CC"
+      title: "To Council Crest & Tualatin"
+      gtfs_direction_id: "0"
+      included_stop_ids: ["1218"]
+      excluded_stop_ids: ["2467"]
+    - id: "0-HD"
+      title: "To Hamilton & Dosch"
+      gtfs_direction_id: "0"
+      included_stop_ids: ["2467"]
+      excluded_stop_ids: ["1218"]
+    - id: "1-CC"
+      title: "From Council Crest to Portland City Center"
+      gtfs_direction_id: "1"
+      included_stop_ids: ["2467"]
+      excluded_stop_ids: ["1218"]
+    - id: "1-HD"
+      title: "From Hamilton & Dosch to Portland City Center"
+      gtfs_direction_id: "1"
+      included_stop_ids: ["1218"]
+      excluded_stop_ids: ["2467"]
+    - id: "1"
+      title: "From Council Crest to Portland City Center via Hamilton & Dosch"
+      gtfs_direction_id: "1"
+      included_stop_ids: ["1218","2467"]
+  '53':
+    - id: "0"
+      title: "Evening Loop"
+      gtfs_direction_id: "0"
+      included_stop_ids: ["9977"]
+    - id: "1"
+      title: "Morning Loop"
+      gtfs_direction_id: "1"
+      included_stop_ids: ["9977"]
+  '84':
+    - id: "0"
+      title: "Evening Loop"
+      gtfs_direction_id: "0"
+    - id: "1"
+      title: "Morning Loop"
+      gtfs_direction_id: "1"
+invalid_direction_times:
+  - start_time: null
+    end_time: "12:00" # directions that aren't scheduled in the morning
+    directions:
+      - ["50","0"]
+      - ["53","0"]
+      - ["84","0"]
+  - start_time: "12:00" # directions that aren't scheduled in the afternoon
+    end_time: null
+    directions:
+      - ["50","1"]
+      - ["53","1"]
+      - ["84","1"]
 js_properties:
   title: TriMet
   initialMapCenter: { lat: 45.525, lng: -122.677 }

--- a/backend/agencies/trimet.yaml
+++ b/backend/agencies/trimet.yaml
@@ -81,6 +81,9 @@ invalid_direction_times:
       - ["50","1"]
       - ["53","1"]
       - ["84","1"]
+custom_day_start_hours:
+  - start_hour: 0
+    routes: ['272'] # PDX night bus runs from about 1am-4:30am
 js_properties:
   title: TriMet
   initialMapCenter: { lat: 45.525, lng: -122.677 }

--- a/backend/agencies/trimet.yaml
+++ b/backend/agencies/trimet.yaml
@@ -15,11 +15,11 @@ custom_directions:
     - id: "1"
       title: "From NW Yeon & 44th to Gateway Transit Center"
       gtfs_direction_id: "1"
-      included_stop_ids: ["6470"]
+      included_stop_ids: ["6470","749"]
     - id: "1-T"
       title: "From NW Thurman & 28th to Gateway Transit Center"
       gtfs_direction_id: "1"
-      included_stop_ids: ["5837"]
+      included_stop_ids: ["5837","749"]
   '50':
     - id: "0"
       title: "Evening Loop"
@@ -51,7 +51,7 @@ custom_directions:
     - id: "1"
       title: "From Council Crest to Portland City Center via Hamilton & Dosch"
       gtfs_direction_id: "1"
-      included_stop_ids: ["1218","2467"]
+      included_stop_ids: ["1218","2467","7098"]
   '53':
     - id: "0"
       title: "Evening Loop"


### PR DESCRIPTION
Handles loop routes, routes with multiple branches, directions that only occur at certain times of day, hides some routes from the dashboard, and excludes certain stops at the beginning and end of routes to make end-to-end statistics more representative of typical performance.