### PR TITLE
Date range comparisons UI in the style of Google Analytics

### DIFF
--- a/frontend/src/UIConstants.js
+++ b/frontend/src/UIConstants.js
@@ -92,3 +92,6 @@ export const WEEKENDS = [
 
 // Marey chart:  how long of a dwell at a stop results in a second data point for exit.
 export const DWELL_THRESHOLD_SECS = 120;
+
+// Representation of a metric with no value (e.g., missing score).
+export const NO_VALUE = '--';

--- a/frontend/src/components/DateTimeLabel.jsx
+++ b/frontend/src/components/DateTimeLabel.jsx
@@ -1,0 +1,48 @@
+import React, { Fragment } from 'react';
+import { makeStyles } from '@material-ui/core/styles';
+import Typography from '@material-ui/core/Typography';
+import CircleIcon from '@material-ui/icons/FiberManualRecord';
+import { generateDateLabels } from '../helpers/dateTime';
+
+const useStyles = makeStyles(theme => ({
+  heading: {
+    fontSize: theme.typography.pxToRem(15),
+  },
+  secondaryHeading: {
+    fontSize: theme.typography.pxToRem(12),
+    color: theme.palette.text.secondary,
+    textAlign: 'left',
+  },
+}));
+
+/**
+ * Displays the current date and time selections as styled text.
+ *
+ * @param {any} props
+ */
+export default function DateTimeLabel(props) {
+  const { dateRangeParams, colorCode, style } = props;
+
+  const classes = useStyles();
+
+  const { dateLabel, smallLabel } = generateDateLabels(dateRangeParams);
+
+  return (
+    <Fragment>
+      <span style={style}>
+        <Typography className={classes.heading} display="inline">
+          {dateLabel}&nbsp;
+        </Typography>
+        <Typography className={classes.secondaryHeading} display="inline">
+          {smallLabel}
+        </Typography>
+      </span>
+      {colorCode ? (
+        <CircleIcon
+          style={{ fill: colorCode, verticalAlign: 'sub' }}
+          fontSize="small"
+        />
+      ) : null}
+    </Fragment>
+  );
+}

--- a/frontend/src/components/DateTimePanel.jsx
+++ b/frontend/src/components/DateTimePanel.jsx
@@ -1,5 +1,4 @@
 import React, { useState, Fragment } from 'react';
-import Moment from 'moment';
 import { makeStyles } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import CircularProgress from '@material-ui/core/CircularProgress';
@@ -12,12 +11,11 @@ import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import RemoveCircleOutlineIcon from '@material-ui/icons/RemoveCircleOutline';
 import InfoIcon from '@material-ui/icons/InfoOutlined';
+import DateTimeLabel from './DateTimeLabel';
 import DateTimePopover from './DateTimePopover';
-import { TIME_RANGES, TIME_RANGE_ALL_DAY } from '../UIConstants';
 import { typeForPage } from '../reducers/page';
 import { fullQueryFromParams } from '../routesMap';
 import { isLoadingRequest } from '../reducers/loadingReducer';
-import { getDaysOfTheWeekLabel } from '../helpers/dateTime';
 
 const useStyles = makeStyles(theme => ({
   button: {
@@ -96,13 +94,6 @@ function DateTimePanel(props) {
     });
   }
 
-  /**
-   * convert yyyy/mm/dd to mm/dd/yyyy
-   */
-  function convertDate(ymdString) {
-    return Moment(ymdString).format('MM/DD/YYYY');
-  }
-
   const firstOpen = Boolean(anchorEl) && anchorEl.id === 'firstDateRange';
   const secondOpen = Boolean(anchorEl) && anchorEl.id === 'secondDateRange';
 
@@ -176,27 +167,6 @@ function DateTimePanel(props) {
 
     const dateRangeParams = graphParams[target];
 
-    // these are the read-only representations of the date and time range
-    let dateLabel = convertDate(dateRangeParams.date);
-    let smallLabel = '';
-
-    if (dateRangeParams.startDate !== dateRangeParams.date) {
-      dateLabel = `${convertDate(dateRangeParams.startDate)} - ${dateLabel}`;
-
-      // generate a days of the week label
-
-      smallLabel = `${getDaysOfTheWeekLabel(dateRangeParams.daysOfTheWeek)}, `;
-    }
-
-    // convert the state's current time range to a string or the sentinel value
-    const timeRange =
-      dateRangeParams.startTime && dateRangeParams.endTime
-        ? `${dateRangeParams.startTime}-${dateRangeParams.endTime}`
-        : TIME_RANGE_ALL_DAY;
-
-    smallLabel += TIME_RANGES.find(range => range.value === timeRange)
-      .shortLabel;
-
     return (
       <Fragment>
         <Button
@@ -206,14 +176,7 @@ function DateTimePanel(props) {
           id={target}
         >
           <div className={classes.dateTime}>
-            <span>
-              <Typography className={classes.heading} display="inline">
-                {dateLabel}&nbsp;
-              </Typography>
-              <Typography className={classes.secondaryHeading} display="inline">
-                {smallLabel}
-              </Typography>
-            </span>
+            <DateTimeLabel dateRangeParams={dateRangeParams} />
             {(target === 'firstDateRange' && firstOpen) ||
             (target === 'secondDateRange' && secondOpen) ? (
               <ExpandLessIcon />

--- a/frontend/src/components/DateTimePopover.jsx
+++ b/frontend/src/components/DateTimePopover.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import Moment from 'moment';
 import { makeStyles } from '@material-ui/core/styles';
 import Checkbox from '@material-ui/core/Checkbox';
@@ -71,17 +71,20 @@ function DateTimePopover(props) {
     graphParams[targetRange] || initialGraphParams.firstDateRange,
   );
 
-  function resetLocalDateRangeParams() {
+  // React wants this method to be memoized via useCallback, otherwise
+  // an exhaustive-deps warning is issued for the useEffect call below.
+
+  const resetLocalDateRangeParams = useCallback(() => {
     setLocalDateRangeParams(
       graphParams[targetRange] || initialGraphParams.firstDateRange,
     );
-  }
+  }, [graphParams, targetRange]);
 
   // Whenever targetRange changes, we need to resync our local state with Redux
 
   useEffect(() => {
     resetLocalDateRangeParams();
-  }, [targetRange, graphParams]);
+  }, [targetRange, graphParams, resetLocalDateRangeParams]);
 
   const classes = useStyles();
   const maxDate = Moment(Date.now()).format('YYYY-MM-DD');

--- a/frontend/src/components/Info.jsx
+++ b/frontend/src/components/Info.jsx
@@ -43,14 +43,6 @@ function Info(props) {
     tripMetrics && tripMetrics.interval2
       ? tripMetrics.interval2.tripTimes
       : null;
-  /*
-   * By day data is not requested for the second date range.
-   *
-   * The second range can have the same data the first, as they are using the same GraphQL query API.
-   * It gets tricky for the "by day" tab, because how do you chart two date ranges by day when they
-   * could have different numbers of days in them?  Does this chart only work when the ranges have
-   * the same number of days?  Do we "scale" the time axis so both are the full width of the chart?
-   */
 
   const headwayData =
     headways && headways.histogram
@@ -134,6 +126,10 @@ function Info(props) {
 
   function handleTabChange(event, newValue) {
     setTabValue(newValue);
+    // This is a workaround to trigger the react-vis resize listeners,
+    // because the hidden flexible width charts are all width zero, and
+    // stay width zero when unhidden.
+    window.dispatchEvent(new Event('resize'));
   }
 
   function a11yProps(index) {

--- a/frontend/src/components/Info.jsx
+++ b/frontend/src/components/Info.jsx
@@ -10,7 +10,6 @@ import {
   Crosshair,
 } from 'react-vis';
 import { AppBar, Box, Tab, Tabs, Typography } from '@material-ui/core';
-import InfoByDay from './InfoByDay';
 import InfoIntervalsOfDay from './InfoIntervalsOfDay';
 import InfoTripSummary from './InfoTripSummary';
 import { CHART_COLORS, REACT_VIS_CROSSHAIR_NO_LINE } from '../UIConstants';
@@ -30,7 +29,7 @@ function Info(props) {
   const headways = tripMetrics ? tripMetrics.interval.headways : null;
   const waitTimes = tripMetrics ? tripMetrics.interval.waitTimes : null;
   const tripTimes = tripMetrics ? tripMetrics.interval.tripTimes : null;
-  const byDayData = tripMetrics ? tripMetrics.byDay : null;
+  // const byDayData = tripMetrics ? tripMetrics.byDay : null;
 
   const headways2 =
     tripMetrics && tripMetrics.interval2
@@ -145,11 +144,11 @@ function Info(props) {
   }
 
   const SUMMARY = 0;
-  const BY_DAY = 1;
-  const TIME_OF_DAY = 2;
-  const HEADWAYS = 3;
-  const WAITS = 4;
-  const TRIPS = 5;
+  // const BY_DAY = 1;
+  const TIME_OF_DAY = 1;
+  const HEADWAYS = 2;
+  const WAITS = 3;
+  const TRIPS = 4;
 
   return (
     <div>
@@ -167,7 +166,7 @@ function Info(props) {
             label="Summary"
             {...a11yProps(SUMMARY)}
           />
-          <Tab style={{ minWidth: 72 }} label="By Day" {...a11yProps(BY_DAY)} />
+          {/*       <Tab style={{ minWidth: 72 }} label="By Day" {...a11yProps(BY_DAY)} /> */}
           <Tab
             style={{ minWidth: 72 }}
             label="By Time of Day"
@@ -201,6 +200,7 @@ function Info(props) {
             />
           </Box>
 
+          {/*
           <Box p={2} hidden={tabValue !== BY_DAY}>
             <Typography variant="h5" display="inline">
               Performance by Day
@@ -208,12 +208,12 @@ function Info(props) {
 
             <InfoByDay
               byDayData={
-                byDayData /* consider switching to trip metrics here for consistency */
+                byDayData
               }
               graphParams={graphParams}
               routes={routes}
             />
-          </Box>
+          </Box> */}
 
           <Box p={2} hidden={tabValue !== TIME_OF_DAY}>
             <Typography variant="h5" display="inline">

--- a/frontend/src/components/InfoByDay.jsx
+++ b/frontend/src/components/InfoByDay.jsx
@@ -1,20 +1,27 @@
 import React, { useState } from 'react';
-import { FormControl, FormControlLabel, Radio } from '@material-ui/core';
+import {
+  Box,
+  FormControl,
+  FormControlLabel,
+  Radio,
+  Tab,
+  Tabs,
+  useTheme,
+} from '@material-ui/core';
+
 import {
   XYPlot,
   HorizontalGridLines,
   XAxis,
   YAxis,
-  LineSeries,
   LineMarkSeries,
-  VerticalBarSeries,
+  AreaSeries,
   ChartLabel,
   Crosshair,
 } from 'react-vis';
-import DiscreteColorLegend from 'react-vis/dist/legends/discrete-color-legend';
+// import DiscreteColorLegend from 'react-vis/dist/legends/discrete-color-legend';
 import Moment from 'moment';
 import {
-  CHART_COLORS,
   PLANNING_PERCENTILE,
   REACT_VIS_CROSSHAIR_NO_LINE,
 } from '../UIConstants';
@@ -32,11 +39,16 @@ function InfoByDay(props) {
   const ON_TIME_RATE = 'on_time_rate';
   const SPEED = 'speed';
   const TRAVEL_VARIABILITY = 'travel_variability';
+  const CHART_HEIGHT = 200;
+
+  const [tabValue, setTabValue] = React.useState(0);
 
   const [selectedOption, setSelectedOption] = useState(AVERAGE_TIME); // radio button starts on average time
   const [crosshairValues, setCrosshairValues] = useState([]); // tooltip starts out empty
 
-  const { byDayData, routes, graphParams } = props;
+  const { byDayData, byDayData2, routes, graphParams } = props;
+
+  const theme = useTheme();
 
   /**
    * Event handler for radio buttons
@@ -75,7 +87,7 @@ function InfoByDay(props) {
 
   /**
    * Returns a mapping function for creating a react-vis XYPlot data series out of interval data.
-   * Example of interval data is shown at end of this file.
+   *
    * Mapping function is for either wait time or trip time, and for either average or planning percentile time.
    *
    * It's possible that an interval will have null wait/travel times due to lack of data (no vehicles
@@ -83,20 +95,27 @@ function InfoByDay(props) {
    *
    * @param {intervalField} One of wait_times or travel_times.
    */
-  const mapDays = (field, attribute) => {
+  const mapDays = (field, attribute, fieldToAdd) => {
     let distance;
     if (attribute === SPEED) {
       distance = routes ? computeDistance(graphParams, routes) : null;
     }
 
-    return day => {
+    return (day, index) => {
       let y = 0;
+      let y0 = 0;
 
       if (day[field] != null) {
         if (attribute === AVERAGE_TIME) {
-          y = day[field].median;
+          const stackedValue = fieldToAdd ? day[fieldToAdd].median : 0;
+          y = day[field].median + stackedValue;
+          y0 = stackedValue;
         } else if (attribute === PLANNING_TIME) {
-          y = getPercentileValue(day[field], 90);
+          const stackedValue = fieldToAdd
+            ? getPercentileValue(day[fieldToAdd], 90)
+            : 0;
+          y = getPercentileValue(day[field], 90) + stackedValue;
+          y0 = stackedValue;
         } else if (attribute === ON_TIME_RATE) {
           const scheduleAdherence = day[field];
           y =
@@ -118,27 +137,50 @@ function InfoByDay(props) {
         y = 0;
       }
 
+      const x = index;
+      const xAsDate = Moment(day.dates[0]).format('dd MM/DD');
+
       return {
-        x: Moment(day.dates[0]).format('dd MM/DD'),
+        x,
         y,
+        y0,
+        xAsDate,
       };
     };
   };
+
+  /* 
+  const meanOfDataSeries = (series) => series &&
+    series.length > 0 &&
+    series.reduce((accum, value) => accum + value.y, 0) / series.length;
+    */
+
+  const maxOfDataSeries = series =>
+    series &&
+    series.length > 0 &&
+    series.reduce((max, value) => (max > value.y ? max : value.y), 0);
+
+  // 1st chart: journey times
 
   const waitData =
     byDayData && byDayData.map(mapDays('waitTimes', selectedOption));
 
   const tripData =
-    byDayData && byDayData.map(mapDays('tripTimes', selectedOption));
+    byDayData &&
+    byDayData.map(mapDays('tripTimes', selectedOption, 'waitTimes'));
 
-  const meanWait =
-    waitData &&
-    waitData.length > 0 &&
-    waitData.reduce((accum, value) => accum + value.y, 0) / waitData.length;
-  const meanTrip =
-    tripData &&
-    tripData.length > 0 &&
-    tripData.reduce((accum, value) => accum + value.y, 0) / tripData.length;
+  const waitData2 =
+    byDayData2 && byDayData2.map(mapDays('waitTimes', selectedOption));
+
+  const tripData2 =
+    byDayData2 &&
+    byDayData2.map(mapDays('tripTimes', selectedOption, 'waitTimes'));
+
+  /*
+
+  const meanWait = meanOfDataSeries(waitData);
+  const meanTrip = meanOfDataSeries(tripData);
+
   const meanWaitData = waitData && [
     { x: waitData[0].x, y: meanWait },
     { x: waitData[waitData.length - 1].x, y: meanWait },
@@ -147,46 +189,51 @@ function InfoByDay(props) {
     { x: tripData[0].x, y: meanWait + meanTrip },
     { x: tripData[tripData.length - 1].x, y: meanWait + meanTrip },
   ];
+  */
 
-  const maxWait =
-    waitData &&
-    waitData.length > 0 &&
-    waitData.reduce((max, value) => (max > value.y ? max : value.y), 0);
-  const maxTrip =
-    tripData &&
-    tripData.length > 0 &&
-    tripData.reduce((max, value) => (max > value.y ? max : value.y), 0);
+  const maxWait = Math.max(
+    maxOfDataSeries(waitData),
+    maxOfDataSeries(waitData2),
+  );
+  const maxTrip = Math.max(
+    maxOfDataSeries(tripData),
+    maxOfDataSeries(tripData2),
+  );
 
+  /*
   const legendItems = [
-    { title: 'Travel time', color: CHART_COLORS[1], strokeWidth: 10 },
-    { title: 'Wait time', color: CHART_COLORS[0], strokeWidth: 10 },
+    { title: 'Travel time', color: theme.palette.primary.main, strokeWidth: 10 },
+    { title: 'Wait time', color: theme.palette.primary.dark, strokeWidth: 10 },
   ];
-
+*/
   // 2nd chart: on time %
 
   const onTimeRateData =
     byDayData &&
     byDayData.map(mapDays('departureScheduleAdherence', ON_TIME_RATE));
+  const onTimeRateData2 =
+    byDayData2 &&
+    byDayData2.map(mapDays('departureScheduleAdherence', ON_TIME_RATE));
 
   // 3rd chart: speed
 
   const speedData = byDayData && byDayData.map(mapDays('tripTimes', SPEED));
-  const maxSpeed =
-    speedData &&
-    speedData.length > 0 &&
-    speedData.reduce((max, value) => (max > value.y ? max : value.y), 0);
+  const speedData2 = byDayData2 && byDayData2.map(mapDays('tripTimes', SPEED));
+  const maxSpeed = Math.max(
+    maxOfDataSeries(speedData),
+    maxOfDataSeries(speedData2),
+  );
 
   // 4th chart: travel variability
 
   const travelVariabilityData =
     byDayData && byDayData.map(mapDays('tripTimes', TRAVEL_VARIABILITY));
-  const maxTravelVariability =
-    travelVariabilityData &&
-    travelVariabilityData.length > 0 &&
-    travelVariabilityData.reduce(
-      (max, value) => (max > value.y ? max : value.y),
-      0,
-    );
+  const travelVariabilityData2 =
+    byDayData2 && byDayData2.map(mapDays('tripTimes', TRAVEL_VARIABILITY));
+  const maxTravelVariability = Math.max(
+    maxOfDataSeries(travelVariabilityData),
+    maxOfDataSeries(travelVariabilityData2),
+  );
 
   // 5th chart: score
 
@@ -200,34 +247,39 @@ function InfoByDay(props) {
         travelVariabilityData[index].y,
       );
       return {
-        x: Moment(day.dates[0]).format('dd MM/DD'),
+        x: index,
+        xAsDate: Moment(day.dates[0]).format('dd MM/DD'),
         y: grades.totalScore,
       };
     });
-  const maxScore =
-    scoreData &&
-    scoreData.length > 0 &&
-    scoreData.reduce((max, value) => (max > value.y ? max : value.y), 0);
+  const scoreData2 =
+    byDayData2 &&
+    byDayData2.map((day, index) => {
+      const grades = computeScores(
+        waitData2[index].y,
+        onTimeRateData2[index].y / 100,
+        speedData2[index].y,
+        travelVariabilityData2[index].y,
+      );
+      return {
+        x: index,
+        xAsDate: Moment(day.dates[0]).format('dd MM/DD'),
+        y: grades.totalScore,
+      };
+    });
+  const maxScore = Math.max(
+    maxOfDataSeries(scoreData),
+    maxOfDataSeries(scoreData2),
+  );
 
   // Non-default chart margins for rotated x-axis tick marks.
   // Default is {left: 40, right: 10, top: 10, bottom: 40}
 
   const chartMargins = { left: 40, right: 10, top: 10, bottom: 60 };
 
-  // Currently not showing by day data for date range comparisons.
-
-  if (graphParams.secondDateRange) {
-    return (
-      <div>
-        <p />
-        Performance by day is not available when comparing date ranges. Remove
-        the second date range to see performance by day.
-      </div>
-    );
-  }
-
   // Show a prompt to choose a date range if a date range is not selected.
 
+  /*
   if (
     graphParams.firstDateRange.date === graphParams.firstDateRange.startDate
   ) {
@@ -237,7 +289,7 @@ function InfoByDay(props) {
         To see performance by day, select a start date and end date.
       </div>
     );
-  }
+  } */
 
   /**
    * Event handler for onNearestX.
@@ -246,7 +298,11 @@ function InfoByDay(props) {
    * @private
    */
   const onNearestX = (_value, { index }) => {
-    setCrosshairValues([waitData[index], tripData[index]]);
+    setCrosshairValues([
+      waitData[index] ? waitData[index] : 0,
+      tripData[index] ? tripData[index] : 0,
+    ]);
+    // TODO: add secondary data
   };
 
   const onNearestXGeneric = (/* _value, { index } */) => {
@@ -254,262 +310,361 @@ function InfoByDay(props) {
     // this currently makes it appear on all charts: setCrosshairValues([_value]);
   };
 
+  /**
+   * For the x-axis, render indexes as relative to the primary data series' dates.  If the index
+   * is above the primary data series, show as blank for now.
+   */
+  const primaryDateFormatter = value => {
+    if (value < waitData.length) {
+      return waitData[value].xAsDate;
+    }
+    return '';
+  };
+
+  function handleTabChange(event, newValue) {
+    setTabValue(newValue);
+  }
+
+  function a11yProps(index) {
+    return {
+      id: `simple-tab-${index}`,
+      'aria-controls': `simple-tabpanel-${index}`,
+    };
+  }
+
+  const JOURNEY_TIMES = 0;
+  const SCORE = 1;
+  const ON_TIME = 2;
+  const MEDIAN_SPEED = 3;
+  const TRIP_VARIABILITY = 4;
+
   return (
     <div>
       {byDayData ? (
         <div>
-          <FormControl>
-            <div className="controls">
-              <FormControlLabel
-                control={
-                  <Radio
-                    id="average_time"
-                    type="radio"
-                    value={AVERAGE_TIME}
-                    checked={selectedOption === AVERAGE_TIME}
-                    onChange={handleOptionChange}
-                  />
-                }
-                label="Median"
-              />
-
-              <FormControlLabel
-                control={
-                  <Radio
-                    id="planning_time"
-                    type="radio"
-                    value={PLANNING_TIME}
-                    checked={selectedOption === PLANNING_TIME}
-                    onChange={handleOptionChange}
-                  />
-                }
-                label={`Planning (${PLANNING_PERCENTILE}th percentile)`}
-              />
-            </div>
-          </FormControl>
-          <XYPlot
-            xType="ordinal"
-            height={300}
-            width={400}
-            margin={chartMargins}
-            stackBy="y"
-            yDomain={[0, maxWait + maxTrip]}
-            onMouseLeave={onMouseLeave}
+          <Tabs
+            value={tabValue}
+            onChange={handleTabChange}
+            aria-label="tab bar"
+            variant="scrollable"
+            scrollButtons="on"
           >
-            <HorizontalGridLines />
-            <XAxis tickLabelAngle={-90} />
-            <YAxis hideLine />
+            <Tab
+              style={{ minWidth: 72 }}
+              label="Journey Times"
+              {...a11yProps(JOURNEY_TIMES)}
+            />
+            <Tab style={{ minWidth: 72 }} label="Score" {...a11yProps(SCORE)} />
+            <Tab
+              style={{ minWidth: 72 }}
+              label="On-Time %"
+              {...a11yProps(ON_TIME)}
+            />
+            <Tab
+              style={{ minWidth: 72 }}
+              label="Median Speed"
+              {...a11yProps(MEDIAN_SPEED)}
+            />
+            <Tab
+              style={{ minWidth: 72 }}
+              label="Trip Variability"
+              {...a11yProps(TRIP_VARIABILITY)}
+            />
+          </Tabs>
 
-            <VerticalBarSeries
-              data={waitData}
-              color={CHART_COLORS[0]}
-              onNearestX={onNearestX}
-              stack
-            />
-            <VerticalBarSeries data={tripData} color={CHART_COLORS[1]} stack />
-            <LineSeries
-              data={meanWaitData}
-              color={CHART_COLORS[2]}
-              strokeDasharray="5, 5"
-            />
-            <LineSeries
-              data={meanTripData}
-              color={CHART_COLORS[3]}
-              strokeDasharray="5, 5"
-            />
+          <Box p={2} hidden={tabValue !== JOURNEY_TIMES}>
+            <FormControl>
+              <div className="controls">
+                <FormControlLabel
+                  control={
+                    <Radio
+                      id="average_time"
+                      type="radio"
+                      value={AVERAGE_TIME}
+                      checked={selectedOption === AVERAGE_TIME}
+                      onChange={handleOptionChange}
+                    />
+                  }
+                  label="Median"
+                />
 
-            <ChartLabel
-              text="minutes"
-              className="alt-y-label"
-              includeMargin={false}
-              xPercent={0.06}
-              yPercent={0.06}
-              style={{
-                transform: 'rotate(-90)',
-                textAnchor: 'end',
-              }}
-            />
+                <FormControlLabel
+                  control={
+                    <Radio
+                      id="planning_time"
+                      type="radio"
+                      value={PLANNING_TIME}
+                      checked={selectedOption === PLANNING_TIME}
+                      onChange={handleOptionChange}
+                    />
+                  }
+                  label={`Planning (${PLANNING_PERCENTILE}th percentile)`}
+                />
+              </div>
+            </FormControl>
+            <XYPlot
+              xType="ordinal"
+              width={400}
+              height={CHART_HEIGHT}
+              margin={chartMargins}
+              yDomain={[0, maxTrip + maxWait]}
+              onMouseLeave={onMouseLeave}
+            >
+              <HorizontalGridLines />
+              <XAxis tickLabelAngle={-90} tickFormat={primaryDateFormatter} />
+              <YAxis hideLine />
 
-            {crosshairValues.length > 0 && (
-              <Crosshair
-                values={crosshairValues}
-                style={REACT_VIS_CROSSHAIR_NO_LINE}
-              >
-                <div className="rv-crosshair__inner__content">
-                  <p>
-                    Onboard time:{' '}
-                    {crosshairValues[1] ? Math.round(crosshairValues[1].y) : ''}
-                  </p>
-                  <p>Wait time: {Math.round(crosshairValues[0].y)}</p>
-                </div>
-              </Crosshair>
-            )}
-          </XYPlot>
-          <DiscreteColorLegend
+              <LineMarkSeries
+                data={waitData}
+                color={theme.palette.primary.dark}
+                onNearestX={onNearestX}
+              />
+              <AreaSeries
+                data={tripData}
+                opacity={0.3}
+                color={theme.palette.primary.light}
+              />
+              <LineMarkSeries
+                data={tripData}
+                color={theme.palette.primary.light}
+              />
+              {byDayData2 ? (
+                <LineMarkSeries
+                  data={waitData2}
+                  color={theme.palette.secondary.dark}
+                  onNearestX={onNearestX}
+                />
+              ) : null}
+              {byDayData2 ? (
+                <LineMarkSeries
+                  data={tripData2}
+                  color={theme.palette.secondary.light}
+                />
+              ) : null}
+
+              <ChartLabel
+                text="minutes"
+                className="alt-y-label"
+                includeMargin={false}
+                xPercent={0.06}
+                yPercent={0.06}
+                style={{
+                  transform: 'rotate(-90)',
+                  textAnchor: 'end',
+                }}
+              />
+
+              {crosshairValues.length > 0 && (
+                <Crosshair
+                  values={crosshairValues}
+                  style={REACT_VIS_CROSSHAIR_NO_LINE}
+                >
+                  <div className="rv-crosshair__inner__content">
+                    <p>
+                      Onboard time:{' '}
+                      {crosshairValues[1]
+                        ? Math.round(
+                            crosshairValues[1].y - crosshairValues[0].y,
+                          )
+                        : ''}
+                    </p>
+                    <p>Wait time: {Math.round(crosshairValues[0].y)}</p>
+                  </div>
+                </Crosshair>
+              )}
+            </XYPlot>
+            {/*          <DiscreteColorLegend
             orientation="horizontal"
             width={300}
             items={legendItems}
-          />
-          On-Time %
-          <XYPlot
-            xType="ordinal"
-            height={300}
-            width={400}
-            margin={chartMargins}
-            yDomain={[0, 100]}
-            onMouseLeave={onMouseLeave}
-          >
-            <HorizontalGridLines />
-            <XAxis tickLabelAngle={-90} />
-            <YAxis hideLine />
+          /> */}
+          </Box>
 
-            <LineMarkSeries
-              data={onTimeRateData}
-              color={CHART_COLORS[0]}
-              onNearestX={onNearestXGeneric}
-              stack
-            />
+          <Box p={2} hidden={tabValue !== ON_TIME}>
+            <XYPlot
+              xType="ordinal"
+              height={CHART_HEIGHT}
+              width={400}
+              margin={chartMargins}
+              yDomain={[0, 100]}
+              onMouseLeave={onMouseLeave}
+            >
+              <HorizontalGridLines />
+              <XAxis tickLabelAngle={-90} tickFormat={primaryDateFormatter} />
+              <YAxis hideLine />
 
-            <ChartLabel
-              text="Long Wait %"
-              className="alt-y-label"
-              includeMargin={false}
-              xPercent={0.06}
-              yPercent={0.06}
-              style={{
-                transform: 'rotate(-90)',
-                textAnchor: 'end',
-              }}
-            />
+              <LineMarkSeries
+                data={onTimeRateData}
+                color={theme.palette.primary.main}
+                onNearestX={onNearestXGeneric}
+              />
+              <LineMarkSeries
+                data={onTimeRateData2}
+                color={theme.palette.secondary.main}
+                onNearestX={onNearestXGeneric}
+              />
 
-            {crosshairValues.length > 0 &&
-            false /* need separate state for each crosshair */ && (
-                <Crosshair
-                  values={crosshairValues}
-                  style={REACT_VIS_CROSSHAIR_NO_LINE}
-                ></Crosshair>
-              )}
-          </XYPlot>
-          Median Speed
-          <XYPlot
-            xType="ordinal"
-            height={300}
-            width={400}
-            margin={chartMargins}
-            yDomain={[0, maxSpeed]}
-            onMouseLeave={onMouseLeave}
-          >
-            <HorizontalGridLines />
-            <XAxis tickLabelAngle={-90} />
-            <YAxis hideLine />
+              <ChartLabel
+                text="On-Time %"
+                className="alt-y-label"
+                includeMargin={false}
+                xPercent={0.06}
+                yPercent={0.06}
+                style={{
+                  transform: 'rotate(-90)',
+                  textAnchor: 'end',
+                }}
+              />
 
-            <LineMarkSeries
-              data={speedData}
-              color={CHART_COLORS[1]}
-              onNearestX={onNearestXGeneric}
-              stack
-            />
+              {crosshairValues.length > 0 &&
+              false /* need separate state for each crosshair */ && (
+                  <Crosshair
+                    values={crosshairValues}
+                    style={REACT_VIS_CROSSHAIR_NO_LINE}
+                  ></Crosshair>
+                )}
+            </XYPlot>
+          </Box>
 
-            <ChartLabel
-              text="Median Speed (mph)"
-              className="alt-y-label"
-              includeMargin={false}
-              xPercent={0.06}
-              yPercent={0.06}
-              style={{
-                transform: 'rotate(-90)',
-                textAnchor: 'end',
-              }}
-            />
+          <Box p={2} hidden={tabValue !== MEDIAN_SPEED}>
+            <XYPlot
+              xType="ordinal"
+              height={CHART_HEIGHT}
+              width={400}
+              margin={chartMargins}
+              yDomain={[0, maxSpeed]}
+              onMouseLeave={onMouseLeave}
+            >
+              <HorizontalGridLines />
+              <XAxis tickLabelAngle={-90} tickFormat={primaryDateFormatter} />
+              <YAxis hideLine />
 
-            {crosshairValues.length > 0 &&
-            false /* need separate state for each crosshair */ && (
-                <Crosshair
-                  values={crosshairValues}
-                  style={REACT_VIS_CROSSHAIR_NO_LINE}
-                ></Crosshair>
-              )}
-          </XYPlot>
-          Travel Variability
-          <XYPlot
-            xType="ordinal"
-            height={300}
-            width={400}
-            margin={chartMargins}
-            yDomain={[0, maxTravelVariability]}
-            onMouseLeave={onMouseLeave}
-          >
-            <HorizontalGridLines />
-            <XAxis tickLabelAngle={-90} />
-            <YAxis hideLine />
+              <LineMarkSeries
+                data={speedData}
+                color={theme.palette.primary.main}
+                onNearestX={onNearestXGeneric}
+              />
+              <LineMarkSeries
+                data={speedData2}
+                color={theme.palette.secondary.main}
+                onNearestX={onNearestXGeneric}
+              />
 
-            <LineMarkSeries
-              data={travelVariabilityData}
-              color={CHART_COLORS[1]}
-              onNearestX={onNearestXGeneric}
-              stack
-            />
+              <ChartLabel
+                text="Median Speed (mph)"
+                className="alt-y-label"
+                includeMargin={false}
+                xPercent={0.06}
+                yPercent={0.06}
+                style={{
+                  transform: 'rotate(-90)',
+                  textAnchor: 'end',
+                }}
+              />
 
-            <ChartLabel
-              text={'Variability (\u00b1 min)'}
-              className="alt-y-label"
-              includeMargin={false}
-              xPercent={0.06}
-              yPercent={0.06}
-              style={{
-                transform: 'rotate(-90)',
-                textAnchor: 'end',
-              }}
-            />
+              {crosshairValues.length > 0 &&
+              false /* need separate state for each crosshair */ && (
+                  <Crosshair
+                    values={crosshairValues}
+                    style={REACT_VIS_CROSSHAIR_NO_LINE}
+                  ></Crosshair>
+                )}
+            </XYPlot>
+          </Box>
 
-            {crosshairValues.length > 0 &&
-            false /* need separate state for each crosshair */ && (
-                <Crosshair
-                  values={crosshairValues}
-                  style={REACT_VIS_CROSSHAIR_NO_LINE}
-                ></Crosshair>
-              )}
-          </XYPlot>
-          Score
-          <XYPlot
-            xType="ordinal"
-            height={300}
-            width={400}
-            margin={chartMargins}
-            yDomain={[0, maxScore]}
-            onMouseLeave={onMouseLeave}
-          >
-            <HorizontalGridLines />
-            <XAxis tickLabelAngle={-90} />
-            <YAxis hideLine />
+          <Box p={2} hidden={tabValue !== TRIP_VARIABILITY}>
+            <XYPlot
+              xType="ordinal"
+              height={CHART_HEIGHT}
+              width={400}
+              margin={chartMargins}
+              yDomain={[0, maxTravelVariability]}
+              onMouseLeave={onMouseLeave}
+            >
+              <HorizontalGridLines />
+              <XAxis tickLabelAngle={-90} tickFormat={primaryDateFormatter} />
+              <YAxis hideLine />
 
-            <LineMarkSeries
-              data={scoreData}
-              color={CHART_COLORS[2]}
-              onNearestX={onNearestXGeneric}
-              stack
-            />
+              <LineMarkSeries
+                data={travelVariabilityData}
+                color={theme.palette.primary.main}
+                onNearestX={onNearestXGeneric}
+              />
+              <LineMarkSeries
+                data={travelVariabilityData2}
+                color={theme.palette.secondary.main}
+                onNearestX={onNearestXGeneric}
+              />
 
-            <ChartLabel
-              text="Score"
-              className="alt-y-label"
-              includeMargin={false}
-              xPercent={0.06}
-              yPercent={0.06}
-              style={{
-                transform: 'rotate(-90)',
-                textAnchor: 'end',
-              }}
-            />
+              <ChartLabel
+                text={'Variability (\u00b1 min)'}
+                className="alt-y-label"
+                includeMargin={false}
+                xPercent={0.06}
+                yPercent={0.06}
+                style={{
+                  transform: 'rotate(-90)',
+                  textAnchor: 'end',
+                }}
+              />
 
-            {crosshairValues.length > 0 &&
-            false /* need separate state for each crosshair */ && (
-                <Crosshair
-                  values={crosshairValues}
-                  style={REACT_VIS_CROSSHAIR_NO_LINE}
-                ></Crosshair>
-              )}
-          </XYPlot>
+              {crosshairValues.length > 0 &&
+              false /* need separate state for each crosshair */ && (
+                  <Crosshair
+                    values={crosshairValues}
+                    style={REACT_VIS_CROSSHAIR_NO_LINE}
+                  ></Crosshair>
+                )}
+            </XYPlot>
+          </Box>
+
+          <Box p={2} hidden={tabValue !== SCORE}>
+            <div style={{ width: '100%' }}>
+              <XYPlot
+                xType="ordinal"
+                width={400}
+                height={CHART_HEIGHT}
+                margin={chartMargins}
+                yDomain={[0, maxScore]}
+                onMouseLeave={onMouseLeave}
+              >
+                <HorizontalGridLines />
+                <XAxis tickLabelAngle={-90} tickFormat={primaryDateFormatter} />
+                <YAxis hideLine />
+
+                <LineMarkSeries
+                  data={scoreData}
+                  color={theme.palette.primary.main}
+                  onNearestX={onNearestXGeneric}
+                />
+                <LineMarkSeries
+                  data={scoreData2}
+                  color={theme.palette.secondary.main}
+                  onNearestX={onNearestXGeneric}
+                />
+
+                <ChartLabel
+                  text="Score"
+                  className="alt-y-label"
+                  includeMargin={false}
+                  xPercent={0.06}
+                  yPercent={0.06}
+                  style={{
+                    transform: 'rotate(-90)',
+                    textAnchor: 'end',
+                  }}
+                />
+
+                {crosshairValues.length > 0 &&
+                false /* need separate state for each crosshair */ && (
+                    <Crosshair
+                      values={crosshairValues}
+                      style={REACT_VIS_CROSSHAIR_NO_LINE}
+                    ></Crosshair>
+                  )}
+              </XYPlot>
+            </div>
+          </Box>
         </div>
       ) : (
         <code>No data.</code>

--- a/frontend/src/components/InfoJourneyChart.jsx
+++ b/frontend/src/components/InfoJourneyChart.jsx
@@ -2,16 +2,17 @@ import React, { Fragment, useState } from 'react';
 import {
   XYPlot,
   HorizontalGridLines,
+  VerticalBarSeries,
   XAxis,
   YAxis,
-  VerticalBarSeries,
   ChartLabel,
   Crosshair,
 } from 'react-vis';
 import DiscreteColorLegend from 'react-vis/dist/legends/discrete-color-legend';
+import { useTheme } from '@material-ui/core/styles';
 import StartStopIcon from '@material-ui/icons/DirectionsTransit';
 import WatchLaterOutlinedIcon from '@material-ui/icons/WatchLaterOutlined';
-import { CHART_COLORS, REACT_VIS_CROSSHAIR_NO_LINE } from '../UIConstants';
+import { REACT_VIS_CROSSHAIR_NO_LINE } from '../UIConstants';
 import '../../node_modules/react-vis/dist/style.css';
 
 /**
@@ -37,9 +38,11 @@ function InfoJourneyChart(props) {
     setCrosshairValues([value]);
   };
 
+  const theme = useTheme();
+
   const { firstWaits, secondWaits, firstTravels, secondTravels } = props;
 
-  const legendItems = [
+  const legendItems = (travelColor, waitColor) => [
     {
       title: (
         <Fragment>
@@ -47,7 +50,7 @@ function InfoJourneyChart(props) {
           &nbsp;Travel
         </Fragment>
       ),
-      color: CHART_COLORS[1],
+      color: travelColor,
       strokeWidth: 10,
     },
     {
@@ -60,7 +63,7 @@ function InfoJourneyChart(props) {
           &nbsp;Wait
         </Fragment>
       ),
-      color: CHART_COLORS[0],
+      color: waitColor,
       strokeWidth: 10,
     },
   ];
@@ -82,7 +85,7 @@ function InfoJourneyChart(props) {
 
           <VerticalBarSeries
             cluster="first"
-            color={CHART_COLORS[0]}
+            color={theme.palette.primary.dark}
             onValueMouseOver={onValue}
             data={[
               { x: 'Typical', y: firstWaits[0] },
@@ -92,7 +95,7 @@ function InfoJourneyChart(props) {
 
           <VerticalBarSeries
             cluster="first"
-            color={CHART_COLORS[1]}
+            color={theme.palette.primary.light}
             onValueMouseOver={onValue}
             data={[
               { x: 'Typical', y: firstTravels[0] },
@@ -102,7 +105,7 @@ function InfoJourneyChart(props) {
 
           <VerticalBarSeries
             cluster="second"
-            color={CHART_COLORS[2]}
+            color={theme.palette.secondary.dark}
             onValueMouseOver={onValue}
             data={[
               { x: 'Typical', y: secondWaits[0] },
@@ -112,7 +115,7 @@ function InfoJourneyChart(props) {
 
           <VerticalBarSeries
             cluster="second"
-            color={CHART_COLORS[3]}
+            color={theme.palette.secondary.light}
             onValueMouseOver={onValue}
             data={[
               { x: 'Typical', y: secondTravels[0] },
@@ -150,7 +153,18 @@ function InfoJourneyChart(props) {
         <DiscreteColorLegend
           orientation="vertical"
           width={110}
-          items={legendItems}
+          items={legendItems(
+            theme.palette.primary.light,
+            theme.palette.primary.dark,
+          )}
+        />
+        <DiscreteColorLegend
+          orientation="vertical"
+          width={110}
+          items={legendItems(
+            theme.palette.secondary.light,
+            theme.palette.secondary.dark,
+          )}
         />
       </div>
     </div>

--- a/frontend/src/components/InfoScoreCard.jsx
+++ b/frontend/src/components/InfoScoreCard.jsx
@@ -82,8 +82,8 @@ export default function InfoScoreCard(props) {
   */
 
   const cardStyle = {
-    background: score != null ? scoreBackgroundColor(score) : 'gray',
-    color: score != null ? scoreContrastColor(score) : 'black',
+    background: score !== NO_VALUE ? scoreBackgroundColor(score) : 'white',
+    color: score !== NO_VALUE ? scoreContrastColor(score) : 'black',
     width: '100%',
     height: '100%',
     display: 'inline-block',
@@ -100,7 +100,7 @@ export default function InfoScoreCard(props) {
   const hasSecondValue = secondValue !== NO_VALUE;
   const largeContent = hasSecondValue ? (
     <Fragment>
-      <Typography variant="h3" display="inline">
+      <Typography variant="h4" display="inline">
         {percentDifference(firstValue, secondValue)}
       </Typography>
       <Typography variant="h5" display="inline">
@@ -109,7 +109,7 @@ export default function InfoScoreCard(props) {
     </Fragment>
   ) : (
     <Fragment>
-      <Typography variant="h3" display="inline">
+      <Typography variant="h4" display="inline">
         {valuePrefix || null}
         {firstValue === null ? NO_VALUE : firstValue}
       </Typography>

--- a/frontend/src/components/InfoTripSummary.jsx
+++ b/frontend/src/components/InfoTripSummary.jsx
@@ -2,7 +2,7 @@
  * Stop to stop trip summary component.
  */
 
-import React, { Fragment, useState } from 'react';
+import React, { Fragment } from 'react';
 
 import {
   Table,
@@ -12,12 +12,8 @@ import {
   Typography,
 } from '@material-ui/core';
 import Grid from '@material-ui/core/Grid';
-import IconButton from '@material-ui/core/IconButton';
 import Paper from '@material-ui/core/Paper';
-import Popover from '@material-ui/core/Popover';
-import { makeStyles, useTheme } from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
-import InfoIcon from '@material-ui/icons/InfoOutlined';
 import StartStopIcon from '@material-ui/icons/DirectionsTransit';
 import WatchLaterOutlinedIcon from '@material-ui/icons/WatchLaterOutlined';
 import {
@@ -31,7 +27,6 @@ import {
   NO_VALUE,
 } from '../UIConstants';
 import { getPercentileValue } from '../helpers/graphData';
-import DateTimeLabel from './DateTimeLabel';
 import InfoByDay from './InfoByDay';
 import InfoJourneyChart from './InfoJourneyChart';
 import InfoScoreCard from './InfoScoreCard';
@@ -43,27 +38,6 @@ import InfoScoreLegend from './InfoScoreLegend';
  * @param {any} props
  */
 export default function InfoTripSummary(props) {
-  const [typicalAnchorEl, setTypicalAnchorEl] = useState(null);
-  const [planningAnchorEl, setPlanningAnchorEl] = useState(null);
-
-  function handleTypicalClick(event) {
-    setTypicalAnchorEl(event.currentTarget);
-  }
-
-  function handleTypicalClose() {
-    setTypicalAnchorEl(null);
-  }
-
-  function handlePlanningClick(event) {
-    setPlanningAnchorEl(event.currentTarget);
-  }
-
-  function handlePlanningClose() {
-    setPlanningAnchorEl(null);
-  }
-
-  const theme = useTheme();
-
   const { tripMetrics, graphParams, routes } = props;
   const waitTimes = tripMetrics ? tripMetrics.interval.waitTimes : null;
   const tripTimes = tripMetrics ? tripMetrics.interval.tripTimes : null;
@@ -171,18 +145,6 @@ export default function InfoTripSummary(props) {
   } else if (!waitTimes.median) {
     whyNoData = 'No median wait time available.';
   }
-
-  const useStyles = makeStyles(myTheme => ({
-    uncolored: {
-      margin: myTheme.spacing(1),
-    },
-    popover: {
-      padding: myTheme.spacing(2),
-      maxWidth: 500,
-    },
-  }));
-
-  const classes = useStyles();
 
   const planningWait = Math.round(
     getPercentileValue(waitTimes, PLANNING_PERCENTILE),
@@ -304,23 +266,14 @@ export default function InfoTripSummary(props) {
 
   const InfoTripCards = () => (
     <Fragment>
-      <Grid item xs component={Paper} className={classes.uncolored}>
-        <Typography variant="overline">Typical journey</Typography>
-        <br />
-
-        <Typography variant="h3" display="inline">
-          {typicalWait + typicalTravel}
-        </Typography>
-        <Typography variant="h5" display="inline">
-          &nbsp;min
-        </Typography>
-
-        <Box
-          display="flex"
-          justifyContent="space-between"
-          alignItems="flex-end"
-          pt={2}
-        >
+      <InfoScoreCard
+        score={NO_VALUE}
+        title="Typical Journey"
+        hideRating
+        firstValue={typicalWait + typicalTravel}
+        secondValue={NO_VALUE}
+        valueSuffix={`\u00a0min`}
+        bottomContent={
           <Typography variant="body1">
             <WatchLaterOutlinedIcon
               fontSize="small"
@@ -333,29 +286,24 @@ export default function InfoTripSummary(props) {
             &nbsp;
             {typicalTravel} min
           </Typography>
-          <IconButton size="small" onClick={handleTypicalClick}>
-            <InfoIcon fontSize="small" />
-          </IconButton>
-        </Box>
-      </Grid>
+        }
+        popoverContent={
+          <Fragment>
+            This is the median wait time when a rider arrives randomly at a stop
+            or a rider starts checking predictions. This is combined with the
+            median trip time.
+          </Fragment>
+        }
+      />
 
-      <Grid item xs component={Paper} className={classes.uncolored}>
-        <Typography variant="overline">Journey planning</Typography>
-        <br />
-
-        <Typography variant="h3" display="inline">
-          {planningWait + planningTravel}
-        </Typography>
-        <Typography variant="h5" display="inline">
-          &nbsp;min
-        </Typography>
-
-        <Box
-          display="flex"
-          justifyContent="space-between"
-          alignItems="flex-end"
-          pt={2}
-        >
+      <InfoScoreCard
+        score={NO_VALUE}
+        title="Journey Planning"
+        hideRating
+        firstValue={planningWait + planningTravel}
+        secondValue={NO_VALUE}
+        valueSuffix={`\u00a0min`}
+        bottomContent={
           <Typography variant="body1">
             <WatchLaterOutlinedIcon
               fontSize="small"
@@ -368,11 +316,15 @@ export default function InfoTripSummary(props) {
             &nbsp;
             {planningTravel} min
           </Typography>
-          <IconButton size="small" onClick={handlePlanningClick}>
-            <InfoIcon fontSize="small" />
-          </IconButton>
-        </Box>
-      </Grid>
+        }
+        popoverContent={
+          <Fragment>
+            When planning to arrive by a specific time, the 90th percentile wait
+            time and 90th percentile travel time suggest how far in advance to
+            start checking predictions. Walking time should also be added.
+          </Fragment>
+        }
+      />
     </Fragment>
   );
 
@@ -408,22 +360,6 @@ export default function InfoTripSummary(props) {
     <Fragment>
       {scores ? (
         <Fragment>
-          <DateTimeLabel
-            style={{ display: 'inline-block', minWidth: 330 }}
-            dateRangeParams={graphParams.firstDateRange}
-            colorCode={theme.palette.primary.main}
-          />
-          {graphParams.secondDateRange ? (
-            <Fragment>
-              <br />
-              <DateTimeLabel
-                style={{ display: 'inline-block', minWidth: 330 }}
-                dateRangeParams={graphParams.secondDateRange}
-                colorCode={theme.palette.secondary.light}
-              />
-            </Fragment>
-          ) : null}
-
           <InfoByDay
             byDayData={
               byDayData /* consider switching to trip metrics here for consistency */
@@ -440,6 +376,7 @@ export default function InfoTripSummary(props) {
                 score={scores.totalScore}
                 title="Trip Score"
                 hideRating
+                preserveRatingSpace
                 firstValue={scores.totalScore}
                 secondValue={waitTimes2 ? scores2.totalScore : NO_VALUE}
                 valueSuffix={`/${HighestPossibleScore}`}
@@ -501,47 +438,6 @@ export default function InfoTripSummary(props) {
               />
             </Grid>
           </div>
-
-          <Popover
-            open={Boolean(typicalAnchorEl)}
-            anchorEl={typicalAnchorEl}
-            onClose={handleTypicalClose}
-            anchorOrigin={{
-              vertical: 'bottom',
-              horizontal: 'center',
-            }}
-            transformOrigin={{
-              vertical: 'top',
-              horizontal: 'center',
-            }}
-          >
-            <div className={classes.popover}>
-              This is the median wait time when a rider arrives randomly at a
-              stop or a rider starts checking predictions. This is combined with
-              the median trip time.
-            </div>
-          </Popover>
-
-          <Popover
-            open={Boolean(planningAnchorEl)}
-            anchorEl={planningAnchorEl}
-            onClose={handlePlanningClose}
-            anchorOrigin={{
-              vertical: 'bottom',
-              horizontal: 'center',
-            }}
-            transformOrigin={{
-              vertical: 'top',
-              horizontal: 'center',
-            }}
-          >
-            <div className={classes.popover}>
-              When planning to arrive by a specific time, the 90th percentile
-              wait time and 90th percentile travel time suggest how far in
-              advance to start checking predictions. Walking time should also be
-              added.
-            </div>
-          </Popover>
         </Fragment>
       ) : (
         `No trip summary (${whyNoData})`

--- a/frontend/src/components/InfoTripSummary.jsx
+++ b/frontend/src/components/InfoTripSummary.jsx
@@ -492,7 +492,7 @@ export default function InfoTripSummary(props) {
                 hideRating={tripTimes2}
                 firstValue={travelTimeVariabilityHalved}
                 secondValue={
-                  tripTimes2 ? { travelTimeVariabilityHalved2 } : NO_VALUE
+                  tripTimes2 ? travelTimeVariabilityHalved2 : NO_VALUE
                 }
                 valuePrefix={`\u00b1`}
                 valueSuffix={`\u00a0min`}

--- a/frontend/src/components/RouteSummary.jsx
+++ b/frontend/src/components/RouteSummary.jsx
@@ -1,155 +1,18 @@
 import React, { Fragment } from 'react';
 
-import { connect } from 'react-redux';
+import { AppBar, Box, Tab, Tabs } from '@material-ui/core';
 
-import Grid from '@material-ui/core/Grid';
-
-import {
-  AppBar,
-  Box,
-  Tab,
-  Tabs,
-  Table,
-  TableBody,
-  TableCell,
-  TableRow,
-} from '@material-ui/core';
-
-import InfoScoreCard from './InfoScoreCard';
-import InfoScoreLegend from './InfoScoreLegend';
+import RouteSummaryCards from './RouteSummaryCards';
 import TravelTimeChart from './TravelTimeChart';
 import MareyChart from './MareyChart';
-import { HighestPossibleScore } from '../helpers/routeCalculations';
 
 /**
  * Renders an "nyc bus stats" style summary of a route and direction.
  *
  * @param {any} props
  */
-function RouteSummary(props) {
-  const { graphParams, statsByRouteId } = props;
+export default function RouteSummary() {
   const [tabValue, setTabValue] = React.useState(0);
-
-  const { routeId, directionId } = graphParams;
-  const routeStats = statsByRouteId[routeId] || { directions: [] };
-
-  let stats = null;
-  if (directionId) {
-    stats =
-      routeStats.directions.find(
-        dirStats => dirStats.directionId === directionId,
-      ) || {};
-  } else {
-    stats = routeStats;
-  }
-
-  const popoverContentTotalScore =
-    stats.totalScore != null ? (
-      <Fragment>
-        Route score of {stats.totalScore} is the average of the following
-        subscores:
-        <Box pt={2}>
-          <Table>
-            <TableBody>
-              <TableRow>
-                <TableCell>Median wait</TableCell>
-                <TableCell align="right">{stats.medianWaitScore}</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>On-Time rate</TableCell>
-                <TableCell align="right">{stats.onTimeRateScore}</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>Average speed</TableCell>
-                <TableCell align="right"> {stats.speedScore}</TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell>Travel time variability</TableCell>
-                <TableCell align="right">
-                  {' '}
-                  {stats.travelVarianceScore}
-                </TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
-        </Box>
-      </Fragment>
-    ) : null;
-
-  const popoverContentWait =
-    stats.medianWaitTime != null ? (
-      <Fragment>
-        Median wait of {stats.medianWaitTime.toFixed(1)} min gets a score of{' '}
-        {stats.medianWaitScore}.
-        <Box pt={2}>
-          <InfoScoreLegend
-            rows={[
-              { label: '5 min or less', value: 100 },
-              { label: '6.25 min', value: 75 },
-              { label: '7.5 min', value: 50 },
-              { label: '8.75', value: 25 },
-              { label: '10 min or more', value: 0 },
-            ]}
-          />
-        </Box>
-      </Fragment>
-    ) : null;
-
-  const popoverContentOnTimeRate =
-    stats.onTimeRate != null ? (
-      <Fragment>
-        The on-time percentage is the percentage of scheduled departure times
-        where a vehicle departed less than 5 minutes after the scheduled
-        departure time or less than 1 minute before the scheduled departure
-        time. The on-time percentage for the entire route is the median of the
-        on-time percentage for each stop along the route. Probability of{' '}
-        {(stats.onTimeRate * 100).toFixed(1) /* be more precise than card */}%
-        gets a score of {stats.onTimeRateScore}.
-      </Fragment>
-    ) : null;
-
-  const popoverContentSpeed =
-    stats.averageSpeed != null ? (
-      <Fragment>
-        This is the average of the speeds for median end to end trips, in all
-        directions. Average speed of {stats.averageSpeed.toFixed(1)} mph gets a
-        score of {stats.speedScore}.
-        <Box pt={2}>
-          <InfoScoreLegend
-            rows={[
-              { label: '10 mph or more', value: 100 },
-              { label: '8.75 mph', value: 75 },
-              { label: '7.5 mph', value: 50 },
-              { label: '6.25 mph', value: 25 },
-              { label: '5 mph or less', value: 0 },
-            ]}
-          />
-        </Box>
-      </Fragment>
-    ) : null;
-
-  const popoverContentTravelVariability =
-    stats.travelTimeVariability != null ? (
-      <Fragment>
-        Travel time variability is difference between the 90th percentile end to
-        end travel time and the 10th percentile travel time. This measures how
-        much extra travel time is needed for some trips. Variability of
-        {' \u00b1'}
-        {(stats.travelTimeVariability / 2).toFixed(1)} min gets a score of{' '}
-        {stats.travelVarianceScore}.
-        <Box pt={2}>
-          <InfoScoreLegend
-            rows={[
-              { label: '5 min or less', value: 100 },
-              { label: '6.25 min', value: 75 },
-              { label: '7.5 min', value: 50 },
-              { label: '8.75 min', value: 25 },
-              { label: '10 min or more', value: 0 },
-            ]}
-          />
-        </Box>
-      </Fragment>
-    ) : null;
 
   function handleTabChange(event, newValue) {
     setTabValue(newValue);
@@ -196,94 +59,7 @@ function RouteSummary(props) {
       </AppBar>
 
       <Box p={2} hidden={tabValue !== SUMMARY}>
-        <div style={{ padding: 8 }}>
-          <Grid container spacing={4}>
-            <InfoScoreCard
-              score={stats.totalScore}
-              hideRating
-              title="Route Score"
-              largeValue={stats.totalScore != null ? stats.totalScore : '--'}
-              smallValue={`/${HighestPossibleScore}`}
-              bottomContent={
-                stats.scoreRank != null
-                  ? `#${stats.scoreRank} of ${stats.scoreRankCount} routes`
-                  : ''
-              }
-              popoverContent={popoverContentTotalScore}
-            />
-            <InfoScoreCard
-              score={stats.medianWaitScore}
-              title="Median Wait"
-              largeValue={
-                stats.medianWaitTime != null
-                  ? stats.medianWaitTime.toFixed(0)
-                  : '--'
-              }
-              smallValue="&nbsp;min"
-              bottomContent={
-                <Fragment>
-                  {stats.waitRank != null
-                    ? `#${stats.waitRank} of ${stats.waitRankCount} routes`
-                    : null}
-                </Fragment>
-              }
-              popoverContent={popoverContentWait}
-            />
-
-            <InfoScoreCard
-              score={stats.onTimeRateScore}
-              title="On-Time %"
-              largeValue={
-                stats.onTimeRate != null
-                  ? (stats.onTimeRate * 100).toFixed(0)
-                  : '--'
-              }
-              smallValue="%"
-              popoverContent={popoverContentOnTimeRate}
-              bottomContent={
-                stats.onTimeRank != null
-                  ? `#${stats.onTimeRank} of ${stats.onTimeRankCount} routes`
-                  : ''
-              }
-            />
-
-            <InfoScoreCard
-              score={stats.speedScore}
-              title="Average Speed"
-              largeValue={
-                stats.averageSpeed != null
-                  ? stats.averageSpeed.toFixed(0)
-                  : '--'
-              }
-              smallValue="&nbsp;mph"
-              bottomContent={
-                <Fragment>
-                  {stats.speedRank != null
-                    ? `#${stats.speedRank} of ${stats.speedRankCount} routes`
-                    : null}
-                </Fragment>
-              }
-              popoverContent={popoverContentSpeed}
-            />
-
-            <InfoScoreCard
-              score={stats.travelVarianceScore}
-              title="Travel Time Variability"
-              largeValue={
-                stats.travelTimeVariability != null
-                  ? `\u00b1${(stats.travelTimeVariability / 2).toFixed(0)}`
-                  : '--'
-              }
-              smallValue="&nbsp;min"
-              bottomContent={
-                stats.variabilityRank != null
-                  ? `#${stats.variabilityRank} of ${stats.variabilityRankCount} routes`
-                  : ''
-              }
-              popoverContent={popoverContentTravelVariability}
-            />
-          </Grid>
-        </div>
+        <RouteSummaryCards />
       </Box>
       <Box
         p={2}
@@ -302,11 +78,3 @@ function RouteSummary(props) {
     </Fragment>
   );
 }
-
-const mapStateToProps = state => ({
-  routes: state.routes.data,
-  graphParams: state.graphParams,
-  statsByRouteId: state.agencyMetrics.statsByRouteId,
-});
-
-export default connect(mapStateToProps)(RouteSummary);

--- a/frontend/src/components/RouteSummaryCards.jsx
+++ b/frontend/src/components/RouteSummaryCards.jsx
@@ -1,0 +1,254 @@
+import React, { Fragment } from 'react';
+import { connect } from 'react-redux';
+import { Box, Table, TableBody, TableCell, TableRow } from '@material-ui/core';
+import InfoScoreCard from './InfoScoreCard';
+import InfoScoreLegend from './InfoScoreLegend';
+import { HighestPossibleScore } from '../helpers/routeCalculations';
+import { NO_VALUE } from '../UIConstants';
+/**
+ * Renders an "nyc bus stats" style summary of a route and direction.
+ *
+ * @param {any} props
+ */
+function RouteSummaryCards(props) {
+  const { graphParams, statsByRouteId, statsByRouteId2 } = props;
+
+  const { routeId, directionId } = graphParams;
+  const routeStats = statsByRouteId[routeId] || { directions: [] };
+  const routeStats2 =
+    statsByRouteId2 && (statsByRouteId2[routeId] || { directions: [] });
+
+  function filterRouteStatsByDirection(myRouteStats) {
+    let stats = null;
+    if (directionId) {
+      stats =
+        myRouteStats.directions.find(
+          dirStats => dirStats.directionId === directionId,
+        ) || {};
+    } else {
+      stats = myRouteStats;
+    }
+    return stats;
+  }
+
+  const stats = filterRouteStatsByDirection(routeStats);
+  const stats2 = statsByRouteId2
+    ? filterRouteStatsByDirection(routeStats2)
+    : null;
+
+  const popovers = {};
+  popovers.contentTotalScore =
+    stats.totalScore != null ? (
+      <Fragment>
+        Route score of {stats.totalScore} is the average of the following
+        subscores:
+        <Box pt={2}>
+          <Table>
+            <TableBody>
+              <TableRow>
+                <TableCell>Median wait</TableCell>
+                <TableCell align="right">{stats.medianWaitScore}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>On-Time rate</TableCell>
+                <TableCell align="right">{stats.onTimeRateScore}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Average speed</TableCell>
+                <TableCell align="right"> {stats.speedScore}</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Travel time variability</TableCell>
+                <TableCell align="right">
+                  {' '}
+                  {stats.travelVarianceScore}
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </Box>
+      </Fragment>
+    ) : null;
+
+  popovers.contentWait =
+    stats.medianWaitTime != null ? (
+      <Fragment>
+        Median wait of {stats.medianWaitTime.toFixed(1)} min gets a score of{' '}
+        {stats.medianWaitScore}.
+        <Box pt={2}>
+          <InfoScoreLegend
+            rows={[
+              { label: '5 min or less', value: 100 },
+              { label: '6.25 min', value: 75 },
+              { label: '7.5 min', value: 50 },
+              { label: '8.75', value: 25 },
+              { label: '10 min or more', value: 0 },
+            ]}
+          />
+        </Box>
+      </Fragment>
+    ) : null;
+
+  popovers.contentOnTimeRate =
+    stats.onTimeRate != null ? (
+      <Fragment>
+        The on-time percentage is the percentage of scheduled departure times
+        where a vehicle departed less than 5 minutes after the scheduled
+        departure time or less than 1 minute before the scheduled departure
+        time. The on-time percentage for the entire route is the median of the
+        on-time percentage for each stop along the route. Probability of{' '}
+        {(stats.onTimeRate * 100).toFixed(1) /* be more precise than card */}%
+        gets a score of {stats.onTimeRateScore}.
+      </Fragment>
+    ) : null;
+
+  popovers.contentSpeed =
+    stats.averageSpeed != null ? (
+      <Fragment>
+        This is the average of the speeds for median end to end trips, in all
+        directions. Average speed of {stats.averageSpeed.toFixed(1)} mph gets a
+        score of {stats.speedScore}.
+        <Box pt={2}>
+          <InfoScoreLegend
+            rows={[
+              { label: '10 mph or more', value: 100 },
+              { label: '8.75 mph', value: 75 },
+              { label: '7.5 mph', value: 50 },
+              { label: '6.25 mph', value: 25 },
+              { label: '5 mph or less', value: 0 },
+            ]}
+          />
+        </Box>
+      </Fragment>
+    ) : null;
+
+  popovers.contentTravelVariability =
+    stats.travelTimeVariability != null ? (
+      <Fragment>
+        Travel time variability is difference between the 90th percentile end to
+        end travel time and the 10th percentile travel time. This measures how
+        much extra travel time is needed for some trips. Variability of
+        {' \u00b1'}
+        {(stats.travelTimeVariability / 2).toFixed(1)} min gets a score of{' '}
+        {stats.travelVarianceScore}.
+        <Box pt={2}>
+          <InfoScoreLegend
+            rows={[
+              { label: '5 min or less', value: 100 },
+              { label: '6.25 min', value: 75 },
+              { label: '7.5 min', value: 50 },
+              { label: '8.75 min', value: 25 },
+              { label: '10 min or more', value: 0 },
+            ]}
+          />
+        </Box>
+      </Fragment>
+    ) : null;
+
+  const toFixedZero = stat => (stat != null ? stat.toFixed(0) : null);
+
+  const rateToFixedZero = stat =>
+    stat != null ? (stat * 100).toFixed(0) : null;
+
+  const variabilityToFixedZero = stat =>
+    stat != null ? (stat / 2).toFixed(0) : null;
+
+  return (
+    <Fragment>
+      <InfoScoreCard
+        score={stats.totalScore}
+        hideRating
+        preserveRatingSpace
+        title="Route Score"
+        firstValue={stats.totalScore}
+        secondValue={statsByRouteId2 ? stats2.totalScore : NO_VALUE}
+        valueSuffix={`/${HighestPossibleScore}`}
+        bottomContent={
+          stats.scoreRank != null
+            ? `#${stats.scoreRank} of ${stats.scoreRankCount} routes`
+            : ''
+        }
+        popoverContent={popovers.contentTotalScore}
+      />
+      <InfoScoreCard
+        score={stats.medianWaitScore}
+        title="Median Wait"
+        firstValue={toFixedZero(stats.medianWaitTime)}
+        secondValue={
+          statsByRouteId2 ? toFixedZero(stats2.medianWaitTime) : NO_VALUE
+        }
+        valueSuffix="&nbsp;min"
+        bottomContent={
+          <Fragment>
+            {stats.waitRank != null
+              ? `#${stats.waitRank} of ${stats.waitRankCount} routes`
+              : null}
+          </Fragment>
+        }
+        popoverContent={popovers.contentWait}
+      />
+
+      <InfoScoreCard
+        score={stats.onTimeRateScore}
+        title="On-Time %"
+        firstValue={rateToFixedZero(stats.onTimeRate)}
+        secondValue={
+          statsByRouteId2 ? rateToFixedZero(stats2.onTimeRate) : NO_VALUE
+        }
+        valueSuffix="%"
+        popoverContent={popovers.contentOnTimeRate}
+        bottomContent={
+          stats.onTimeRank != null
+            ? `#${stats.onTimeRank} of ${stats.onTimeRankCount} routes`
+            : ''
+        }
+      />
+
+      <InfoScoreCard
+        score={stats.speedScore}
+        title="Average Speed"
+        firstValue={toFixedZero(stats.averageSpeed)}
+        secondValue={
+          statsByRouteId2 ? toFixedZero(stats.averageSpeed) : NO_VALUE
+        }
+        valueSuffix="&nbsp;mph"
+        bottomContent={
+          <Fragment>
+            {stats.speedRank != null
+              ? `#${stats.speedRank} of ${stats.speedRankCount} routes`
+              : null}
+          </Fragment>
+        }
+        popoverContent={popovers.contentSpeed}
+      />
+
+      <InfoScoreCard
+        score={stats.travelVarianceScore}
+        title="Travel Time Variability"
+        firstValue={variabilityToFixedZero(stats.travelTimeVariability)}
+        secondValue={
+          statsByRouteId2
+            ? variabilityToFixedZero(stats2.travelTimeVariability)
+            : NO_VALUE
+        }
+        valuePrefix={`\u00b1`}
+        valueSuffix="&nbsp;min"
+        bottomContent={
+          stats.variabilityRank != null
+            ? `#${stats.variabilityRank} of ${stats.variabilityRankCount} routes`
+            : ''
+        }
+        popoverContent={popovers.contentTravelVariability}
+      />
+    </Fragment>
+  );
+}
+
+const mapStateToProps = state => ({
+  routes: state.routes.data,
+  graphParams: state.graphParams,
+  statsByRouteId: state.agencyMetrics.statsByRouteId,
+  statsByRouteId2: state.agencyMetrics.statsByRouteId2,
+});
+
+export default connect(mapStateToProps)(RouteSummaryCards);

--- a/frontend/src/helpers/dateTime.js
+++ b/frontend/src/helpers/dateTime.js
@@ -2,7 +2,14 @@
  * Helper functions for manipulating date and time.
  */
 
-import { WEEKDAYS, WEEKENDS } from '../UIConstants';
+import Moment from 'moment';
+
+import {
+  WEEKDAYS,
+  WEEKENDS,
+  TIME_RANGES,
+  TIME_RANGE_ALL_DAY,
+} from '../UIConstants';
 
 /**
  * Whether all of array's entries in the dictionary are false.
@@ -75,4 +82,40 @@ export function getDaysOfTheWeekLabel(daysOfTheWeek) {
     return accumulator;
   }, []);
   return checkedLabels.join();
+}
+
+/**
+ * convert yyyy/mm/dd to mm/dd/yyyy
+ */
+function convertDate(ymdString) {
+  return Moment(ymdString).format('MM/DD/YYYY');
+}
+
+/**
+ * Create the date range label and small descriptive label.
+ *
+ * @param {Object} dateRangeParams Date settings from Redux state
+ */
+export function generateDateLabels(dateRangeParams) {
+  // these are the read-only representations of the date and time range
+  let dateLabel = convertDate(dateRangeParams.date);
+  let smallLabel = '';
+
+  if (dateRangeParams.startDate !== dateRangeParams.date) {
+    dateLabel = `${convertDate(dateRangeParams.startDate)} - ${dateLabel}`;
+
+    // generate a days of the week label
+
+    smallLabel = `${getDaysOfTheWeekLabel(dateRangeParams.daysOfTheWeek)}, `;
+  }
+
+  // convert the state's current time range to a string or the sentinel value
+  const timeRange =
+    dateRangeParams.startTime && dateRangeParams.endTime
+      ? `${dateRangeParams.startTime}-${dateRangeParams.endTime}`
+      : TIME_RANGE_ALL_DAY;
+
+  smallLabel += TIME_RANGES.find(range => range.value === timeRange).shortLabel;
+
+  return { dateLabel, smallLabel };
 }

--- a/frontend/src/helpers/routeCalculations.js
+++ b/frontend/src/helpers/routeCalculations.js
@@ -114,7 +114,7 @@ const backgroundColorScale = d3
 
 export const scoreBackgroundColor = score => {
   if (score == null || Number.isNaN(score)) {
-    return null;
+    return 'gray';
   }
   return backgroundColorScale(score / HighestPossibleScore);
 };
@@ -126,7 +126,7 @@ const contrastColorScale = d3
 
 export const scoreContrastColor = score => {
   if (score == null || Number.isNaN(score)) {
-    return null;
+    return 'black';
   }
   return contrastColorScale(score / HighestPossibleScore);
 };

--- a/frontend/src/reducers/index.js
+++ b/frontend/src/reducers/index.js
@@ -166,8 +166,11 @@ function addScores(stats) {
   );
 }
 
-function makeStatsByRouteId(agencyMetricsData) {
-  const routeStats = agencyMetricsData ? agencyMetricsData.interval.routes : [];
+function makeStatsByRouteId(agencyMetricsData, intervalName) {
+  const routeStats =
+    agencyMetricsData && agencyMetricsData[intervalName]
+      ? agencyMetricsData[intervalName].routes
+      : [];
   const rankedRouteStats = routeStats.filter(
     stats =>
       !isIgnoredRoute({
@@ -222,7 +225,10 @@ export function agencyMetrics(state = initialAgencyMetrics, action) {
         ...state,
         variablesJson: action.variablesJson,
         data: action.data,
-        statsByRouteId: makeStatsByRouteId(action.data),
+        statsByRouteId: makeStatsByRouteId(action.data, 'interval'),
+        statsByRouteId2: action.data.interval2
+          ? makeStatsByRouteId(action.data, 'interval2')
+          : null,
       };
     case 'REQUEST_AGENCY_METRICS':
       return {
@@ -230,6 +236,7 @@ export function agencyMetrics(state = initialAgencyMetrics, action) {
         variablesJson: action.variablesJson,
         data: null,
         statsByRouteId: {},
+        statsByRouteId2: {},
       };
     default:
       return state;


### PR DESCRIPTION
<!-- Does this PR fix any issues? If so, uncomment the below and put in the right number(s).
     You need to have a separate "Fixes #xyz" sentence for each issue you fix.
     Of course, erase issue numbers you don't need.
-->
<!--
Fixes #1234. Fixes #2345. Fixes #3456.
-->

<!-- Delete any of these headings if they aren't needed or applicable -->

## Proposed changes

#321 #582  The idea is to change the "stop to stop" trip summary (and eventually route summary) to be like the Google Analytics UI.  This UI is used for both date range comparisons and for single date ranges.  It combines our summary page with the "by day" tab.  Essentially a chart for one metric is shown with the cards for all the metrics below that.

The chart can be changed to show metrics corresponding to any card.  The cards have been reformatted to be fixed width and fixed height.

- [ ] Chart tooltips only work on "Journey Times" by day chart, need to add tooltips to remaining charts.  Chart tooltips only show values for the first (blue) series.
- [ ] Google Analytics puts miniature (spark-line) charts in the card for each metric (see screenshots in #461).  Clicking the miniature chart switches the main chart to that metric.  Would like to try this here.
- [ ] Google Analytics colors the percentage change green or red, to mean improved or worsened as is appropriate for each metric.  To do this, we may have to put the change inside a chip (white oval) to make the colored text legible, or a different styling of the card backgrounds.
- [ ] Google Analytics, when comparing a single day, switches from a per day scale to a per hour scale.  We could try do something similar with our intervals of the day, or switch to hours.
- [ ] Consider adding a radar chart.


## Screenshot

Single date range:

![Screen Shot 2020-03-05 at 1 50 37 AM](https://user-images.githubusercontent.com/44861283/75969384-b9d9b200-5e83-11ea-876a-a3a7ebe69c08.png)

Date range comparison:

![Screen Shot 2020-03-05 at 1 49 47 AM](https://user-images.githubusercontent.com/44861283/75969341-a9293c00-5e83-11ea-9ff4-46182137ed4d.png)

## Link to demo, if any

https://ot-terence-date-range-compare.herokuapp.com/

Deep link for singe date range:

https://ot-terence-date-range-compare.herokuapp.com/route/KT/1/14506/17344?firstDateRange%5BstartDate%5D=2020-02-26&firstDateRange%5BdaysOfTheWeek%5D%5B0%5D=false&firstDateRange%5BdaysOfTheWeek%5D%5B1%5D=true&firstDateRange%5BdaysOfTheWeek%5D%5B2%5D=true&firstDateRange%5BdaysOfTheWeek%5D%5B3%5D=true&firstDateRange%5BdaysOfTheWeek%5D%5B4%5D=true&firstDateRange%5BdaysOfTheWeek%5D%5B5%5D=true&firstDateRange%5BdaysOfTheWeek%5D%5B6%5D=false

Deep link for date range comparison:

https://ot-terence-date-range-compare.herokuapp.com/route/7/1/15652/15638?firstDateRange%5BstartDate%5D=2020-02-19&firstDateRange%5BstartTime%5D=07%3A00&firstDateRange%5BendTime%5D=10%3A00&firstDateRange%5BdaysOfTheWeek%5D%5B0%5D=false&firstDateRange%5BdaysOfTheWeek%5D%5B1%5D=true&firstDateRange%5BdaysOfTheWeek%5D%5B2%5D=true&firstDateRange%5BdaysOfTheWeek%5D%5B3%5D=true&firstDateRange%5BdaysOfTheWeek%5D%5B4%5D=true&firstDateRange%5BdaysOfTheWeek%5D%5B5%5D=true&firstDateRange%5BdaysOfTheWeek%5D%5B6%5D=false&secondDateRange%5BstartDate%5D=2020-01-14&secondDateRange%5Bdate%5D=2020-01-28&secondDateRange%5BstartTime%5D=07%3A00&secondDateRange%5BendTime%5D=10%3A00&secondDateRange%5BdaysOfTheWeek%5D%5B0%5D=false&secondDateRange%5BdaysOfTheWeek%5D%5B1%5D=true&secondDateRange%5BdaysOfTheWeek%5D%5B2%5D=true&secondDateRange%5BdaysOfTheWeek%5D%5B3%5D=true&secondDateRange%5BdaysOfTheWeek%5D%5B4%5D=true&secondDateRange%5BdaysOfTheWeek%5D%5B5%5D=true&secondDateRange%5BdaysOfTheWeek%5D%5B6%5D=false