### PR TITLE
Better 404 page

### DIFF
--- a/frontend/src/components/NotFound.jsx
+++ b/frontend/src/components/NotFound.jsx
@@ -1,5 +1,24 @@
-import React from 'react';
+import React, { Fragment } from 'react';
+import Link from 'redux-first-router-link';
 
 export default function NotFound() {
-  return <h3>404</h3>;
+  return (
+    <Fragment>
+      <h2>
+        This train went off the rails!{' '}
+        <span role="img" aria-label="train-crash">
+          🚈💥
+        </span>
+      </h2>
+
+      <p>
+        Sorry, but we can&apos;t find what you&apos;re looking for. This link
+        might be malformed.
+      </p>
+
+      <p>
+        Try going <Link to="/">back to the main page</Link>.
+      </p>
+    </Fragment>
+  );
 }

--- a/frontend/src/components/NotFound.jsx
+++ b/frontend/src/components/NotFound.jsx
@@ -1,11 +1,11 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import Link from 'redux-first-router-link';
 
 export default function NotFound() {
   return (
-    <Fragment>
+    <div style={{ padding: '0px 20px' }}>
       <h2>
-        This train went off the rails!{' '}
+        This train went off the rails! &nbsp;
         <span role="img" aria-label="train-crash">
           🚈💥
         </span>
@@ -19,6 +19,6 @@ export default function NotFound() {
       <p>
         Try going <Link to="/">back to the main page</Link>.
       </p>
-    </Fragment>
+    </div>
   );
 }


### PR DESCRIPTION
Fixes #216.


## Proposed changes

A more informative 404 page with a link to go back to safety. Adds a tiny bit of whimsy, too, like all the great 404 pages. It's no Fail Whale, but I did my best.

## Screenshot

Before:

<img width="1552" alt="Screen Shot 2020-03-25 at 11 04 38 PM" src="https://user-images.githubusercontent.com/728084/77606151-2842ea80-6eed-11ea-817a-39a08dc083d3.png">

After:

<img width="1552" alt="Screen Shot 2020-03-25 at 11 04 50 PM" src="https://user-images.githubusercontent.com/728084/77606156-2b3ddb00-6eed-11ea-9575-565efd005d5d.png">

## Notes


Note that #607 automatically wraps the 404 page with a header bar, so I'm not adding that here.

<img width="1552" alt="Screen Shot 2020-03-25 at 11 05 59 PM" src="https://user-images.githubusercontent.com/728084/77606226-490b4000-6eed-11ea-9a63-a4691ec76a71.png">

Also, I had to manually add padding because our framework doesn't automatically add any. I would like to see that factored out into CSS at some point.