### PR TITLE
skip invalid custom directions in save_routes.py instead of stopping

### DIFF
--- a/backend/agencies/trimet.yaml
+++ b/backend/agencies/trimet.yaml
@@ -15,11 +15,11 @@ custom_directions:
     - id: "1"
       title: "From NW Yeon & 44th to Gateway Transit Center"
       gtfs_direction_id: "1"
-      included_stop_ids: ["6470","749"]
+      included_stop_ids: ["6470"]
     - id: "1-T"
       title: "From NW Thurman & 28th to Gateway Transit Center"
       gtfs_direction_id: "1"
-      included_stop_ids: ["5837","749"]
+      included_stop_ids: ["5835"]
   '50':
     - id: "0"
       title: "Evening Loop"
@@ -56,11 +56,9 @@ custom_directions:
     - id: "0"
       title: "Evening Loop"
       gtfs_direction_id: "0"
-      included_stop_ids: ["9977"]
     - id: "1"
       title: "Morning Loop"
       gtfs_direction_id: "1"
-      included_stop_ids: ["9977"]
   '84':
     - id: "0"
       title: "Evening Loop"

--- a/backend/models/gtfs.py
+++ b/backend/models/gtfs.py
@@ -107,9 +107,6 @@ def contains_excluded_stop(shape_stop_ids, excluded_stop_ids):
             pass
     return False
 
-class ShapeNotFoundException(Exception):
-    pass
-
 class GtfsScraper:
     def __init__(self, agency: config.Agency):
         self.agency = agency
@@ -732,6 +729,7 @@ class GtfsScraper:
             print(f'  {error_message}')
             return None
         elif len(matching_shapes) > 1:
+            # Matching shapes already sorted by count in descending order
             print("   multiple matching shapes found: " + ', '.join([f"{shape['shape_id']} ({shape['count']} times)" for shape in matching_shapes]))
 
         matching_shape = matching_shapes[0]

--- a/backend/save_routes.py
+++ b/backend/save_routes.py
@@ -51,6 +51,8 @@ if __name__ == '__main__':
 
     save_to_s3 = args.s3
 
+    errors = []
+
     for agency in agencies:
         scraper = gtfs.GtfsScraper(agency)
         scraper.save_routes(save_to_s3)
@@ -61,3 +63,8 @@ if __name__ == '__main__':
             if timetables_updated and args.scheduled_stats:
                 dates = sorted(scraper.get_services_by_date().keys())
                 compute_stats_for_dates(dates, agency, scheduled=True, save_to_s3=save_to_s3)
+
+        errors += scraper.errors
+
+    if errors:
+        raise Exception("\n".join(errors))

--- a/docs/agencies.md
+++ b/docs/agencies.md
@@ -41,7 +41,7 @@ default_directions:
 
 `custom_directions` - an optional object that allows manually defining directions for certain routes, in order to support routes with multiple branches. Each key in this object is a route ID, and the value is an array of directions for that route, with the properties `id`, `title` (optional), `gtfs_direction_id`, `included_stop_ids` (optional), and `excluded_stop_ids` (optional).
 
-The `gtfs_direction_id`, `included_stop_ids`, and `excluded_stop_ids` properties are used to filter the shape_ids referred to by trips.txt in the GTFS feed. Each filter should match exactly one unique shape from the GTFS feed (after merging shapes with common subsequences of stops). If included_stop_ids contains multiple stop IDs, they must be listed in order.
+The `gtfs_direction_id`, `included_stop_ids`, and `excluded_stop_ids` properties are used to filter the shape_ids referred to by trips.txt in the GTFS feed. Each custom direction should match at least one shape in the GTFS feed. If a custom direction can be matched to multiple shapes, it is matched to the one associated with the most trips in the GTFS feed. If a custom direction cannot be matched to any shapes, the direction will be omitted and an exception will be raised by save_routes.py after saving the new routes file. If included_stop_ids contains multiple stop IDs, they must be listed in order.
 
 For example:
 


### PR DESCRIPTION
save_routes.py was raising an exception because trimet's GTFS file changed again and some of the custom directions no longer matched any shapes. Since this has been happening often, this PR updates save_routes.py to skip any invalid custom directions and raise an exception at the end, after saving the route configuration.

Also, if a custom direction matches multiple shapes, it will use the most common shape instead of raising an exception.

Updates the custom directions for trimet's latest GTFS file.