### PR TITLE
Change Metrics API production endpoint

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_METRICS_BASE_URL=https://muni.opentransit.city
+REACT_APP_METRICS_BASE_URL=https://data.opentransit.city

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_METRICS_BASE_URL=https://data.opentransit.city
+REACT_APP_METRICS_BASE_URL=https://sf-muni.opentransit.city


### PR DESCRIPTION
As the frontend is hosted on S3 the metrics API endpoint needs to be changed to point to the API running on google cloud, which can be reached through data.opentransit.city


