### PR TITLE
Allow frontend to load from nginx deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ CMD gunicorn --bind 0.0.0.0:$PORT metrics-api:app
 
 FROM react-dev as react-build
 ENV REACT_APP_METRICS_BASE_URL=
-RUN cd /app/frontend && npm run build
+RUN cd /app/frontend && PUBLIC_URL="frontend/build" npm run build
 
 FROM flask AS all-in-one
 ENV METRICS_ALL_IN_ONE 1


### PR DESCRIPTION
A previous PR (#613) broke viewing the frontend when
deployed on nginx by changing the homepage from frontend/build
to https://muni.opentransit.city. This PR resolves this by
setting the PUBLIC_URL environment variable to frontend/build
when running npm run build from the Dockerfile, which is used
for all server deployments including Google Cloud, Heroku, and
by future users who want to deploy OpenTransit on their own
server using our Docker setup.

The static S3 serverless approach continues to work for
muni.opentransit.city but requires
modifying the URLs in frontend/package.json and in
frontend/public/CNAME for deploying a static site for other agencies
or environments which we don't officially support or document
as of yet.
