### PR TITLE
Fix regression and warning from compare date range PR.

### DIFF
--- a/frontend/src/actions/index.js
+++ b/frontend/src/actions/index.js
@@ -395,8 +395,8 @@ export function fetchAgencyMetrics(params) {
     const variablesJson = JSON.stringify({
       agencyId: Agencies[0].id,
       dates,
-      startTime: params.startTime,
-      endTime: params.endTime,
+      startTime: params.firstDateRange.startTime,
+      endTime: params.firstDateRange.endTime,
     });
 
     if (getState().agencyMetrics.variablesJson !== variablesJson) {
@@ -493,7 +493,7 @@ export function handleGraphParams(params) {
     const graphParams = getState().graphParams;
 
     if (
-      oldParams.date !== graphParams.date ||
+      oldParams.firstDateRange.date !== graphParams.firstDateRange.date ||
       oldParams.routeId !== graphParams.routeId ||
       oldParams.agencyId !== graphParams.agencyId
     ) {

--- a/frontend/src/components/DateTimePopover.jsx
+++ b/frontend/src/components/DateTimePopover.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import Moment from 'moment';
 import { makeStyles } from '@material-ui/core/styles';
 import Checkbox from '@material-ui/core/Checkbox';
@@ -71,17 +71,20 @@ function DateTimePopover(props) {
     graphParams[targetRange] || initialGraphParams.firstDateRange,
   );
 
-  function resetLocalDateRangeParams() {
+  // React wants this method to be memoized via useCallback, otherwise
+  // an exhaustive-deps warning is issued for the useEffect call below.
+
+  const resetLocalDateRangeParams = useCallback(() => {
     setLocalDateRangeParams(
       graphParams[targetRange] || initialGraphParams.firstDateRange,
     );
-  }
+  }, [graphParams, targetRange]);
 
   // Whenever targetRange changes, we need to resync our local state with Redux
 
   useEffect(() => {
     resetLocalDateRangeParams();
-  }, [targetRange, graphParams]);
+  }, [targetRange, graphParams, resetLocalDateRangeParams]);
 
   const classes = useStyles();
   const maxDate = Moment(Date.now()).format('YYYY-MM-DD');


### PR DESCRIPTION


<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->
<!--
Fixes #1234. Fixes #2345. Fixes #3456.
-->

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

- index.js: Fixed references to date/time parameter that should have been updated in the compare date range PR.  This fixes time of day options that were not being sent in the route metrics query.
- DateTimePopover: Fix react-hooks/exhaustive-deps compiler warning, which was

```
metrics-react-dev | ./src/components/DateTimePopover.jsx
metrics-react-dev |   Line 84:  React Hook useEffect has a missing dependency: 'resetLocalDateRangeParams'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
```
which when fixed results in

```
metrics-react-dev | ./src/components/DateTimePopover.jsx
metrics-react-dev |   Line 74:  The 'resetLocalDateRangeParams' function makes the dependencies of useEffect Hook (at line 89) change on every render. To fix this, wrap the 'resetLocalDateRangeParams' definition into its own useCallback() Hook  react-hooks/exhaustive-deps
```
which is now fixed in this PR.

## Screenshot

n/a

## Link to demo, if any

n/a
