### PR TITLE
use CSV for storing per-route state instead of JSON for better performance

### DIFF
--- a/backend/models/trynapi.py
+++ b/backend/models/trynapi.py
@@ -17,6 +17,9 @@ class CachedState:
         self.cache_paths[route_id] = cache_path
 
     def get_for_route(self, route_id) -> pd.DataFrame:
+        if route_id not in self.cache_paths:
+            return None
+
         cache_path = self.cache_paths[route_id]
         print(f'loading state for route {route_id} from cache: {cache_path}')
         buses = pd.read_csv(

--- a/backend/models/trynapi.py
+++ b/backend/models/trynapi.py
@@ -121,7 +121,7 @@ def get_state(agency_id: str, d: date, start_time, end_time, route_ids) -> Cache
 
         temp_cache_path = get_route_temp_cache_path(agency_id, route_id)
         if not os.path.exists(temp_cache_path):
-            return None
+            continue
 
         os.rename(temp_cache_path, cache_path)
 


### PR DESCRIPTION
When fetching the state from tryn-api to compute arrivals, profiling showed that a significant amount of running time was spent in read_temp_chunk_state, which loaded a cache file in CSV format into memory, converted the data structure, and wrote a file in JSON format. However, the JSON format was only used by eclipses.produce_buses to initialize a DataFrame, which could also be done from the original CSV format without using JSON. 

This PR removes the JSON format and updates CachedState.get_for_route to return the DataFrame that used to be returned by eclipses.produce_buses. eclipses.find_arrivals is updated to take the DataFrame as a parameter instead of a dict.