### PR TITLE
fix bug where get_state failed if cache dir did not already exist

### DIFF
--- a/backend/models/trynapi.py
+++ b/backend/models/trynapi.py
@@ -180,9 +180,6 @@ def remove_route_temp_cache(agency_id: str):
         if path.endswith('_temp_cache.csv'):
             os.remove(os.path.join(dir, path))
 
-def get_temp_dir(agency_id):
-    return f"state_v2_{agency_id}"
-
 def get_cache_path(agency_id: str, d: date, start_time, end_time, route_id) -> str:
     validate_agency_route_path_attributes(agency_id, route_id)
     return os.path.join(


### PR DESCRIPTION
On GKE, compute_new.py was failing when it tried to delete cache files from a directory that hadn't been created yet:
```
FileNotFoundError: [Errno 2] No such file or directory: '/app/backend/data/state_v2_trimet'
at remove_route_temp_cache (/app/backend/models/trynapi.py:165)
at get_state (/app/backend/models/trynapi.py:97)
at compute_arrivals_for_date_and_start_hour (/app/backend/compute_arrivals.py:22)
at compute_arrivals (/app/backend/compute_arrivals.py:61)
at <module> (compute_new.py:72)
```

This PR fixes this issue by creating the directory before calling remove_route_temp_cache.