### PR TITLE
fix lint errors introduced by dependency bump

### DIFF
--- a/frontend/src/components/ControlPanel.jsx
+++ b/frontend/src/components/ControlPanel.jsx
@@ -278,7 +278,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(ControlPanel);
+export default connect(mapStateToProps, mapDispatchToProps)(ControlPanel);

--- a/frontend/src/components/DateTimePanel.jsx
+++ b/frontend/src/components/DateTimePanel.jsx
@@ -276,7 +276,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(DateTimePanel);
+export default connect(mapStateToProps, mapDispatchToProps)(DateTimePanel);

--- a/frontend/src/components/DateTimePopover.jsx
+++ b/frontend/src/components/DateTimePopover.jsx
@@ -500,7 +500,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(DateTimePopover);
+export default connect(mapStateToProps, mapDispatchToProps)(DateTimePopover);

--- a/frontend/src/components/InfoIntervalsOfDay.jsx
+++ b/frontend/src/components/InfoIntervalsOfDay.jsx
@@ -22,10 +22,6 @@ import '../../node_modules/react-vis/dist/style.css';
  * Bar chart of average and planning percentile wait and time across the day.
  */
 class InfoIntervalsOfDay extends Component {
-  static AVERAGE_TIME = 'average_time';
-
-  static PLANNING_TIME = 'planning_time';
-
   constructor(props) {
     super(props);
 
@@ -65,6 +61,10 @@ class InfoIntervalsOfDay extends Component {
       crosshairValues: [this.waitData[index], this.tripData[index]],
     });
   };
+
+  static AVERAGE_TIME = 'average_time';
+
+  static PLANNING_TIME = 'planning_time';
 
   /**
    * Returns a mapping function for creating a react-vis XYPlot data series out of interval data.

--- a/frontend/src/components/MapSpider.jsx
+++ b/frontend/src/components/MapSpider.jsx
@@ -546,7 +546,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(MapSpider);
+export default connect(mapStateToProps, mapDispatchToProps)(MapSpider);

--- a/frontend/src/components/MareyChart.jsx
+++ b/frontend/src/components/MareyChart.jsx
@@ -491,7 +491,4 @@ const mapDispatchToProps = dispatch => {
   };
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(MareyChart);
+export default connect(mapStateToProps, mapDispatchToProps)(MareyChart);

--- a/frontend/src/screens/Dashboard.jsx
+++ b/frontend/src/screens/Dashboard.jsx
@@ -62,7 +62,4 @@ const mapDispatchToProps = dispatch => ({
   handleGraphParams: params => dispatch(handleGraphParams(params)),
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(Dashboard);
+export default connect(mapStateToProps, mapDispatchToProps)(Dashboard);

--- a/frontend/src/screens/DataDiagnostic.jsx
+++ b/frontend/src/screens/DataDiagnostic.jsx
@@ -67,7 +67,4 @@ const mapDispatchToProps = dispatch => ({
   handleGraphParams: params => dispatch(handleGraphParams(params)),
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(DataDiagnostic);
+export default connect(mapStateToProps, mapDispatchToProps)(DataDiagnostic);

--- a/frontend/src/screens/RouteScreen.jsx
+++ b/frontend/src/screens/RouteScreen.jsx
@@ -236,7 +236,4 @@ const mapDispatchToProps = dispatch => ({
   fetchRoutes: params => dispatch(fetchRoutes(params)),
 });
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(RouteScreen);
+export default connect(mapStateToProps, mapDispatchToProps)(RouteScreen);


### PR DESCRIPTION
The lint check has been failing since bumping the version of eslint in #615. This PR fixes the new lint errors.