### PR TITLE
Improve SEO by rendering route name as H1

### DIFF
--- a/frontend/src/screens/RouteScreen.jsx
+++ b/frontend/src/screens/RouteScreen.jsx
@@ -91,10 +91,17 @@ function RouteScreen(props) {
         const updatedPayload = Object.assign({ ...link.payload }, payload);
         link = Object.assign({ ...link }, { payload: updatedPayload });
         const { label, specialLabel } = labels(param, path.title);
+
+        // For SEO purposes, make the very first breadcrumb (which is the
+        // route name) render as an H1, but be styled like everything else
+        // (as a regular, small subtitle).
+        // if it's not the first one, render as default HTML tag.
+        const renderAsTag = index === 0 ? 'h1' : null;
+
         return hasNextValue ? (
           <Typography
             variant="subtitle1"
-            component="h1"
+            component={renderAsTag}
             key={label}
             className={`${breadCrumbStyling} ${darkLinks}`}
           >
@@ -108,7 +115,7 @@ function RouteScreen(props) {
         ) : (
           <Typography
             variant="subtitle1"
-            component="h1"
+            component={renderAsTag}
             key={label}
             className={breadCrumbStyling}
           >

--- a/frontend/src/screens/RouteScreen.jsx
+++ b/frontend/src/screens/RouteScreen.jsx
@@ -94,6 +94,7 @@ function RouteScreen(props) {
         return hasNextValue ? (
           <Typography
             variant="subtitle1"
+            component="h1"
             key={label}
             className={`${breadCrumbStyling} ${darkLinks}`}
           >
@@ -107,6 +108,7 @@ function RouteScreen(props) {
         ) : (
           <Typography
             variant="subtitle1"
+            component="h1"
             key={label}
             className={breadCrumbStyling}
           >

--- a/frontend/src/screens/RouteScreen.jsx
+++ b/frontend/src/screens/RouteScreen.jsx
@@ -96,12 +96,12 @@ function RouteScreen(props) {
         // route name) render as an H1, but be styled like everything else
         // (as a regular, small subtitle).
         // if it's not the first one, render as default HTML tag.
-        const renderAsTag = index === 0 ? 'h1' : null;
+        const renderAsH1 = index === 0 ? 'h1' : null;
 
         return hasNextValue ? (
           <Typography
             variant="subtitle1"
-            component={renderAsTag}
+            component={renderAsH1}
             key={label}
             className={`${breadCrumbStyling} ${darkLinks}`}
           >
@@ -115,7 +115,7 @@ function RouteScreen(props) {
         ) : (
           <Typography
             variant="subtitle1"
-            component={renderAsTag}
+            component={renderAsH1}
             key={label}
             className={breadCrumbStyling}
           >


### PR DESCRIPTION
Fixes #391 .

## Proposed changes

For SEO reasons, it helps to make the most important heading in your page an H1. For us, that would be the route name (e.g. "38-Geary") on a route page. 

This PR makes the route name render as an H1, but actually keep the same styling as all the other breadcrumbs.

## Screenshot

Observe how the route name is an H1 but everything else is rendered as the default tag, H6; all the breadcrumb tags have the same styling regardless.

H6:
<img width="1552" alt="Screen Shot 2020-03-04 at 8 45 29 PM" src="https://user-images.githubusercontent.com/728084/75948883-7e29f280-5e59-11ea-9595-e7cefbff855a.png">

H1:
<img width="1552" alt="Screen Shot 2020-03-04 at 8 45 19 PM" src="https://user-images.githubusercontent.com/728084/75948894-83873d00-5e59-11ea-8800-c5a357216a1d.png">