### PR TITLE
if no routes currently have active services, save all routes

### DIFF
--- a/backend/agencies/muni.yaml
+++ b/backend/agencies/muni.yaml
@@ -16,10 +16,10 @@ custom_directions:
       title: "Inbound from 48th Ave & Point Lobos Ave to Transit Center"
       gtfs_direction_id: "1"
       included_stop_ids: ["13608"]
-    - id: "1-VA"
-      title: "Inbound from V.A. Hospital to Transit Center"
-      gtfs_direction_id: "1"
-      included_stop_ids: ["15511"]
+    #- id: "1-VA"
+    #  title: "Inbound from V.A. Hospital to Transit Center"
+    #  gtfs_direction_id: "1"
+    #  included_stop_ids: ["15511"]
     - id: "0-32nd"
       gtfs_direction_id: "0"
       included_stop_ids: ["14275"]

--- a/backend/models/gtfs.py
+++ b/backend/models/gtfs.py
@@ -992,7 +992,7 @@ class GtfsScraper:
         for service_date in dates_map:
             if service_date <= d:
                 before_service_ids += dates_map[service_date]
-            elif service_date >= d:
+            if service_date >= d:
                 after_service_ids += dates_map[service_date]
         active_services = set.intersection(
             set(before_service_ids),
@@ -1062,7 +1062,10 @@ class GtfsScraper:
         agency = self.agency
         agency_id = agency.id
         routes_df = self.get_gtfs_routes()
-        routes_df = self.get_active_routes(routes_df, d)
+        active_routes_df = self.get_active_routes(routes_df, d)
+        if len(active_routes_df) > 0:
+            routes_df = active_routes_df
+
         routes_data = [
             self.get_route_data(route)
             for route in routes_df.itertuples()


### PR DESCRIPTION
The current GTFS feed from SF Muni starts on April 4, which caused get_active_routes to save an empty list of routes. This PR updates the behavior so if there are no active services, all routes in the GTFS feed will be saved.

It also removes a muni custom direction which no longer exists in the GTFS feed.