### PR TITLE
Skip updating GTFS if no active routes on date being run

### DIFF
--- a/backend/models/gtfs.py
+++ b/backend/models/gtfs.py
@@ -1062,9 +1062,13 @@ class GtfsScraper:
         agency = self.agency
         agency_id = agency.id
         routes_df = self.get_gtfs_routes()
-        active_routes_df = self.get_active_routes(routes_df, d)
-        if len(active_routes_df) > 0:
-            routes_df = active_routes_df
+        routes_df = self.get_active_routes(routes_df, d)
+        if len(routes_df) == 0:
+            self.errors.append((
+                f'Zero active routes for {agency_id}, the routes config was not updated. '
+                f'Ensure the GTFS is active for the given date {d}'
+            ))
+            return
 
         routes_data = [
             self.get_route_data(route)


### PR DESCRIPTION
Agencies normally update their GTFS a few days ahead so the one that gets downloaded ends up having no active routes. This could result in the wrong routes being shown on the dates just before the changes take effect, if for example a route is added or removed.

If there are no active routes on the provided date, save_routes will raise an exception and the routes will not be updated. The older version of routes will be used by the backend, which should result in the expected behaviour.

There could be the case where an agency schedules zero routes for the entire duration of their GTFS, but I don't see that happening.