### PR TITLE
quick revert for no data bug

### DIFF
--- a/frontend/src/components/InfoTripSummary.jsx
+++ b/frontend/src/components/InfoTripSummary.jsx
@@ -134,7 +134,7 @@ export default function InfoTripSummary(props) {
           speed,
           travelTimeVariability,
         )
-      : null;
+      : {};
 
   const scores2 =
     speed2 && waitTimes2.median


### PR DESCRIPTION
## Proposed changes
Very quick fix for no data error in InfoTripSummary. This is not an ideal fix just a patch so not getting blank screen on prod. Seems there was a change in commit: 
https://github.com/trynmaps/metrics-mvp/commit/cabe88a5ba1dc7f605b6cb267b1f6fff10cec69a
That defaulted scores to null instead of empty object. Just changed it back.

- A better fix would be handling for no data case and reflect that in the view; however, I don't know how common this is so might not be worth it. 

##Steps to test
Select route and set a trip with start and end stops. Trip summary cards should render greyed out. 

